### PR TITLE
release: v15.0.10

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -73,6 +73,23 @@ jobs:
           echo "::error::HQ_AUDIT_BOT_APP_ID or HQ_AUDIT_BOT_PRIVATE_KEY not set. The App token is required so the tag push triggers release.yml."
           exit 1
 
+      - name: Checkout release commit
+        if: steps.parse.outputs.match == 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Require release migration doc before tag
+        if: steps.parse.outputs.match == 'true'
+        env:
+          TAG: ${{ steps.parse.outputs.tag }}
+        run: |
+          set -euo pipefail
+          bash core/scripts/ensure-release-migration.sh \
+            --mode verify \
+            --version "$TAG" \
+            --base-ref HEAD^
+
       - name: Mint installation token
         id: app-token
         if: steps.parse.outputs.match == 'true'

--- a/.github/workflows/promote-to-hq-core.yml
+++ b/.github/workflows/promote-to-hq-core.yml
@@ -309,6 +309,21 @@ jobs:
           echo "----- core/core.yaml diff -----"
           diff -u "staging/core/core.yaml" "$CORE_YAML" || true
 
+      - name: Ensure release migration doc
+        # /update-hq reads core/docs/hq/MIGRATION.md at the target tag, so the
+        # release PR commit itself must carry migration data before
+        # auto-tag-release.yml creates the tag.
+        if: steps.realchanges.outputs.skip != 'true' && steps.params.outputs.pr_type == 'release'
+        env:
+          INPUT_VERSION: ${{ steps.params.outputs.version }}
+        run: |
+          set -euo pipefail
+          cd target
+          bash core/scripts/ensure-release-migration.sh \
+            --mode generate \
+            --version "$INPUT_VERSION" \
+            --base-ref HEAD
+
       - name: Diff summary
         id: diff
         if: steps.realchanges.outputs.skip != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,16 @@ jobs:
             echo "prerelease=${PRERELEASE}"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Require release migration doc
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+        run: |
+          set -euo pipefail
+          bash core/scripts/ensure-release-migration.sh \
+            --mode verify \
+            --version "$TAG" \
+            --base-ref HEAD^
+
       - name: Mint App token (for MIGRATION.md TBD swap commit)
         id: app-token
         if: env.HQ_AUDIT_BOT_APP_ID != '' && env.HQ_AUDIT_BOT_PRIVATE_KEY != ''

--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,6 +1,6 @@
 version: 1
-hqVersion: "15.0.9"
-updatedAt: "2026-06-06T12:15:36Z"
+hqVersion: "15.0.10"
+updatedAt: "2026-06-09T16:04:01Z"
 # hq-core is the minimal scaffold seed. Rich add-ons ship as `@indigoai-us/hq-pack-*`
 # npm packages installed into `core/packages/` via `hq install`. See `core/packages/README.md`.
 rules:

--- a/core/docs/hq/CHANGELOG.md
+++ b/core/docs/hq/CHANGELOG.md
@@ -1,5 +1,39 @@
 ## [Unreleased]
 
+## [15.0.10] -- release migration docs restored and gated
+
+### Fixed
+- Restores `core/docs/hq/MIGRATION.md` with concrete v15.0.9 migration data so upgraders on v15.0.8 have a consumable patch-line path again.
+- Adds release automation coverage that fails a non-trivial release when the target tag would not carry a migration section with `### Migration Steps` and backtick-wrapped file paths.
+
+### Added
+- `core/scripts/ensure-release-migration.sh` generates release migration sections from the staged release diff during `promote-to-hq-core.yml`.
+- `auto-tag-release.yml` verifies the release commit before creating a tag, and `release.yml` re-checks before cutting the GitHub release.
+- Regression test: `core/scripts/tests/ensure-release-migration.test.sh`.
+
+### Migration
+- Upgrading from v15.0.8 should target v15.0.10 or later. The v15.0.10 migration file includes both the restored v15.0.9 file list and the v15.0.10 release-gate changes.
+
+## [15.0.9] -- policy trigger system and hook routing cleanup
+
+### Added
+- Policy trigger evaluator scripts: `core/scripts/eval-trigger.sh`, `core/scripts/derive-trigger-facts.sh`, and `core/scripts/migrate-policy-triggers.sh`.
+- Regression coverage for policy trigger derivation and hook injection.
+- `.claude/hooks/reindex.sh` as the replacement path for the removed master-sync/reindex split.
+
+### Changed
+- Policy files gained trigger-oriented frontmatter, and hook/session policy loading was routed through the new trigger evaluation path.
+- `.claude/hooks/hook-gate.sh`, `.claude/settings.json`, and related hook surfaces were updated for the trigger-based flow.
+- `/update-hq` was simplified toward the `hq rescue` updater path.
+
+### Removed
+- Removed legacy `.claude/hooks/master-sync.sh`, `.claude/hooks/load-policies-for-session.sh`, `.claude/stack.yaml`, `core/scripts/build-policy-digest.sh`, and generated policy digest output from the public core release.
+- The v15.0.9 tag accidentally removed `core/docs/hq/MIGRATION.md`; v15.0.10 restores the patch-line migration data.
+
+### Migration
+- Do not hand-merge the v15.0.9 diff. Upgrade to v15.0.10 or later so `/update-hq` can read the restored migration file and apply the patch-line changes.
+- Restart Claude Code or Codex after updating because this patch line changes hooks, settings, and core scripts.
+
 ## [15.0.0] — BREAKING — engineering surface extracted
 
 ### Added — Skills

