### PR TITLE
fix(core/scripts): correct HQ_ROOT path resolution after core consolidation

### DIFF
--- a/core/scripts/audit-log.sh
+++ b/core/scripts/audit-log.sh
@@ -22,7 +22,7 @@
 
 set -euo pipefail
 
-HQ_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HQ_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 AUDIT_LOG="$HQ_ROOT/workspace/metrics/audit-log.jsonl"
 
 VALID_EVENTS="task_started phase_completed task_completed task_failed project_started project_completed story_dispatched story_completed story_failed pipeline_started pipeline_completed pipeline_paused pipeline_failed project_pr_created project_reviewed project_merged project_deployed project_canary_pass project_canary_fail gate_requested gate_resolved"

--- a/core/scripts/compute-checksums.sh
+++ b/core/scripts/compute-checksums.sh
@@ -11,7 +11,7 @@
 
 set -euo pipefail
 
-HQ_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HQ_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 CORE_YAML="${1:-$HQ_ROOT/core/core.yaml}"
 
 if [ ! -f "$CORE_YAML" ]; then


### PR DESCRIPTION
## Summary

The v14.1.0-beta.1 core consolidation ([f38d350](https://github.com/indigoai-us/hq-core/commit/f38d350)) moved kernel scripts from the top-level `scripts/` directory into `core/scripts/`, but two scripts kept their `\$(dirname)/..` HQ_ROOT calculation calibrated to the OLD one-level-deep location.

From `core/scripts/<script>.sh`, `\$(dirname "\$0")/..` resolves to `<root>/core/`, **not** the HQ root. Every path built from `HQ_ROOT` after that line was off-by-one.

### Concrete symptom

`bash core/scripts/compute-checksums.sh` on a fresh HQ install errored with:

```
ERROR: core/core.yaml not found at <install>/core/core/core.yaml
```

`HQ_ROOT` resolved to `<install>/core`, then the script appended `core/core.yaml` on top of that — producing the doubled `core/core/` segment in the path.

### What this affects

- **hq-installer's git-init step** spawns `compute-checksums.sh` verbatim from `<installPath>/core/scripts/`. With the previous PR ([indigoai-us/hq-installer#59](https://github.com/indigoai-us/hq-installer/pull/59)) the installer finds the script at its new location; this PR makes the script itself work once found.
- **`audit-log.sh`** — any cold caller (not setting `HQ_ROOT` in the env) would write the audit log to `<root>/core/workspace/metrics/audit-log.jsonl` instead of `<root>/workspace/metrics/audit-log.jsonl`.

### Why setup.sh was already right

[setup.sh:6](https://github.com/indigoai-us/hq-core/blob/main/core/scripts/setup.sh#L6) already uses `/../..`. The consolidation refactor updated that one but missed these two siblings — this PR finishes the migration.

### Fix

Mechanical one-line change in each file:

```diff
-HQ_ROOT="\$(cd "\$(dirname "\${BASH_SOURCE[0]}")/.." && pwd)"
+HQ_ROOT="\$(cd "\$(dirname "\${BASH_SOURCE[0]}")/../.." && pwd)"
```

## Test plan

- [x] Patched files run cleanly against a real install — verified by running \`bash core/scripts/compute-checksums.sh\` against a freshly-installed hq:
  ```
  Checksums updated in <install>/core/core.yaml
  Paths processed: 11
  ```
- [ ] Manual install via hq-installer 0.3.7 reaches the "Verify kernel integrity" step without error.

## Followup (not in this PR)

Six other scripts in `core/scripts/` (e.g. `archive-old-threads.sh`, `build-policy-digest.sh`, `codex-skill-bridge.sh`) use `\${HQ_ROOT:-\$(cd dirname/..)}` — env-override safe, but the broken default still fires for any caller that doesn't export `HQ_ROOT`. Those could be swept to `/../..` in a follow-up to fully close the door on this class of bug.