### PR TITLE
chore(release): stamp v14.2.1 on MIGRATION.md and core.yaml

### DIFF
--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,6 +1,6 @@
 version: 1
-hqVersion: "14.2.0"
-updatedAt: "2026-05-18T15:40:13Z"
+hqVersion: "14.2.1"
+updatedAt: "2026-05-20T13:21:51Z"
 # hq-core is the minimal scaffold seed. Rich add-ons ship as `@indigoai-us/hq-pack-*`
 # npm packages installed into `core/packages/` via `hq install`. See `core/packages/README.md`.
 rules:

--- a/core/docs/hq/MIGRATION.md
+++ b/core/docs/hq/MIGRATION.md
@@ -1,4 +1,4 @@
-## Release: TBD
+## Release: v14.2.1
 
 ### TL;DR
 


### PR DESCRIPTION
## Summary
- Manual recovery of the v14.2.1 TBD → version stamp + `core/core.yaml` bump that `release.yml` failed to push (rule violation despite App being in bypass_actors)
- Sister PR fixes the backmerge regex in `hq-core-staging` so future stamps actually trigger the staging backmerge

## Why manual
`release.yml` ran successfully on the v14.2.1 tag but its direct push to `main` was rejected:
> `remote: error: GH013: Repository rule violations found for refs/heads/main.`
> `remote: - Changes must be made through a pull request.`

`hq-audit-bot` App (id `3628704`) IS listed in repo ruleset `main_protect` bypass_actors with `bypass_mode: always`, so this is likely an org-level ruleset override that doesn't include the App — needs an admin pass.

## What's stamped
- `core/docs/hq/MIGRATION.md`: `## Release: TBD` → `## Release: v14.2.1`
- `core/core.yaml`: `hqVersion: "14.2.0"` → `"14.2.1"`, `updatedAt` bumped

## After merge
- A separate backmerge PR will be opened manually on `hq-core-staging` (the `backmerge-to-staging.yml` workflow's detection regex looks for `^chore(migration): stamp v` but `release.yml` emits `chore(release): stamp ...` — fix lands in the sister PR)