### PR TITLE
Closed stale qmd setup health checks

### DIFF
--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -29,11 +29,12 @@ If a manifest exists, this phase becomes the primary driver of setup. The manife
 - `steps.git-init` failed → no git repo; run `git init && git add . && git commit -m "init"`
 
 **P1 — Required (HQ works poorly without these):**
-- `dependencies.qmd` failed → no semantic search; install with `cargo install qmd` or `brew install tobi/tap/qmd`, then `qmd index .`
+- `dependencies.qmd` failed → no search; install with `npm install -g @tobilu/qmd`, then run `qmd update`
+- `dependencies.qmd` installed but search/index commands fail → Node likely changed after install; rerun `core/scripts/setup.sh` or reinstall with `npm install -g @tobilu/qmd`
 - `dependencies.claude-code` failed → can't run workers; `npm install -g @anthropic-ai/claude-code`
 - `dependencies.yq` failed → can't parse YAML configs; `brew install yq` or download binary
 - `dependencies.hq-cli` failed → can't install packs or sync; `npm install -g @indigoai-us/hq-cli`
-- `steps.indexing` failed → search won't work; run `qmd index .` directly
+- `steps.indexing` failed → search won't work; run `qmd update` directly
 - `packs` with status `"failed"` or `"running"` (interrupted) → retry each: `npx --package=@indigoai-us/hq-cli hq install {pack-name}`
 
 **P2 — Recommended (HQ works but some features limited):**
@@ -90,7 +91,7 @@ If installed but not authenticated (`vercel whoami` exits non-zero): offer `verc
 - `gh auth status` — if gh is installed but not authenticated, offer `gh auth login`
 - `vercel whoami` — if vercel is installed but not authenticated, offer `vercel login`
 
-Post-install: run `qmd index .` if qmd was just installed or no index exists.
+Post-install: run `qmd update` if qmd was just installed or no index exists. Embeddings may download a large local model; run `HQ_SETUP_QMD_EMBED=1 core/scripts/setup.sh` when you explicitly want semantic/vector setup.
 
 ## Phase 1: Identity
 
@@ -249,7 +250,7 @@ knowledge/*/
 
 ### Index
 ```bash
-qmd update 2>/dev/null || qmd index . 2>/dev/null || true
+qmd update 2>/dev/null || true
 ```
 
 ## Phase 3: Summary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## [Unreleased]
 
-_Nothing yet._
+### Fixed
+- **`core/scripts/setup.sh` validates qmd search/index health, not just `qmd --version`** — setup now catches stale native npm dependencies after Node upgrades, rebuilds `better-sqlite3` when possible, and reinstalls qmd if needed.
+
+### Changed
+- **qmd embeddings are opt-in during setup** — setup still builds the keyword index, but only runs the large semantic embedding/model step when `HQ_SETUP_QMD_EMBED=1` is set.
 
 ## [14.1.2-beta.2] — 2026-05-14
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ HQ is **model-agnostic**, so it works inside any AI tool and leverages the subsc
 |------|----------|---------|
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | Yes | `npm install -g @anthropic-ai/claude-code` |
 | [GitHub CLI](https://cli.github.com/) | Yes | `brew install gh` then `gh auth login` |
-| [qmd](https://github.com/tobi/qmd) | Recommended | `brew install tobi/tap/qmd` |
+| [qmd](https://github.com/tobi/qmd) | Recommended | `npm install -g @tobilu/qmd` |
 | [OpenAI Codex](https://openai.com/codex) | Optional | `npm install -g @openai/codex` then `codex login` |
 | [Vercel CLI](https://vercel.com/docs/cli) | Optional | `npm install -g vercel` then `vercel login` |
 | [ggshield](https://docs.gitguardian.com/ggshield-docs/getting-started/installation) | Recommended | `brew install ggshield` then `ggshield auth login` |

--- a/core/scripts/setup.sh
+++ b/core/scripts/setup.sh
@@ -17,6 +17,41 @@ check_cmd() {
   command -v "$1" &>/dev/null
 }
 
+qmd_healthcheck() {
+  command -v qmd &>/dev/null && qmd collection list >/dev/null 2>&1
+}
+
+rebuild_qmd_native_deps() {
+  local npm_root qmd_dir
+
+  npm_root="$(npm root -g 2>/dev/null || true)"
+  [[ -n "$npm_root" ]] || return 1
+
+  qmd_dir="$npm_root/@tobilu/qmd"
+  [[ -d "$qmd_dir/node_modules/better-sqlite3" ]] || return 1
+
+  (
+    cd "$qmd_dir"
+    npm_config_build_from_source=true npm rebuild better-sqlite3 >/dev/null 2>&1
+  )
+}
+
+ensure_qmd_healthy() {
+  if qmd_healthcheck; then
+    return 0
+  fi
+
+  echo "  qmd is installed but index commands failed; rebuilding native dependencies…"
+  if rebuild_qmd_native_deps && qmd_healthcheck; then
+    ok "qmd native dependencies rebuilt"
+    return 0
+  fi
+
+  echo "  Reinstalling @tobilu/qmd@$QMD_VERSION…"
+  npm install -g "@tobilu/qmd@$QMD_VERSION"
+  qmd_healthcheck
+}
+
 # ── 1. Prerequisites ────────────────────────────────────────────────────────
 
 echo "╔══════════════════════════════════════╗"
@@ -82,6 +117,14 @@ else
   fi
   npm install -g "@tobilu/qmd@$QMD_VERSION"
   ok "qmd $QMD_VERSION installed"
+fi
+
+if ensure_qmd_healthy; then
+  ok "qmd search/index commands ready"
+else
+  fail "qmd is installed but search/index commands still fail"
+  fail "Try: npm install -g @tobilu/qmd@$QMD_VERSION"
+  exit 1
 fi
 
 # ── 3. Make scripts executable ───────────────────────────────────────────────
@@ -231,10 +274,17 @@ if command -v qmd &>/dev/null; then
   qmd context add qmd://hq-projects "Project PRDs and documentation." 2>/dev/null || true
 fi
 
-# Update qmd search index and build embeddings
+# Update the keyword/search index. Embeddings can download a large local model,
+# so keep them explicit instead of surprising fresh installs.
 qmd update 2>/dev/null || true
-qmd embed 2>/dev/null || true
-ok "qmd index built"
+ok "qmd keyword index built"
+
+if [[ "${HQ_SETUP_QMD_EMBED:-0}" == "1" ]]; then
+  qmd embed 2>/dev/null || true
+  ok "qmd embeddings built"
+else
+  skip "qmd embeddings not built — set HQ_SETUP_QMD_EMBED=1 to download semantic model"
+fi
 
 # ── 7. Recommended content packs (hq-core v12+) ──────────────────────────────
 # hq-core ships as a minimal scaffold; batteries-included UX comes from packs


### PR DESCRIPTION
## Summary

- Validate qmd search/index health during setup instead of trusting `qmd --version` alone.
- Rebuild qmd's native `better-sqlite3` dependency when Node upgrades leave the installed binary stale, with reinstall fallback.
- Keep setup's keyword index refresh automatic, but make the semantic embedding/model download opt-in with `HQ_SETUP_QMD_EMBED=1`.
- Align setup docs and README with the npm-based qmd install path.

## Root Cause

`qmd --version` can succeed even when real search/index commands fail because the native SQLite module is compiled for an older Node ABI. Setup previously missed that broken-but-present state.

## Validation

- `bash -n core/scripts/setup.sh`
- `git diff --check`
- Verified `qmd collection list` exits successfully without triggering semantic model download.
