### PR TITLE
release: v14.2.2 — /hq-share Claude-drafted note pre-fill

### DIFF
--- a/.claude/skills/hq-share/SKILL.md
+++ b/.claude/skills/hq-share/SKILL.md
@@ -20,7 +20,7 @@ grant and the browser flow".
 ## Usage
 
 ```
-/hq-share <path>... [--company <slug>] [--no-open]
+/hq-share <path>... [--company <slug>] [--no-open] [--no-draft]
 ```
 
 Examples:
@@ -29,7 +29,13 @@ Examples:
 /hq-share reports/q3/
 /hq-share reports/q3/ docs/handbook/ --company {company}
 /hq-share announcements/ --no-open               # print URL, headless contexts
+/hq-share reports/q3/ --no-draft                 # skip the LLM-drafted note step
 ```
+
+`--no-draft` skips the Step 3.5 "draft the note" pre-fill — useful when
+the sender wants to type their own context from scratch without an
+agent-generated starting point. Sender always gets the textarea in the
+browser regardless.
 
 ## Process
 
@@ -58,15 +64,93 @@ or the active company in `~/.hq/config.json`). Granting on the wrong company
 uid is hard to clean up — pause for approval if anything looks off, then
 proceed.
 
+### 3.5. Draft the note (sender-side LLM pre-fill)
+
+The share-session form has an optional **Note** textarea — the recipient
+sees the note as the body of their macOS notification ("their note: …")
+and again at the top of the ShareDetail window. Empty note → recipient
+notification falls back to a comma-joined list of basenames, which is
+much less useful.
+
+When the local paths are readable (skill is running in the user's session,
+not headless), draft a short note BEFORE minting so the user just reviews
+and approves rather than typing from scratch.
+
+**Inventory step (cheap):**
+
+- For each `<path>` positional:
+  - Folder (trailing slash) → `ls` the top level + recurse one level (cap
+    ~30 entries total); collect basenames + a brief sense of contents
+    (presence of `README.md`, `package.json`, `prd.json`, leading docs).
+  - File → just the basename and (if small text) a 1-line skim.
+- Skip binaries / files > 100 KB / known noise (`node_modules/`, `.git/`,
+  build output). Read text files only when their basename suggests
+  context (`README.md`, `prd.json`, top-level `.md` in folder).
+
+**Draft step (≤2 sentences, factual):**
+
+- Lead with what + why ("Sharing the Q3 retro notes for your review
+  before the all-hands.").
+- Name 1–2 specific things if obvious from the inventory ("Brief +
+  three open-question docs.").
+- Do NOT invent context not present in the files / recent conversation.
+- Cap ~280 chars — the recipient sees it as a notification body which
+  truncates at ~100 chars, and the textarea soft-warns above 1800.
+
+**Confirm step (one structured question, single picker):**
+
+Show the user the draft note and offer:
+
+- **Use this draft (Recommended)** — proceed with the note as written.
+- **Edit before sending** — print the draft so the user can quote/edit
+  in chat; their reply becomes the note.
+- **Skip — no note** — proceed without pre-fill.
+
+If the user types their own note inline ("note: …"), treat that as the
+chosen text without re-asking.
+
+**Skip the whole step when:**
+
+- `--no-open` is set (headless / scripted — the URL goes to a side
+  channel, the human writes the note in the browser).
+- The path is not locally readable (vault-only prefix the user is sharing
+  without a local mirror).
+- The user explicitly passed `--no-draft` (flag added below).
+- The user has set `personal/agents-profile.md` to opt out of LLM-drafted
+  notes (free-form heuristic — if uncertain, ask once and remember the
+  answer for the session).
+
+The drafted text rides on the URL as `?note=<urlencoded>` (Step 4); the
+hq-console form reads it on mount and seeds the textarea, showing a
+"drafted by Claude — edit freely" hint until the user touches it.
+
 ### 4. Mint + open
 
 ```bash
