### PR TITLE
release: v14.1.2-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 _Nothing yet._
 
+## [14.1.2-beta.2] — 2026-05-14
+
+### Headline
+**Minimal beta cut from `main` containing the `companies/manifest.yaml` lock-list fix.** Distinct lineage from `v14.1.2-beta.1`, which was cut from `hq-core-staging` and never merged into `hq-core/main` — this beta is what `main` actually contains today.
+
+### Fixed
+- **`companies/manifest.yaml` no longer in `core/core.yaml` `rules.locked`** (#15) — `protect-core.sh` and `block-core-writes-bash.sh` were rejecting every Edit/Write to the manifest, even though it's a per-user mutable config that `/newcompany`, `hq-sync`, and direct user edits write to routinely. Operations no longer need `HQ_BYPASS_CORE_PROTECT=1` to touch manifest.yaml.
+
 ## [14.1.1] — 2026-05-13
 
 ### Headline

--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,6 +1,6 @@
 version: 1
-hqVersion: "14.1.1"
-updatedAt: "2026-05-13T16:56:12Z"
+hqVersion: "14.1.2-beta.2"
+updatedAt: "2026-05-14T17:51:13Z"
 # hq-core is the minimal scaffold seed. Rich add-ons ship as `@indigoai-us/hq-pack-*`
 # npm packages installed into `core/packages/` via `hq install`. See `core/packages/README.md`.
 rules:


### PR DESCRIPTION
## Summary
- Bumps `hqVersion`: 14.1.1 → 14.1.2-beta.2
- Adds CHANGELOG.md entry for v14.1.2-beta.2
- Touches `updatedAt` in core.yaml

## Lineage note
This beta is cut from `hq-core/main`. It is **distinct from `v14.1.2-beta.1`**, which was cut from `hq-core-staging` (staging-rollup commit `ca86c63`) and never merged into `hq-core/main`. The only delta from `v14.1.1` on this lineage is the manifest-lock fix in #15.

## Test plan
- [ ] `core-yaml-locked` CI passes (label: `version-bump`)
- [ ] `special-case-files` CI passes (label: `special-case-confirmed`)
- [ ] After merge, tag `v14.1.2-beta.2` on the squash commit
- [ ] Create GitHub prerelease with the CHANGELOG entry as the body