### PR TITLE
test: gate hooks against bash-3.2 nested-heredoc syntax trap (feedback_1513f1f5)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -176,6 +176,8 @@ jobs:
         run: bash core/scripts/tests/auto-acl-suggest.test.sh
       - name: Stop reminder smoke test
         run: bash core/scripts/tests/auto-acl-share-reminder.test.sh
+      - name: Hooks parse + no bash-3.2 nested-heredoc (DEV-1513f1f5)
+        run: bash core/scripts/tests/hooks-heredoc-syntax.test.sh
 
   # ─── Label-gated checks ────────────────────────────────────────────
   # These read PR labels to allow intentional overrides.

--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,6 +1,6 @@
 version: 1
-hqVersion: "15.0.20"
-updatedAt: "2026-06-19T19:27:19Z"
+hqVersion: "15.0.21"
+updatedAt: "2026-06-19T21:00:00Z"
 # hq-core is the minimal scaffold seed. Rich add-ons ship as `@indigoai-us/hq-pack-*`
 # npm packages installed into `core/packages/` via `hq install`. See `core/packages/README.md`.
 rules:

--- a/core/scripts/lint-hook-heredoc-nesting.py
+++ b/core/scripts/lint-hook-heredoc-nesting.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Lint shell scripts for heredocs nested inside command/process substitution.
+
+macOS ships bash 3.2, whose parser mishandles a heredoc opened inside a
+`$( ... )` command substitution, a `<( ... )` / `>( ... )` process
+substitution, or a `` `...` `` backtick substitution. The body is read past
+the substitution and the parser reports a phantom "unexpected EOF while
+looking for matching quote" / unterminated-quote error. For a PreToolUse /
+PostToolUse hook that means EVERY tool call fails with a hook error.
+
+The fix is always the same: slurp the heredoc into a variable at the top
+level (a standalone heredoc, no enclosing substitution) and feed it to the
+inner command via an argument, e.g. `python3 -c "$var"`.
+
+This lint flags the dangerous shape directly, so it is caught on any bash
+version — including CI runners on bash 5, which do NOT reproduce the 3.2
+parse error. `bash -n` alone is therefore not enough.
+
+Usage:
+    lint-hook-heredoc-nesting.py FILE [FILE ...]
+
+Exit status 0 = clean, 1 = at least one violation (printed to stderr).
+"""
+
+import sys
+
+
+def find_violations(path):
+    """Return a list of (line_no, delimiter) heredocs opened while inside a
+    command/process/backtick substitution."""
+    with open(path, "r", encoding="utf-8") as handle:
+        lines = handle.readlines()
+
+    violations = []
+    # Context stack of frame types. Command contexts (where a heredoc operator
+    # is meaningful) are: 'top', 'cmdsub', 'procsub', 'backtick'. Non-command
+    # frames: 'squote', 'dquote', 'arith'.
+    stack = ["top"]
+    # Heredoc delimiters whose bodies are still being consumed, in FIFO order
+    # (bash fills the first-opened heredoc first). Each entry: (word, strip_tabs).
+    active = []
+
+    def in_substitution():
+        # A heredoc is dangerous if any enclosing command frame is a
+        # substitution (cmdsub/procsub/backtick). Plain quote/arith frames do
+        # not by themselves make it dangerous, but a cmdsub *inside* a dquote
+        # is still on the stack and counts.
+        return any(frame in ("cmdsub", "procsub", "backtick") for frame in stack)
+
+    for idx, raw in enumerate(lines):
+        line = raw.rstrip("\n")
+        line_no = idx + 1
+
+        # If we are consuming heredoc bodies, this whole physical line is data
+        # until it matches the delimiter of the oldest open heredoc.
+        if active:
+            word, strip_tabs = active[0]
+            cmp = line.lstrip("\t") if strip_tabs else line
+            if cmp == word:
+                active.pop(0)
+            continue
+
+        j = 0
+        length = len(line)
+        while j < length:
+            top = stack[-1]
+            c = line[j]
+
+            if top == "squote":
+                if c == "'":
+                    stack.pop()
+                j += 1
+                continue
+
+            if top == "dquote":
+                if c == "\\":
+                    j += 2
+                    continue
+                if c == '"':
+                    stack.pop()
+                    j += 1
+                    continue
+                if c == "`":
+                    stack.append("backtick")
+                    j += 1
+                    continue
+                if c == "$" and j + 1 < length and line[j + 1] == "(":
+                    if j + 2 < length and line[j + 2] == "(":
+                        stack.append("arith")
+                        j += 3
+                        continue
+                    stack.append("cmdsub")
+                    j += 2
+                    continue
+                j += 1
+                continue
+
+            if top == "arith":
+                # Arithmetic context ends at the matching '))'. Track nested
+                # parens loosely; no heredoc/quote parsing needed inside.
+                if c == ")" and j + 1 < length and line[j + 1] == ")":
+                    stack.pop()
+                    j += 2
+                    continue
+                j += 1
+                continue
+
+            # Command context: top, cmdsub, procsub, backtick.
+            if c == "\\":
+                j += 2
+                continue
+            if c == "#" and (j == 0 or line[j - 1] in " \t"):
+                break  # comment to end of line
+            if c == "'":
+                stack.append("squote")
+                j += 1
+                continue
+            if c == '"':
+                stack.append("dquote")
+                j += 1
+                continue
+            if c == "`":
+                if top == "backtick":
+                    stack.pop()
+                else:
+                    stack.append("backtick")
+                j += 1
+                continue
+            if c == "$" and j + 1 < length and line[j + 1] == "(":
+                if j + 2 < length and line[j + 2] == "(":
+                    stack.append("arith")
+                    j += 3
+                    continue
+                stack.append("cmdsub")
+                j += 2
+                continue
+            if c in "<>" and j + 1 < length and line[j + 1] == "(":
+                stack.append("procsub")
+                j += 2
+                continue
+            if c == "<" and j + 1 < length and line[j + 1] == "<":
+                if j + 2 < length and line[j + 2] == "<":
+                    j += 3  # here-string <<<, not a heredoc
+                    continue
+                k = j + 2
+                strip_tabs = False
+                if k < length and line[k] == "-":
+                    strip_tabs = True
+                    k += 1
+                while k < length and line[k] in " \t":
+                    k += 1
+                word = ""
+                if k < length and line[k] in ("'", '"'):
+                    quote = line[k]
+                    k += 1
+                    while k < length and line[k] != quote:
+                        word += line[k]
+                        k += 1
+                    k += 1
+                else:
+                    while k < length and (line[k].isalnum() or line[k] in "_-.+"):
+                        word += line[k]
+                        k += 1
+                if word:
+                    if in_substitution():
+                        violations.append((line_no, word))
+                    active.append((word, strip_tabs))
+                j = k
+                continue
+            if c == "(":
+                # plain subshell / grouping; only matters for paren balance
+                stack.append("subshell")
+                j += 1
+                continue
+            if c == ")":
+                if top in ("cmdsub", "procsub", "subshell"):
+                    stack.pop()
+                j += 1
+                continue
+            j += 1
+
+    return violations
+
+
+def main(argv):
+    paths = argv[1:]
+    if not paths:
+        sys.stderr.write("usage: lint-hook-heredoc-nesting.py FILE [FILE ...]\n")
+        return 2
+    bad = 0
+    for path in paths:
+        for line_no, word in find_violations(path):
+            bad += 1
+            sys.stderr.write(
+                "%s:%d: heredoc <<%s opened inside a command/process "
+                "substitution; bash 3.2 mis-parses this as an unterminated "
+                "quote. Slurp it into a top-level variable and run via "
+                'an argument (e.g. python3 -c "$var").\n' % (path, line_no, word)
+            )
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/core/scripts/tests/hooks-heredoc-syntax.test.sh
+++ b/core/scripts/tests/hooks-heredoc-syntax.test.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# Regression gate for DEV feedback_1513f1f5.
+#
+# hq-auto-acl-suggest.sh embeds two Python programs. An earlier form fed them
+# into the shell via a heredoc nested inside a `$( … )` command substitution.
+# macOS system bash (3.2) mis-parses a heredoc opened inside `$( … )` /
+# `<( … )` / backticks as an unterminated quote, so the PostToolUse hook died
+# with a syntax error on EVERY Bash/Write/Edit tool call. The fix slurps each
+# program into a top-level variable (standalone heredoc) and runs it via
+# `python3 -c "$var"`, which never nests a heredoc inside a substitution.
+#
+# This gate makes the bug non-recurring on any bash version:
+#   1. `bash -n` over every shipped hook (catches genuine unterminated quotes
+#      and other syntax errors).
+#   2. A structural lint (lint-hook-heredoc-nesting.py) that flags the
+#      bash-3.2 nested-heredoc trap directly — bash-version-independent, since
+#      CI runs bash 5 and does NOT reproduce the 3.2 phantom error.
+#      hq-auto-acl-suggest.sh MUST have zero nesting, and no NEW hook may
+#      introduce the pattern beyond a documented legacy baseline.
+#   3. A runtime smoke of hq-auto-acl-suggest.sh on a sample PostToolUse Bash
+#      payload (clean exit, no stderr parser noise).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+HOOKS_DIR="$ROOT/.claude/hooks"
+LINT="$ROOT/core/scripts/lint-hook-heredoc-nesting.py"
+TARGET_HOOK="$HOOKS_DIR/hq-auto-acl-suggest.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+# Known pre-existing hooks that still nest a heredoc inside a substitution.
+# These predate this gate and are tracked for a separate fix-forward; the gate
+# allows them but forbids any NEW file from joining the list. DO NOT add
+# entries here to silence a freshly-introduced violation — fix the hook.
+BASELINE="auto-mirror-company-skill.sh
+auto-session-project.sh
+observe-patterns.sh
+route-company-skill-creation.sh"
+
+is_baseline() {
+  local name="$1" b
+  while IFS= read -r b; do
+    [ -n "$b" ] || continue
+    [ "$name" = "$b" ] && return 0
+  done <<EOF
+$BASELINE
+EOF
+  return 1
+}
+
+# ── 1. bash -n over every hook ──────────────────────────────────────────────
+parsed=0
+for hook in "$HOOKS_DIR"/*.sh; do
+  [ -f "$hook" ] || continue
+  if ! err="$(bash -n "$hook" 2>&1)"; then
+    fail "bash -n syntax error in $hook:
+$err"
+  fi
+  parsed=$((parsed + 1))
+done
+[ "$parsed" -gt 0 ] || fail "no hook scripts found under $HOOKS_DIR"
+echo "PASS: bash -n clean across $parsed hook scripts"
+
+# ── 2. structural nested-heredoc lint ───────────────────────────────────────
+[ -f "$LINT" ] || fail "missing lint: $LINT"
+
+# 2a. The lint must actually catch the bug it guards against (self-test on a
+#     synthetic dquote-wrapped `var="$( … <<PY … )"`, the form that broke the
+#     acl hook). A no-op gate is worse than none.
+FIXTURE_DIR="$(mktemp -d)"
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+BAD="$FIXTURE_DIR/bad.sh"
+{
+  printf '%s\n' '#!/usr/bin/env bash'
+  printf '%s\n' 'out="$('
+  printf '%s\n' "python3 - <<'PY'"
+  printf '%s\n' 'print("hi")'
+  printf '%s\n' 'PY'
+  printf '%s\n' ')"'
+  printf '%s\n' 'echo "$out"'
+} > "$BAD"
+if python3 "$LINT" "$BAD" 2>/dev/null; then
+  fail "lint self-test: did NOT catch a heredoc nested in a \"\$( … )\" substitution"
+fi
+echo "PASS: lint self-test catches the nested-heredoc trap"
+
+# 2b. The acl hook (the file this feedback is about) must have ZERO nesting.
+if ! python3 "$LINT" "$TARGET_HOOK" >/dev/null 2>&1; then
+  python3 "$LINT" "$TARGET_HOOK" || true
+  fail "hq-auto-acl-suggest.sh nests a heredoc inside a substitution — the bash-3.2 bug has regressed"
+fi
+echo "PASS: hq-auto-acl-suggest.sh has no nested heredoc"
+
+# 2c. No NEW hook may introduce the pattern. Every violating file must be in the
+#     documented legacy baseline.
+new_violations=""
+for hook in "$HOOKS_DIR"/*.sh; do
+  [ -f "$hook" ] || continue
+  name="$(basename "$hook")"
+  if ! python3 "$LINT" "$hook" >/dev/null 2>&1; then
+    if ! is_baseline "$name"; then
+      new_violations="$new_violations $name"
+    fi
+  fi
+done
+if [ -n "$new_violations" ]; then
+  fail "new hook(s) nest a heredoc inside a substitution (bash-3.2 trap):$new_violations
+Slurp the heredoc into a top-level variable and run via an argument, e.g.
+  prog=\"\"; IFS= read -r -d '' prog <<'PY' || true ... PY ; python3 -c \"\$prog\""
+fi
+echo "PASS: no new hook introduces the nested-heredoc pattern"
+
+# ── 3. runtime smoke of the acl hook ────────────────────────────────────────
+sample='{"hook_event_name":"PostToolUse","session_id":"gate-smoke","cwd":"'"$ROOT"'","tool_name":"Bash","tool_input":{"command":"echo hello"},"tool_response":{"stdout":"hello"}}'
+smoke_err="$(printf '%s' "$sample" | bash "$TARGET_HOOK" 2>&1 >/dev/null)" || \
+  fail "hq-auto-acl-suggest.sh exited non-zero on a sample PostToolUse payload"
+if printf '%s' "$smoke_err" | grep -qiE 'syntax error|unexpected EOF|unterminated|matching quote'; then
+  fail "hq-auto-acl-suggest.sh emitted a parser error at runtime:
+$smoke_err"
+fi
+echo "PASS: hq-auto-acl-suggest.sh runs clean on a sample PostToolUse payload"
+
+echo "ALL CHECKS PASSED"


### PR DESCRIPTION
## feedback_1513f1f5 — hq-auto-acl-suggest.sh unterminated-quote hook error

### Root cause
`hq-auto-acl-suggest.sh` embeds two Python programs. An earlier form of the
hook fed them to the shell via a heredoc opened **inside** a `$( … )` command
substitution. macOS system bash (3.2) mis-parses a heredoc opened inside
`$( … )` / `<( … )` / backticks as an *unterminated quote* ("unexpected EOF /
matching quote"). Because the hook is registered on `PostToolUse` for
Bash/Write/Edit/MultiEdit, that parse error fired on **every** tool call for
macOS users — the reported "blocks every Bash hook" symptom.

### Status of the code fix
The fix already shipped in **v15.0.20**: each Python program is slurped into a
top-level variable via a standalone heredoc and run with `python3 -c "$var"`,
so no heredoc is ever nested in a substitution. The current released file
parses with `bash -n` and runs cleanly. **No further code change to the hook
was needed.**

### What was missing — and what this PR adds
There was no regression coverage, so the trap could silently return. CI runs on
ubuntu bash 5, which does **not** reproduce the bash-3.2 phantom error, so a
plain `bash -n` gate is insufficient. This PR adds a bash-version-independent
gate:

- **`core/scripts/lint-hook-heredoc-nesting.py`** — a structural lint that flags
  a heredoc opened inside a command/process/backtick substitution directly
  (handles the tricky double-quote-wrapped `var="$( … <<PY … )"` form).
- **`core/scripts/tests/hooks-heredoc-syntax.test.sh`** — `bash -n` over every
  hook; a lint self-test proving it catches the trap; an assertion that
  `hq-auto-acl-suggest.sh` has zero nesting (locks the fix); a no-new-violations
  guard across all hooks against a documented legacy baseline; and a runtime
  smoke of the acl hook on a sample `PostToolUse` payload.
- **`.github/workflows/pr-checks.yml`** — runs the gate in `auto-acl-share-hooks`.

### Heads-up: 4 sibling hooks share the same shape (tracked separately)
The new lint surfaced four other hooks that still nest a heredoc inside a
substitution and so carry the same latent bash-3.2 risk:
`auto-mirror-company-skill.sh`, `auto-session-project.sh`, `observe-patterns.sh`,
`route-company-skill-creation.sh`. They are out of scope for this feedback item
and may be under concurrent edit, so they are recorded as a documented baseline
here (the gate blocks any *new* offender) and reported for separate triage —
not silently changed in this PR.

### Verification
- `bash -n` clean across all 51 hooks.
- Gate passes; lint self-test catches a synthetic nested heredoc and a simulated
  regression of the acl hook.
- Existing `auto-acl-suggest.test.sh` still passes.

-created by dev-executor:dev-3