-hq files share <paths...> [--company <slug>] [--no-open]
+# Always mint with --no-open so the skill can append ?note= before
+# launching the browser. (Skipping the draft step → no `?note=` param,
+# behavior matches today's flow.)
+URL=$(hq files share <paths...> [--company <slug>] --no-open 2>&1 \
+  | grep -oE 'https://hq\.[^[:space:]]+')
+
+# If a draft was accepted, append ?note=<urlencoded>. Use jq's @uri
+# filter so newlines / quotes / unicode are encoded safely.
+if [ -n "$DRAFT_NOTE" ]; then
+  ENCODED=$(printf '%s' "$DRAFT_NOTE" | jq -sRr @uri)
+  URL="${URL}?note=${ENCODED}"
+fi
+
+# Open in browser unless the user passed --no-open.
+if [ -z "$USER_NO_OPEN" ]; then
+  open "$URL" 2>/dev/null || xdg-open "$URL" 2>/dev/null
+fi
 ```
 
 The CLI prints `Share-session URL generated:` followed by the URL,
 normalized paths, and `Expires:` timestamp. Default TTL is 15 minutes,
-bounded `60s..7d`.
+bounded `60s..7d`. The skill always reads the URL from `--no-open` output
+and handles browser launch itself so the `?note=` param can be appended
+without a CLI release.
 
 ### 5. Surface the URL + safe metadata
 
@@ -129,6 +213,18 @@ artifact — in those contexts use the redacted form
    scheduled tasks, and sub-agents have no browser to launch into. The flag
    tells the CLI to print the URL and exit, leaving the human handoff for the
    parent session to coordinate over a side channel.
+
+6. **The agent-drafted note is a starting point, never an assertion.** The
+   draft from Step 3.5 lands in the recipient's macOS notification body
+   verbatim — keep it factual ("Sharing the Q3 retro for review"), avoid
+   speculation about the recipient's response or the contents' importance
+   ("urgent", "you'll love this", "make sure to read carefully"), and never
+   include anything the sender hasn't seen. The sender ALWAYS gets the
+   textarea pre-filled in the browser and is the final approver — but a
+   misleading or pushy draft they have to delete is worse than no draft at
+   all. If the inventory step produced nothing usable (binary blob, single
+   opaque file, no README), skip the draft and let the sender type their
+   own note rather than padding the textarea with filler.
 
 ## Requires
 

--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,6 +1,6 @@
 version: 1
-hqVersion: "14.2.1"
-updatedAt: "2026-05-20T13:21:51Z"
+hqVersion: "14.2.2"
+updatedAt: "2026-05-26T14:30:00Z"
 # hq-core is the minimal scaffold seed. Rich add-ons ship as `@indigoai-us/hq-pack-*`
 # npm packages installed into `core/packages/` via `hq install`. See `core/packages/README.md`.
 rules:

--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,6 +1,6 @@
 version: 1
-hqVersion: "14.2.2"
-updatedAt: "2026-05-26T14:30:00Z"
+hqVersion: "14.2.1"
+updatedAt: "2026-05-20T13:21:51Z"
 # hq-core is the minimal scaffold seed. Rich add-ons ship as `@indigoai-us/hq-pack-*`
 # npm packages installed into `core/packages/` via `hq install`. See `core/packages/README.md`.
 rules:

--- a/core/docs/hq/CHANGELOG.md
+++ b/core/docs/hq/CHANGELOG.md
@@ -9,6 +9,11 @@
 ### Removed
 - Removed legacy root `data/` scaffold and root copies of public HQ docs.
 
+## [14.2.2] — 2026-05-26
+
+### Added — Skills
+- **`/hq-share` — Claude-drafted note pre-fill.** When `/hq-share` is invoked with the shared paths locally readable, the skill now inventories the files, drafts a 1–2 sentence factual note describing what's being shared, and confirms with the user (Use as-is / Edit / Skip) before minting. The accepted draft rides on the share-session URL as `?note=<urlencoded>`; the hq-console form reads it on mount and seeds the note textarea, auto-grown to fit and capped at 2000 chars. A subtle "drafted by Claude — edit freely" hint sits above the label until the sender takes ownership with their first keystroke. The sender always sees the textarea in the browser and can rewrite or clear the prefill — they remain the final approver. New `--no-draft` flag opts out of the draft step entirely (sender sees an empty textarea, today's pre-prototype behavior). Step 3.5 in `SKILL.md` covers the inventory + draft + confirm flow; rule #6 captures the factual-no-speculation drafting guidance. No CLI release required — the skill captures the URL via `hq files share --no-open`, appends `?note=`, and opens the browser itself.
+
 ## [14.1.0] — 2026-05-13
 
 ### Headline

--- a/core/docs/hq/MIGRATION.md
+++ b/core/docs/hq/MIGRATION.md
@@ -1,4 +1,4 @@
-## Release: v14.2.2
+## Release: TBD
 
 ### TL;DR
 

--- a/core/docs/hq/MIGRATION.md
+++ b/core/docs/hq/MIGRATION.md
@@ -1,3 +1,42 @@
+## Release: v14.2.2
+
+### TL;DR
+
+Patch release. Adds Claude-drafted note pre-fill to `/hq-share`: the skill inventories the shared paths, drafts a 1–2 sentence factual note, and confirms with you before minting. The accepted draft rides on the share-session URL as `?note=` and pre-populates the recipient-facing note textarea in the hq-console form — the sender just reviews and approves.
+
+**No operator action required.** Run `/update-hq` to pick it up. No breaking changes, no config to set, no migration steps. Existing `/hq-share` invocations behave identically when the draft step doesn't fire (vault-only paths, headless contexts, or `--no-draft`).
+
+Companion server-side change shipped via `indigoai-us/hq-console#126` — already live on `hq.{your-domain}.com`. The form-side `?note=` reader was deployed before this release, so old `/hq-share` invocations (no `?note=` param) keep their empty-textarea behavior.
+
+### Changed
+
+- **`.claude/skills/hq-share/SKILL.md`** — new Step 3.5 "Draft the note" inserts between scope-confirm and mint. Documents the inventory cap (~30 entries, ≤100 KB per file, text-only basenames), the confirm picker (Use as-is / Edit / Skip / Type-my-own), the always-edit guarantee for the sender, and the new `--no-draft` flag. Step 4 (Mint) now always passes `--no-open` and re-opens the browser itself so `?note=` can be appended without a CLI release. Rule #6 added: factual no-speculation drafting (no "urgent", no "you'll love this", skip the draft if the inventory produces nothing usable).
+
+### New Flag
+
+- `--no-draft` — skips Step 3.5 entirely. Useful when the sender wants to type the note from scratch without an agent-generated starting point. The textarea is still optional and editable in the browser; only the pre-fill is bypassed.
+
+### Server-Side Companion (Already Live)
+
+- `hq-console` `ShareSessionForm` reads `?note=` from `useSearchParams` on mount and seeds the note textarea. A small "drafted by Claude — edit freely" hint appears above the label while the draft is untouched; it disappears on the sender's first keystroke. `?note=` value is capped at 2000 chars (matches the existing soft-hint threshold for notification-preview truncation). Auto-grow `useEffect` ensures multi-line drafts render at natural height on first paint. Three new vitest cases cover prefill behavior, the 2000-char cap, and the absent-param path (no behavior change).
+
+### How To Verify
+
+```
+# In any HQ session that picked up v14.2.2:
+/hq-share companies/{co}/data/some-folder/
+
+# You should see, after path confirmation:
+# - A short Claude-drafted note for review
+# - A picker: Use as-is / Edit / Skip
+# - Browser opens with the textarea pre-filled and "drafted by Claude" hint visible
+# - Editing the textarea clears the hint
+```
+
+If `?note=` doesn't appear on the URL, check that the skill ran Step 3.5 (it skips on `--no-draft`, headless contexts, or vault-only paths that aren't locally readable).
+
+---
+
 ## Release: v14.2.1
 
 ### TL;DR


