### PR TITLE
docs: fix stale package and CLI references

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -168,7 +168,7 @@ Hotfix that finishes the dev→prod Cognito cutover. Two file-level changes to e
 ### Companion package upgrades (recommended same-day)
 
 - `@indigoai-us/hq-cloud@5.9.0` — adds stale-pool detection so pre-cutover dev tokens stop producing 401s against the prod vault API. No action required from operators; cached tokens with mismatched `client_id` claim are silently re-authed on next CLI invocation.
-- `@indigoai-us/hq-cli@5.7.1` — `bun install -g @indigoai-us/hq-cli@5.7.1` to pick up hq-cloud@5.9.0.
+- `@indigoai-us/hq-cli@5.9.0` — `bun install -g @indigoai-us/hq-cli@5.9.0` to pick up hq-cloud@5.9.0.
 - `create-hq@10.12.0` — only matters for new HQs created after 2026-04-29; existing HQs are unaffected.
 
 ### Verification

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>
-  <a href="https://github.com/indigoai-us/hq-cli"><img src="https://img.shields.io/badge/CLI-hq--cli-green.svg" alt="HQ CLI"></a>
+  <a href="https://github.com/indigoai-us/hq/tree/main/packages/hq-cli"><img src="https://img.shields.io/badge/CLI-hq--cli-green.svg" alt="HQ CLI"></a>
 </p>
 
 <p align="center">
@@ -60,7 +60,7 @@ Not just files. Active systems that:
 | [qmd](https://github.com/tobi/qmd) | Recommended | `brew install tobi/tap/qmd` |
 | [OpenAI Codex](https://openai.com/codex) | Optional | `npm install -g @openai/codex` then `codex login` |
 | [Vercel CLI](https://vercel.com/docs/cli) | Optional | `npm install -g vercel` then `vercel login` |
-| [ggshield](https://docs.gitguardian.com/ggshield-docs/getting-started/installation) | Recommended | `brew install ggshield` then `ggshield auth login` |
+| [ggshield](https://docs.gitguardian.com/ggshield-docs/getting-started) | Recommended | `brew install ggshield` then `ggshield auth login` |
 
 ### LSP (Language Server Protocol)
 
@@ -527,7 +527,7 @@ my-hq/
 | Component | Purpose |
 |-----------|---------|
 | **hq-core** | This repo — personal OS template |
-| **[hq-cli](https://github.com/indigoai-us/hq-cli)** | Module management CLI |
+| **[hq-cli](https://github.com/indigoai-us/hq/tree/main/packages/hq-cli)** | Module management CLI |
 
 ---
 

--- a/packages/README.md
+++ b/packages/README.md
@@ -51,7 +51,7 @@ contributes:
   commands: []
 ```
 
-Schema: `knowledge/public/hq-core/package-yaml-spec.md` (authoritative; shipped with hq-core).
+Schema: see the [hq package spec](https://github.com/indigoai-us/hq/blob/main/docs/hq-package-spec.md). The canonical JSON Schema lives at [`packages/hq-cli/src/schemas/hq-package.schema.json`](https://github.com/indigoai-us/hq/blob/main/packages/hq-cli/src/schemas/hq-package.schema.json).
 
 ## Backwards compatibility
 

--- a/scripts/scan-packages.sh
+++ b/scripts/scan-packages.sh
@@ -6,7 +6,7 @@
 # a no-op when the symlinks already match. Warns and skips on collisions instead
 # of clobbering.
 #
-# Mapping (see knowledge/public/hq-core/package-yaml-spec.md):
+# Mapping (see https://github.com/indigoai-us/hq/blob/main/docs/hq-package-spec.md):
 #   contributes.workers[name]    packages/{pkg}/workers/{name}/       -> workers/public/{name}
 #   contributes.knowledge[name]  packages/{pkg}/knowledge/{name}/     -> knowledge/public/{name}
 #   contributes.skills[name]     packages/{pkg}/skills/{name}/        -> .claude/skills/{name}


### PR DESCRIPTION
## Summary
- update stale `hq-cli` GitHub links in the README to the current monorepo package path
- update a broken ggshield documentation link
- point package schema references at the current hq package spec / JSON schema in `indigoai-us/hq`
- replace a nonexistent `@indigoai-us/hq-cli@5.7.1` migration pin with published `5.9.0`

## Verification
- `gh repo view indigoai-us/hq-cli` fails because the old standalone repo does not exist
- `curl -L -s -o /dev/null -w '%{http_code}' https://github.com/indigoai-us/hq/tree/main/packages/hq-cli` returns `200`
- `curl -L -s -o /dev/null -w '%{http_code}' https://docs.gitguardian.com/ggshield-docs/getting-started` returns `200`
- `curl -L -s -o /dev/null -w '%{http_code}' https://github.com/indigoai-us/hq/blob/main/docs/hq-package-spec.md` returns `200`
- `curl -L -s -o /dev/null -w '%{http_code}' https://github.com/indigoai-us/hq/blob/main/packages/hq-cli/src/schemas/hq-package.schema.json` returns `200`
- `npm view @indigoai-us/hq-cli@5.9.0 version` returns `5.9.0`
- `npm view @indigoai-us/hq-cli@5.7.1 version` returns `E404`

## Notes
This is docs-only. I did not run the repository CI locally.