--- a/core/docs/hq/MIGRATION.md
+++ b/core/docs/hq/MIGRATION.md
@@ -1,0 +1,267 @@
+## Migrating to v15.0.10 -- generated migration summary
+
+Generated from the release diff against `origin/main` so `/update-hq` has concrete migration data at the target tag.
+
+### New Files
+
+- `core/docs/hq/MIGRATION.md`
+- `core/scripts/ensure-release-migration.sh`
+- `core/scripts/tests/ensure-release-migration.test.sh`
+
+### Updated Files
+
+- `.github/workflows/auto-tag-release.yml`
+- `.github/workflows/promote-to-hq-core.yml`
+- `.github/workflows/release.yml`
+- `core/core.yaml`
+- `core/docs/hq/CHANGELOG.md`
+
+### Removed
+
+- None.
+
+### Breaking Changes
+
+- None declared automatically. Review hook, settings, and updater changes before merging if this release changes session startup or upgrade behavior.
+
+### Migration Steps
+
+1. Run `/update-hq` to apply this release.
+2. Restart Claude Code or Codex after the update if this release changes `.claude/hooks/`, `.claude/settings.json`, `.codex/`, `.agents/`, or `core/scripts/`.
+3. Review any local drift that `/update-hq` reports before continuing normal work.
+
+## Migrating to v15.0.9 -- generated migration summary
+
+Generated from the release diff against `v15.0.8` so `/update-hq` has concrete migration data at the target tag.
+
+### New Files
+
+- `.claude/hooks/reindex.sh`
+- `core/scripts/derive-trigger-facts.sh`
+- `core/scripts/eval-trigger.sh`
+- `core/scripts/migrate-policy-triggers.sh`
+- `core/scripts/tests/derive-trigger-facts.test.sh`
+- `core/scripts/tests/eval-trigger.test.sh`
+- `core/scripts/tests/eval-triggers-hooks.test.sh`
+- `core/scripts/tests/inject-policy-e2e.test.sh`
+
+### Updated Files
+
+- `.claude/CLAUDE.md`
+- `.claude/hooks/block-core-writes.sh`
+- `.claude/hooks/check-hq-update.sh`
+- `.claude/hooks/hook-gate.sh`
+- `.claude/hooks/inject-policy-on-trigger.sh`
+- `.claude/hooks/natural-language-router.sh`
+- `.claude/hooks/protect-core.sh`
+- `.claude/hooks/surface-company-infra-policy.sh`
+- `.claude/settings.json`
+- `.claude/skills/brainstorm/SKILL.md`
+- `.claude/skills/handoff/SKILL.md`
+- `.claude/skills/hq-heal/SKILL.md`
+- `.claude/skills/hq-secrets/SKILL.md`
+- `.claude/skills/import-claude/SKILL.md`
+- `.claude/skills/knowledge-pulse/SKILL.md`
+- `.claude/skills/learn/SKILL.md`
+- `.claude/skills/newworker/SKILL.md`
+- `.claude/skills/plan/SKILL.md`
+- `.claude/skills/run/SKILL.md`
+- `.claude/skills/setup/SKILL.md`
+- `.claude/skills/startwork/SKILL.md`
+- `.claude/skills/update-hq/SKILL.md`
+- `.codex/hooks/hq-codex-hook-adapter.sh`
+- `.github/workflows/audit.yml`
+- `.github/workflows/auto-beta-release.yml`
+- `.github/workflows/pr-checks.yml`
+- `.github/workflows/promote-to-hq-core.yml`
+- `.leak-scan/scan.sh`
+- `core/core.yaml`
+- `core/docs/hq/README.md`
+- `core/docs/hq/USER-GUIDE.md`
+- `core/knowledge/public/INDEX.md`
+- `core/knowledge/public/hq-core/hq-desktop/knowledge-system-mapping.md`
+- `core/knowledge/public/hq-core/hq-desktop/worker-system-mapping.md`
+- `core/knowledge/public/hq-core/hq-structure-detection.md`
+- `core/knowledge/public/hq-core/native-knowledge-stores.md`
+- `core/knowledge/public/hq-core/obsidian-setup.md`
+- `core/knowledge/public/hq-core/policies-spec.md`
+- `core/knowledge/public/hq-core/quick-reference.md`
+- `core/knowledge/public/hq-core/starter-kit-compatibility-contract.md`
+- `core/knowledge/public/workers/README.md`
+- `core/policies/ai-velocity-time-sense.md`
+- `core/policies/always-pr-shared-state-repos.md`
+- `core/policies/auto-deploy-on-create.md`
+- `core/policies/bulk-sed-exception-ordering.md`
+- `core/policies/chunked-reads-large-files.md`
+- `core/policies/company-archive-cleanup.md`
+- `core/policies/credential-access-protocol.md`
+- `core/policies/decision-queue-one-at-a-time.md`
+- `core/policies/deep-plan-skill-routing.md`
+- `core/policies/distributed-join-partial-failure-diagnosis.md`
+- `core/policies/env-file-no-trailing-newline.md`
+- `core/policies/git-add-explicit-paths-no-drift.md`
+- `core/policies/git-branch-verify.md`
+- `core/policies/git-checkout-not-a-probe.md`
+- `core/policies/git-stash-build-artifacts-conflict.md`
+- `core/policies/glob-scoped-path.md`
+- `core/policies/hook-macos-case-paths.md`
+- `core/policies/hq-alert-baseline-calibration.md`
+- `core/policies/hq-announce-before-irreversible.md`
+- `core/policies/hq-audience-mode.md`
+- `core/policies/hq-auth-middleware-whitelist-password-flow.md`
+- `core/policies/hq-bash-discipline.md`
+- `core/policies/hq-bash-non-subshell-cd-cwd-leak-cross-repo.md`
+- `core/policies/hq-check-dirty-tree-before-repo-edit.md`
+- `core/policies/hq-classifier-own-labels-single-source.md`
+- `core/policies/hq-claude-code-default-mode-plan-not-auto.md`
+- `core/policies/hq-claude-path-string-trips-block-core-writes-bash.md`
+- `core/policies/hq-cluster-test-failures-by-root-cause.md`
+- `core/policies/hq-codex-decision-gate-fallback.md`
+- `core/policies/hq-codex-sdk-config-vs-typed-fields.md`
+- `core/policies/hq-company-scoped-writes-verify-company.md`
+- `core/policies/hq-compiled-ts-rebuild-after-src-edits.md`
+- `core/policies/hq-confirm-creative-direction.md`
+- `core/policies/hq-confirm-session-scope-after-plan-approval.md`
+- `core/policies/hq-core-main-gated-by-ruleset-not-classic-protection.md`
+- `core/policies/hq-core-never-recut-shipped-tag-for-docs.md`
+- `core/policies/hq-core-vs-personal-skill-location-and-rename.md`
+- `core/policies/hq-cross-repo-privilege-tier-surface-scope.md`
+- `core/policies/hq-customizations-live-in-personal-or-company.md`
+- `core/policies/hq-data-collection-isolation.md`
+- `core/policies/hq-db-query-probe-real-table.md`
+- `core/policies/hq-debug-multi-hop-exhaust-all-layers.md`
+- `core/policies/hq-deploy-reinforcement.md`
+- `core/policies/hq-destructive-scripts-default-dry-run.md`
+- `core/policies/hq-detect-secrets-echo-escape-testing.md`
+- `core/policies/hq-docker-build-platform-amd64.md`
+- `core/policies/hq-docker-in-docker-path-translation.md`
+- `core/policies/hq-eslint-allow-default-project-for-root-configs.md`
+- `core/policies/hq-fix-root-cause-not-symptoms.md`
+- `core/policies/hq-ggshield-recursive-for-dirs.md`
+- `core/policies/hq-git-diff-three-dot-for-pr-review.md`
+- `core/policies/hq-git-discipline.md`
+- `core/policies/hq-git-divergence-check-both-directions.md`
+- `core/policies/hq-git-large-diff-audit-before-panic.md`
+- `core/policies/hq-git-merge-ff-only-trunk.md`
+- `core/policies/hq-git-push-refspec-chip-safe.md`
+- `core/policies/hq-github.md`
+- `core/policies/hq-gitignore-before-first-commit.md`
+- `core/policies/hq-handoff-changeset-scope.md`
+- `core/policies/hq-hook-gate-three-profile-lists.md`
+- `core/policies/hq-hook-json-build-with-jq-not-unquoted-heredoc.md`
+- `core/policies/hq-html-target-blank-noopener.md`
+- `core/policies/hq-jq-atomic-edits-large-json-configs.md`
+- `core/policies/hq-linear.md`
+- `core/policies/hq-load-company-hard-policies-on-mid-session-bind.md`
+- `core/policies/hq-local-autocommit.md`
+- `core/policies/hq-mcp-absolute-paths.md`
+- `core/policies/hq-migration-bidirectional-grep-verify.md`
+- `core/policies/hq-migration-independent-grep-verify.md`
+- `core/policies/hq-migration-phase-boundary-regression-gate.md`
+- `core/policies/hq-never-fabricate-research-artifacts.md`
+- `core/policies/hq-never-swallow-errors.md`
+- `core/policies/hq-no-diff-q-in-parallel-bash.md`
+- `core/policies/hq-no-force-push-diverged-release-branch.md`
+- `core/policies/hq-no-limits-means-kill-switch.md`
+- `core/policies/hq-no-parent-import-from-child-component.md`
+- `core/policies/hq-no-production-testing.md`
+- `core/policies/hq-no-screencapture-self-verify-gui.md`
+- `core/policies/hq-no-worktree-for-repo-work.md`
+- `core/policies/hq-octokit-commit-vs-pr-phases-distinct.md`
+- `core/policies/hq-orthogonal-filters-over-overlapping-presets.md`
+- `core/policies/hq-pack-hooks-auto-discover-from-packages-dir.md`
+- `core/policies/hq-pack-policies-excluded-from-core-release.md`
+- `core/policies/hq-parallel-batch-block-cancels-writes.md`
+- `core/policies/hq-permission-rules-literal-subcommand-prefixes.md`
+- `core/policies/hq-permission-simple-expansion-extract-to-script.md`
+- `core/policies/hq-permissions-fan-out-edit-write-multiedit.md`
+- `core/policies/hq-pnpm-min-release-age-supply-chain.md`
+- `core/policies/hq-policy-enforcement-claims-verify-wiring.md`
+- `core/policies/hq-post-parallel-build-verify.md`
+- `core/policies/hq-pr-single-concern.md`
+- `core/policies/hq-pre-push-gate-probes-prod-not-localhost.md`
+- `core/policies/hq-prefer-agent-browser.md`
+- `core/policies/hq-pull-before-work.md`
+- `core/policies/hq-qmd-first-for-hq-search.md`
+- `core/policies/hq-redact-structural-plus-regex-pass.md`
+- `core/policies/hq-rm-permission-allow-scope-paths.md`
+- `core/policies/hq-rust-helper-extension-audit-call-sites.md`
+- `core/policies/hq-rust-string-byte-slice-char-boundary-panic.md`
+- `core/policies/hq-scanner-no-default-scopes-test-flag.md`
+- `core/policies/hq-secure-link-render-as-markdown.md`
+- `core/policies/hq-session-resume-git-status-reverify.md`
+- `core/policies/hq-share-session-urls-are-capabilities.md`
+- `core/policies/hq-skill-plugin-pattern.md`
+- `core/policies/hq-slack.md`
+- `core/policies/hq-static-regression-anchor-forbidden-pattern.md`
+- `core/policies/hq-sub-agent-summary-verify-via-grep.md`
+- `core/policies/hq-subagent-granularity-ambiguity.md`
+- `core/policies/hq-supabase.md`
+- `core/policies/hq-sync-codex-validation-and-conflict-resolution.md`
+- `core/policies/hq-task-chip-worktree-isolation.md`
+- `core/policies/hq-toolsearch-load-deferred-schemas.md`
+- `core/policies/hq-user-specified-tool-unavailable.md`
+- `core/policies/hq-validator-and-schema-paired-in-pr.md`
+- `core/policies/hq-vendor-cutover-runbook-default.md`
+- `core/policies/hq-vercel.md`
+- `core/policies/hq-verify-git-after-compact.md`
+- `core/policies/hq-verify-shared-files-after-parallel-agents.md`
+- `core/policies/humanize-generated-content.md`
+- `core/policies/image-context-isolation.md`
+- `core/policies/journal-project-scoped-writes.md`
+- `core/policies/learn-auto-no-confirmation.md`
+- `core/policies/learned-rules-never-in-claude-md.md`
+- `core/policies/mcp-process-cleanup.md`
+- `core/policies/mcp-transport-detection.md`
+- `core/policies/model-context-window.md`
+- `core/policies/native-knowledge-first.md`
+- `core/policies/native-session-project-capture.md`
+- `core/policies/natural-language-mode.md`
+- `core/policies/never-echo-tokens-stdout.md`
+- `core/policies/no-grep-discovery.md`
+- `core/policies/no-headless-browser-in-vercel-lambda.md`
+- `core/policies/no-relative-symlinks-from-worktree.md`
+- `core/policies/no-shared-skill-extraction-touching-5-files.md`
+- `core/policies/post-edit-verification.md`
+- `core/policies/prd-content-sources.md`
+- `core/policies/prd-story-sizing.md`
+- `core/policies/prd-validation.md`
+- `core/policies/pre-deploy-domain-check.md`
+- `core/policies/pre-refactor-hygiene.md`
+- `core/policies/prefer-systemic-fix-over-user-bandaid.md`
+- `core/policies/quiet-by-default-narration.md`
+- `core/policies/ralph-orchestrator-context-discipline.md`
+- `core/policies/regression-gate-lint-fix.md`
+- `core/policies/rename-safety-checklist.md`
+- `core/policies/reread-before-edit-long-sessions.md`
+- `core/policies/reskin-separate-orchestration-from-visual.md`
+- `core/policies/slack-broadcasts-follow-tier-discipline.md`
+- `core/policies/subagent-fanout-budget.md`
+- `core/policies/subagent-no-mcp.md`
+- `core/policies/verify-routes-after-parallel-execution.md`
+- `core/policies/work-broadcast-jq-inline-recipe-fails-bash-harness.md`
+- `core/policies/work-broadcast-prompt.md`
+- `core/scripts/codex-preflight.sh`
+- `core/scripts/generate-workers-registry.sh`
+- `core/scripts/hq-session.sh`
+- `core/scripts/rebuild-threads-index.sh`
+- `core/scripts/test-codex-hook-adapter.sh`
+- `core/workers/public/INDEX.md`
+
+### Removed
+
+- `.claude/hooks/load-policies-for-session.sh`
+- `.claude/hooks/master-sync.sh`
+- `.claude/stack.yaml`
+- `core/policies/_digest.md`
+- `core/scripts/build-policy-digest.sh`
+
+### Breaking Changes
+
+- None declared automatically. Review hook, settings, and updater changes before merging if this release changes session startup or upgrade behavior.
+
+### Migration Steps
+
+1. Run `/update-hq` to apply this release.
+2. Restart Claude Code or Codex after the update if this release changes `.claude/hooks/`, `.claude/settings.json`, `.codex/`, `.agents/`, or `core/scripts/`.
+3. Review any local drift that `/update-hq` reports before continuing normal work.

