### PR TITLE
Reframe HQ product description from personal OS to team AI OS

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # HQ
 
-Personal OS for orchestrating work across companies, workers, and AI.
+The AI operating system for your company. A shared context layer on top of Claude Code, Cursor, and Codex — syncs knowledge, skills, and capabilities across your team. Scales from solopreneur to enterprise.
 
 ## Key Files
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-<h1 align="center">HQ by Indigo — Personal OS for AI Workers</h1>
+<h1 align="center">HQ by Indigo — The AI Operating System for Your Company</h1>
 
 <p align="center">
-  <strong>Build your AI team. Ship projects autonomously. Never lose context.</strong>
+  <strong>Shared context. Shared skills. Shared intelligence.<br>
+  One person's breakthrough becomes everyone's baseline.</strong>
 </p>
 
 <p align="center">
@@ -20,35 +21,33 @@
 
 ## What is HQ?
 
-HQ is infrastructure for orchestrating **AI workers** — autonomous agents that code, write content, research, and automate tasks.
+HQ is a **shared context layer** on top of any AI tool — Claude Code, Cursor, Codex, or whatever your team uses. It syncs knowledge, skills, and capabilities across everyone working with AI, so the most skilled user's workflow becomes the whole team's baseline.
 
-Not just files. Active systems that:
-- **Execute** — Workers do real work autonomously
-- **Learn** — Rules get injected into the files they govern
-- **Scale** — Build workers for any domain with `/newworker`
-- **Survive** — Threads persist across sessions, auto-handoff at context limits
+Solo AI is easy. Team AI is hard. Every person builds their own context from scratch, every session. The most capable users have no clean way to share what they've built, and context evaporates between sessions and between people. HQ turns those individual wins into infrastructure the whole team inherits.
+
+**It scales with you.** Solopreneurs use HQ to compound their own capabilities across projects, companies, and AI tools. Large enterprises use it to give every team member the same context, the same tools, and the same baseline of intelligence — without locking anyone into a single AI vendor.
+
+Four systems sit at the core:
+
+- **Cloud file system** — bidirectional sync between every team member's local HQ and a shared cloud store. Knowledge bases, policies, skills, workers, and threads stay in lockstep across the team. Conflicts surface for interactive review instead of silent overwrite, and the same context is reachable from web, mobile, or a remote AI session running in the cloud.
+- **Access control** — company-scoped isolation by default. Roles and named groups govern who can see which files, secrets, and capabilities; cross-company contamination is architecturally impossible. Sign in once, and every HQ surface — vault, deploys, secrets, sync — works without re-authenticating. Every access is logged.
+- **Secrets manager** — a per-company credential store with fine-grained ACLs. Each secret grants `read`, `write`, or `admin` to individuals or named groups, with optional company-wide open access. Values are injected directly into child processes — they never touch disk, stdout, or logs. For credentials a human holds, one-time links let a teammate hand off the value without any agent or operator ever seeing it.
+- **Deployment** — one command ships any HQ artifact — reports, dashboards, decks, applications — to a shareable URL. Static sites and full server apps both work out of the box. Sensitive artifacts (PII, financial, private) are automatically password-protected. Deploy is opt-out and triggers itself when HQ produces something shareable, so the user gets a link without ever typing `deploy`.
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
-│                           YOUR HQ                               │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                 │
-│   ┌─────────────┐    ┌─────────────┐    ┌─────────────┐         │
-│   │   WORKERS   │    │  KNOWLEDGE  │    │  COMMANDS   │         │
-│   │  Do things  │    │   Learn &   │    │ Orchestrate │         │
-│   │ autonomously│    │   remember  │    │  workflows  │         │
-│   └─────────────┘    └─────────────┘    └─────────────┘         │
-│          │                  │                  │                │
-│          └──────────────────┼──────────────────┘                │
-│                             ▼                                   │
-│                    ┌─────────────┐                              │
-│                    │   THREADS   │                              │
-│                    │   Survive   │                              │
-│                    │   sessions  │                              │
-│                    └─────────────┘                              │
-│                                                                 │
-└─────────────────────────────────────────────────────────────────┘
+┌──────────────────────────┐    ┌──────────────────────────┐    ┌──────────────────────────┐
+│   COMPANY KNOWLEDGE      │    │                          │    │                          │
+│   + CAPABILITIES         │ →  │         HQ LAYER         │ →  │        EVERY USER        │
+├──────────────────────────┤    ├──────────────────────────┤    ├──────────────────────────┤
+│  • Knowledge bases       │    │  • Cloud file system     │    │  • Claude Code           │
+│  • Skills                │    │  • Access control        │    │  • Cursor                │
+│  • Workers               │    │  • Secrets manager       │    │  • Codex                 │
+│  • Policies              │    │  • Deployment            │    │  • Any AI tool           │
+│  • Threads               │    │                          │    │                          │
+└──────────────────────────┘    └──────────────────────────┘    └──────────────────────────┘
 ```
+
+HQ is **model-agnostic**, so it works inside any AI tool and leverages the subscriptions your team already has — no new per-seat AI cost. It's **open source**. And it manages and creates context autonomously as your team works, so intelligence compounds without manual curation.
 
 ## Prerequisites
 

--- a/USER-GUIDE.md
+++ b/USER-GUIDE.md
@@ -1,6 +1,6 @@
 # HQ User Guide
 
-Personal OS for orchestrating work across companies, workers, and AI.
+The AI operating system for your company. A shared context layer on top of Claude Code, Cursor, and Codex — syncs knowledge, skills, and capabilities across your team. Scales from solopreneur to enterprise.
 
 ## Commands
 


### PR DESCRIPTION
## Summary

Updates the customer-facing product description across `README.md`, `.claude/CLAUDE.md` (and `AGENTS.md` via symlink), and `USER-GUIDE.md` so a new customer asking *"what is HQ?"* gets an answer that matches the framing in the deck and on getindigo.ai.

Before this PR, every product-description surface led with **"Personal OS for AI Workers"** and defined HQ around workers as the primary noun. After this PR, all four surfaces lead with **"the AI operating system for your company"** — a shared context layer that syncs knowledge, skills, and capabilities across a team. Solopreneur to enterprise.

## What changed

| File | Change |
|---|---|
| `README.md` | New H1, new tagline, rewritten "What is HQ?" section. Four capability pillars (cloud file system, access control, secrets manager, deployment) described in terms of what they enable, not the underlying stack. New ASCII diagram: **Company Knowledge + Capabilities → HQ Layer → Every User**. |
| `.claude/CLAUDE.md` | One-line product definition rewritten so every Claude Code session inherits the team-AI-OS framing. |
| `AGENTS.md` | No diff — `AGENTS.md` is a symlink to `.claude/CLAUDE.md`, so the CLAUDE.md edit covers both Claude Code and Codex/OpenAI Agents surfaces. |
| `USER-GUIDE.md` | Same one-line definition for human readers. |

The mechanical sections of each file (Quick Start, Commands, Workers, Knowledge Repos, etc.) are intentionally untouched — they describe how the product works, and they remain correct under the new framing. This PR is scoped to the framing layer.

## What's deliberately out of scope

- The GitHub repo description (set via `gh repo edit`) still reads *"scaffold seed for the personal OS for AI workers."* That's a one-line repo-settings update we can roll in once this PR is approved, since it's a separate surface from the file diff.
- Go-to-market, traction, pricing, founder bios, business model — none of that belongs in the product-description surface.
- Adjacent surfaces that may carry stale framing (`core.yaml`, `CONTRIBUTING.md`, installer copy, `knowledge/public/hq-core/quick-reference.md`, npm package descriptions) are candidates for a follow-up sweep but were left out to keep this PR tight.

## Test plan

- [ ] Render `README.md` on GitHub and verify the new ASCII diagram displays cleanly in monospace
- [ ] Open a fresh Claude Code session in a clone of this branch and ask *"what is HQ?"* — confirm the answer aligns with the new framing
- [ ] Open a fresh Codex session in the same clone and verify it picks up the same framing via `AGENTS.md`
- [ ] Confirm `USER-GUIDE.md` opens with the new one-liner

🤖 Generated with [Claude Code](https://claude.com/claude-code)