### PR DESCRIPTION
## Summary

Patch release. Adds the Claude-drafted note pre-fill follow-up to share-notify v1: when `/hq-share` is invoked with the shared paths locally readable, the skill inventories them, drafts a 1-2 sentence factual note, and confirms with the sender before minting. The accepted draft rides on the share-session URL as `?note=<urlencoded>` — the hq-console form reads it on mount and seeds the note textarea. Sender just reviews and approves rather than typing from scratch.

Builds on:
- share-notify v0.1.105 (recipient-side macOS notifications) — `indigoai-us/hq-sync#112`, `indigoai-us/hq-pro#146`, `indigoai-us/hq-console#125`
- Note textarea + `?note=` reader on share-session form — `indigoai-us/hq-console#126` (merged 2026-05-26, live on hq-prod)

## What's in the change

- **`.claude/skills/hq-share/SKILL.md`** — new Step 3.5 "Draft the note" between scope-confirm and mint. Documents inventory cap (~30 entries, ≤100 KB per file, text-only basenames), confirm picker (Use as-is / Edit / Skip / Type-my-own), always-edit guarantee for the sender, new \`--no-draft\` flag. Step 4 (Mint) always passes \`--no-open\` and re-opens the browser itself so \`?note=\` can be appended without a CLI release. Rule #6 added: factual no-speculation drafting.
- **`core/core.yaml`** — \`hqVersion\` 14.2.1 → 14.2.2, \`updatedAt\` refreshed
- **`core/docs/hq/CHANGELOG.md`** — new \`[14.2.2]\` section
- **`core/docs/hq/MIGRATION.md`** — v14.2.2 release notes prepended (root \`MIGRATION.md\` symlinks here)

## Operator action

**None.** \`/update-hq\` picks up the new skill. Existing \`/hq-share\` invocations behave identically when Step 3.5 doesn't fire (vault-only paths, headless, \`--no-draft\`).

## Test plan

- [x] Skill change exercised in author's session against \`companies/indigo/projects/hq-sync-share-notify/broadcast/\`
- [x] URL minted with \`?note=...\` appended via the new flow
- [x] hq-console form (PR #126, live on prod) reads \`?note=\` on mount, textarea pre-filled, "drafted by Claude" hint visible
- [x] First keystroke clears the hint
- [x] 9/9 vitest tests on \`share-session-form\` pass
- [ ] After merge: tag \`v14.2.2\`, push tag, create GitHub release
- [ ] Teammates run \`/update-hq\` to pick up the new skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)