### PR TITLE
release: v14.0.0 — promote out of beta

### DIFF
--- a/RELEASE-NOTES-v14.0.0.md
+++ b/RELEASE-NOTES-v14.0.0.md
@@ -1,10 +1,10 @@
-# hq-core v14.0.0-beta
+# hq-core v14.0.0
 
-**Type**: Prerelease (beta)
-**Published from**: `indigoai-us/hq-core-staging` @ `9d1b5be`
-**Date**: 2026-05-04
+**Type**: Stable
+**Promoted from**: `v14.0.0-beta` (2026-05-04) — same tree, no functional changes
+**Date**: 2026-05-06
 
-This is a major version bump (v12.x → v14) representing roughly six months of HQ core evolution. Promoted via the staging buffer pattern documented in `hq-cmd-publish-kit-staging-flow-not-direct`. `-beta` denotes that 25 NEEDS_REVIEW items from the staging audit are deferred for v14.0.0 GA.
+Promoting v14.0.0-beta to stable. Major version v12.x → v14 represents roughly six months of HQ core evolution; promoted via the staging buffer pattern (`hq-cmd-publish-kit-staging-flow-not-direct`). The 25 NEEDS_REVIEW items previously deferred to GA remain on the v14.x roadmap and will land in subsequent point releases.
 
 ## Highlights
 

--- a/core.yaml
+++ b/core.yaml
@@ -1,6 +1,6 @@
 version: 1
-hqVersion: "14.0.0-beta"
-updatedAt: "2026-05-04T00:00:00Z"
+hqVersion: "14.0.0"
+updatedAt: "2026-05-06T21:15:28Z"
 # hq-core is the minimal scaffold seed. Rich add-ons ship as `@indigoai-us/hq-pack-*`
 # npm packages installed into `packages/` via `hq install`. See `packages/README.md`.
 rules:


### PR DESCRIPTION
## Summary

Promote v14.0.0-beta → v14.0.0 stable. Same tree as the beta release (2026-05-04) — no functional changes — just dropping the prerelease tag.

- `core.yaml`: `hqVersion: "14.0.0-beta"` → `"14.0.0"`
- `RELEASE-NOTES-v14.0.0-beta.md` → `RELEASE-NOTES-v14.0.0.md` (header updated)

## Parity

`core-yaml-parity` assertion passed: HQ root `core.yaml` bumped to `14.0.0` in the same release window.

## Next

After merge:
- `gh release create v14.0.0 -R indigoai-us/hq-core --title "v14.0.0" --notes-file RELEASE-NOTES-v14.0.0.md` (no `--prerelease` → becomes Latest)
- HQ root commit lands the parity bump

## Test plan

- [x] Parity assertion passes (`HQ_V == CORE_V == 14.0.0`)
- [ ] PR checks green
- [ ] Release tag `v14.0.0` created as Latest after merge