--- a/core/scripts/ensure-release-migration.sh
+++ b/core/scripts/ensure-release-migration.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# hq-core: public
+# Ensure a release commit carries migration data before it can be tagged.
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage:
+  ensure-release-migration.sh --mode <generate|verify> --version <semver|vsemver> [--base-ref <ref>] [--repo <path>]
+
+generate  Creates core/docs/hq/MIGRATION.md section for the release when absent.
+verify    Fails when a non-trivial release diff has no consumable migration section.
+USAGE
+}
+
+MODE=""
+VERSION=""
+BASE_REF="HEAD^"
+REPO="."
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --mode)
+      MODE="${2:-}"; shift 2 ;;
+    --version)
+      VERSION="${2:-}"; shift 2 ;;
+    --base-ref)
+      BASE_REF="${2:-}"; shift 2 ;;
+    --repo)
+      REPO="${2:-}"; shift 2 ;;
+    -h|--help)
+      usage; exit 0 ;;
+    *)
+      echo "ERROR: unknown argument: $1" >&2
+      usage
+      exit 2 ;;
+  esac
+done
+
+[ "$MODE" = "generate" ] || [ "$MODE" = "verify" ] || {
+  echo "ERROR: --mode must be generate or verify" >&2
+  exit 2
+}
+[ -n "$VERSION" ] || {
+  echo "ERROR: --version is required" >&2
+  exit 2
+}
+
+VERSION="${VERSION#v}"
+TAG="v${VERSION}"
+
+if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.]+)?$'; then
+  echo "ERROR: invalid release version: ${VERSION}" >&2
+  exit 2
+fi
+
+cd "$REPO"
+
+if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+  echo "ERROR: base ref not found: ${BASE_REF}" >&2
+  exit 2
+fi
+
+MIGRATION_PATH="core/docs/hq/MIGRATION.md"
+
+is_release_bookkeeping_path() {
+  case "$1" in
+    core/core.yaml|MIGRATION.md|core/docs/hq/MIGRATION.md|core/docs/hq/CHANGELOG.md)
+      return 0 ;;
+    RELEASE-NOTES-*.md|core/docs/hq/RELEASE-NOTES-*.md)
+      return 0 ;;
+    *)
+      return 1 ;;
+  esac
+}
+
+is_migration_doc_path() {
+  case "$1" in
+    MIGRATION.md|core/docs/hq/MIGRATION.md)
+      return 0 ;;
+    *)
+      return 1 ;;
+  esac
+}
+
+NEW_FILES=()
+UPDATED_FILES=()
+REMOVED_FILES=()
+SIGNIFICANT_COUNT=0
+
+add_path() {
+  # $1 = bucket name, $2 = path
+  [ -n "$2" ] || return 0
+  case "$1" in
+    new) NEW_FILES+=("$2") ;;
+    updated) UPDATED_FILES+=("$2") ;;
+    removed) REMOVED_FILES+=("$2") ;;
+  esac
+}
+
+collect_diff() {
+  local status path_a path_b code path
+  while IFS=$'\t' read -r status path_a path_b; do
+    [ -n "${status:-}" ] || continue
+    code="${status:0:1}"
+    case "$code" in
+      A)
+        path="$path_a"
+        is_release_bookkeeping_path "$path" || SIGNIFICANT_COUNT=$((SIGNIFICANT_COUNT + 1))
+        add_path new "$path"
+        ;;
+      D)
+        path="$path_a"
+        is_release_bookkeeping_path "$path" || SIGNIFICANT_COUNT=$((SIGNIFICANT_COUNT + 1))
+        is_migration_doc_path "$path" || add_path removed "$path"
+        ;;
+      M|T)
+        path="$path_a"
+        is_release_bookkeeping_path "$path" || SIGNIFICANT_COUNT=$((SIGNIFICANT_COUNT + 1))
+        add_path updated "$path"
+        ;;
+      R|C)
+        is_release_bookkeeping_path "$path_a" || SIGNIFICANT_COUNT=$((SIGNIFICANT_COUNT + 1))
+        is_release_bookkeeping_path "$path_b" || SIGNIFICANT_COUNT=$((SIGNIFICANT_COUNT + 1))
+        is_migration_doc_path "$path_a" || add_path removed "$path_a"
+        add_path new "$path_b"
+        ;;
+      *)
+        path="$path_a"
+        is_release_bookkeeping_path "$path" || SIGNIFICANT_COUNT=$((SIGNIFICANT_COUNT + 1))
+        add_path updated "$path"
+        ;;
+    esac
+  done < <(git diff --name-status "$BASE_REF" --)
+
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    is_release_bookkeeping_path "$path" || SIGNIFICANT_COUNT=$((SIGNIFICANT_COUNT + 1))
+    add_path new "$path"
+  done < <(git ls-files --others --exclude-standard)
+}
+
+section_has() {
+  # $1 = awk condition evaluated inside the matching release section.
+  local condition="$1"
+  [ -f "$MIGRATION_PATH" ] || return 1
+  awk -v tag="$TAG" -v condition="$condition" '
+    /^## / {
+      in_section = ($0 ~ "^## (Release:|Migrating to) " tag "($|[[:space:]-])")
+      next
+    }
+    in_section {
+      if (condition == "migration_steps" && $0 ~ /^### Migration Steps/) found = 1
+      if (condition == "file_path" && $0 ~ /^- `[^`]+`/) found = 1
+    }
+    END { exit found ? 0 : 1 }
+  ' "$MIGRATION_PATH"
+}
+
+section_exists() {
+  [ -f "$MIGRATION_PATH" ] || return 1
+  grep -Eq "^## (Release:|Migrating to) ${TAG}($|[[:space:]-])" "$MIGRATION_PATH"
+}
+
+verify_section() {
+  if [ "$SIGNIFICANT_COUNT" -eq 0 ]; then
+    echo "ensure-release-migration: no non-bookkeeping release diff; migration doc not required"
+    return 0
+  fi
+  if [ ! -f "$MIGRATION_PATH" ]; then
+    echo "::error file=${MIGRATION_PATH}::${TAG} changes ${SIGNIFICANT_COUNT} non-bookkeeping path(s), but ${MIGRATION_PATH} is missing" >&2
+    return 1
+  fi
+  if ! section_exists; then
+    echo "::error file=${MIGRATION_PATH}::missing ${TAG} migration section" >&2
+    return 1
+  fi
+  if ! section_has migration_steps; then
+    echo "::error file=${MIGRATION_PATH}::${TAG} migration section must include ### Migration Steps" >&2
+    return 1
+  fi
+  if ! section_has file_path; then
+    echo "::error file=${MIGRATION_PATH}::${TAG} migration section must include backtick-wrapped file paths for /update-hq" >&2
+    return 1
+  fi
+  echo "ensure-release-migration: ${TAG} migration section present"
+}
+
+print_path_section() {
+  # $1 = heading, remaining args = paths
+  local heading="$1"; shift
+  printf '### %s\n\n' "$heading"
+  if [ "$#" -eq 0 ]; then
+    printf -- '- None.\n\n'
+    return 0
+  fi
+  local p
+  for p in "$@"; do
+    printf -- '- `%s`\n' "$p"
+  done
+  printf '\n'
+}
+
+print_array_section() {
+  # $1 = heading, $2 = array variable name
+  local heading="$1"
+  local array_name="$2"
+  eval "local count=\${#${array_name}[@]}"
+  if [ "$count" -eq 0 ]; then
+    print_path_section "$heading"
+    return 0
+  fi
+  eval "print_path_section \"\$heading\" \"\${${array_name}[@]}\""
+}
+
+generate_section() {
+  mkdir -p "$(dirname "$MIGRATION_PATH")"
+  local tmp body existing
+  tmp="$(mktemp)"
+  body="$(mktemp)"
+  existing="$(mktemp)"
+  trap 'rm -f "${tmp:-}" "${body:-}" "${existing:-}"' EXIT
+
+  {
+    printf '## Migrating to %s -- generated migration summary\n\n' "$TAG"
+    printf 'Generated from the release diff against `%s` so `/update-hq` has concrete migration data at the target tag.\n\n' "$BASE_REF"
+    print_array_section "New Files" NEW_FILES
+    print_array_section "Updated Files" UPDATED_FILES
+    print_array_section "Removed" REMOVED_FILES
+    printf '### Breaking Changes\n\n'
+    printf -- '- None declared automatically. Review hook, settings, and updater changes before merging if this release changes session startup or upgrade behavior.\n\n'
+    printf '### Migration Steps\n\n'
+    printf '1. Run `/update-hq` to apply this release.\n'
+    printf '2. Restart Claude Code or Codex after the update if this release changes `.claude/hooks/`, `.claude/settings.json`, `.codex/`, `.agents/`, or `core/scripts/`.\n'
+    printf '3. Review any local drift that `/update-hq` reports before continuing normal work.\n\n'
+  } > "$body"
+
+  if [ -f "$MIGRATION_PATH" ]; then
+    awk 'NR == 1 && /^## Release: TBD/ { next } { print }' "$MIGRATION_PATH" > "$existing"
+  else
+    : > "$existing"
+  fi
+
+  {
+    cat "$body"
+    if [ -s "$existing" ]; then
+      cat "$existing"
+    fi
+  } > "$tmp"
+  mv "$tmp" "$MIGRATION_PATH"
+  echo "ensure-release-migration: generated ${TAG} section in ${MIGRATION_PATH}"
+}
+
+collect_diff
+
+if [ "$MODE" = "verify" ]; then
+  verify_section
+  exit $?
+fi
+
+if [ "$SIGNIFICANT_COUNT" -eq 0 ]; then
+  echo "ensure-release-migration: no non-bookkeeping release diff; nothing to generate"
+  exit 0
+fi
+
+if section_exists; then
+  verify_section
+  exit $?
+fi
+
+generate_section
+verify_section

--- a/core/scripts/tests/ensure-release-migration.test.sh
+++ b/core/scripts/tests/ensure-release-migration.test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# hq-core: public
+# Regression coverage for release commits that ship no MIGRATION.md.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SRC="${ROOT}/core/scripts/ensure-release-migration.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$SRC" ] || fail "ensure-release-migration.sh not found at $SRC"
+
+make_repo() {
+  local repo="$1"
+  mkdir -p "$repo"
+  (
+    cd "$repo"
+    git init -q
+    git config user.name "Test User"
+    git config user.email "test@example.com"
+    mkdir -p core/scripts core/docs/hq .claude
+    printf 'hqVersion: "15.0.8"\n' > core/core.yaml
+    printf 'old hook\n' > core/scripts/old-hook.sh
+    printf '## Release: v15.0.8\n' > core/docs/hq/MIGRATION.md
+    printf '{"version":1}\n' > .claude/settings.json
+    git add core/core.yaml core/scripts/old-hook.sh core/docs/hq/MIGRATION.md .claude/settings.json
+    git commit -qm "base"
+  )
+}
+
+REPO="${TMP}/repo"
+make_repo "$REPO"
+OUT="${TMP}/verify.out"
+
+(
+  cd "$REPO"
+  rm core/docs/hq/MIGRATION.md
+  rm core/scripts/old-hook.sh
+  printf 'new hook\n' > core/scripts/new-hook.sh
+  printf '{"version":2}\n' > .claude/settings.json
+)
+
+if (cd "$REPO" && bash "$SRC" --mode verify --version 15.0.9 --base-ref HEAD >"$OUT" 2>&1); then
+  fail "verify passed despite a non-trivial diff with no MIGRATION.md"
+fi
+grep -q 'MIGRATION.md is missing' "$OUT" \
+  || fail "missing MIGRATION.md failure did not explain the regression"
+
+(cd "$REPO" && bash "$SRC" --mode generate --version 15.0.9 --base-ref HEAD >/dev/null)
+
+MIG="${REPO}/core/docs/hq/MIGRATION.md"
+grep -q '^## Migrating to v15.0.9' "$MIG" || fail "generated migration section missing release header"
+grep -q '^### New Files' "$MIG" || fail "generated migration missing New Files section"
+grep -q -- '- `core/scripts/new-hook.sh`' "$MIG" || fail "generated migration missing added file path"
+grep -q -- '- `.claude/settings.json`' "$MIG" || fail "generated migration missing updated file path"
+grep -q -- '- `core/scripts/old-hook.sh`' "$MIG" || fail "generated migration missing removed file path"
+! grep -q -- '- `core/docs/hq/MIGRATION.md`' "$MIG" \
+  || fail "generated migration must not instruct removal of its own migration doc"
+grep -q '^### Migration Steps' "$MIG" || fail "generated migration missing Migration Steps"
+
+(cd "$REPO" && bash "$SRC" --mode verify --version 15.0.9 --base-ref HEAD >/dev/null) \
+  || fail "verify failed after generated migration"
+
+BOOKKEEPING="${TMP}/bookkeeping-only"
+make_repo "$BOOKKEEPING"
+(
+  cd "$BOOKKEEPING"
+  printf 'hqVersion: "15.0.9"\n' > core/core.yaml
+  bash "$SRC" --mode verify --version 15.0.9 --base-ref HEAD >/dev/null
+) || fail "bookkeeping-only version bump should not require migration doc"
+
+echo "PASS: ensure-release-migration.sh"


### PR DESCRIPTION
## Summary
- Restores core/docs/hq/MIGRATION.md with generated sections for v15.0.9 and v15.0.10 so /update-hq has migration data at the target tag.
- Adds a release migration guard/generator in core/scripts/ensure-release-migration.sh.
- Wires promote-to-hq-core.yml to generate migration sections before the release PR commit is tagged.
- Wires auto-tag-release.yml and release.yml to fail non-trivial releases missing consumable migration data.
- Unfreezes core/docs/hq/CHANGELOG.md for the 15.0.x patch line.

Feedback: feedback_ea628143-25ee-46bd-9b0c-08ba92532d0c
Linear: DEV-1734

## Test plan
- bash core/scripts/tests/ensure-release-migration.test.sh
- bash core/scripts/ensure-release-migration.sh --mode verify --version 15.0.10 --base-ref HEAD
- bash core/scripts/ensure-release-migration.sh --mode verify --version 15.0.9 --base-ref v15.0.8
- bash -n on all repo shell scripts
- all core/scripts/tests/*.test.sh
- local .leak-scan/scan.sh gates with version-bump and special-case-confirmed labels