### PR TITLE
fix(hooks): read tool matcher from frontmatter (Windows filename compat)

### DIFF
--- a/.claude/hooks/master-hook.sh
+++ b/.claude/hooks/master-hook.sh
@@ -68,8 +68,18 @@ is_tool_event() {
 
 parse_matcher() {
   local stem="${1%.sh}"
+  local full="${2:-}"
   if [[ "$stem" != *"--"* ]]; then
-    printf ''
+    # No filename matcher. Check for a '# hq-hook-match:' frontmatter line so a
+    # hook can carry a tool matcher containing characters that are illegal in
+    # Windows filenames (e.g. '*', which causes ERROR_INVALID_NAME on NTFS and
+    # makes 'git checkout' of the whole pack fail on Windows). Falls back to
+    # empty (always-run) when absent, identical to prior behaviour for plain
+    # <NN>-<name>.sh hooks.
+    if [ -n "$full" ] && [ -f "$full" ]; then
+      sed -n 's/^#[[:space:]]*hq-hook-match:[[:space:]]*//p' "$full" | head -n1 | tr -d '
+'
+    fi
     return
   fi
   local prefix="${stem%%--*}"
@@ -177,7 +187,7 @@ is_json_object() {
 
 for hook in ${hooks[@]+"${hooks[@]}"}; do
   base="$(basename "$hook")"
-  matcher="$(parse_matcher "$base")"
+  matcher="$(parse_matcher "$base" "$hook")"
 
   if is_tool_event "$EVENT" && [ -n "$matcher" ]; then
     if ! matches_tool "$matcher" "$TOOL_NAME"; then


### PR DESCRIPTION
## Why

A hook in `hq-packages` (`hq-pack-engineering`) had a filename containing `*`:
`50-mcp__Claude_in_Chrome__*,mcp__playwright__*,mcp__Playwright__*--prefer-agent-browser.sh`

`*` is illegal on NTFS, so `git checkout` of the pack fails on Windows with `error: invalid path ...` and **breaks `hq install` for every pack** (hq-cli clones the whole monorepo per pack).

## What

`parse_matcher()` now takes an optional full-path arg. When a hook filename has **no** `--matcher--` segment, it reads a `# hq-hook-match:` line from the file body to get the tool matcher. This lets a hook carry a matcher with chars illegal in Windows filenames.

- Old `<NN>-<matcher>--<name>.sh` hooks: **unaffected** (filename branch is checked first).
- New plain `<NN>-<name>.sh` hooks: gain optional frontmatter matcher; absent → always-run (unchanged).

Companion change in `hq-packages`: renamed the offending file to `50-prefer-agent-browser.sh` + added the `# hq-hook-match:` line (already merged to main there).

## Test

Fresh `git clone` of `hq-packages` now succeeds on Windows 11 (checkout clean, 0 illegal filenames). Matcher regex verified: `mcp__playwright__navigate` matches, `Bash` does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)