### PR TITLE
fix(core): drop companies/manifest.yaml from locked list

### DIFF
--- a/core/core.yaml
+++ b/core/core.yaml
@@ -10,7 +10,6 @@ rules:
     - .claude/hooks/
     - core/policies/
     - core/modules/
-    - companies/manifest.yaml
     - companies/_template/
     - core/workers/registry.yaml
     - core/scripts/


### PR DESCRIPTION
## Summary
- Remove `companies/manifest.yaml` from `rules.locked` in `core/core.yaml`.
- `manifest.yaml` is per-user mutable config (`/newcompany`, `hq-sync`, direct edits to register companies). Listing it under `locked` made `protect-core.sh` block every legitimate write, forcing `HQ_BYPASS_CORE_PROTECT=1` for normal operations.
- Same fix already landed on `hq-core-staging` main (4bc85a9).

## Test plan
- [ ] After merge, an Edit on `companies/manifest.yaml` is no longer blocked by `protect-core.sh`.
- [ ] `core/core.yaml` still parses (`yq eval '.rules.locked' core/core.yaml`).
- [ ] `companies/_template/` and other still-locked entries remain enforced.