### PR TITLE
fix: remove bash-3.2 nested-heredoc trap from four sibling hooks (four-hook-heredoc-fixforward)

### DIFF
--- a/.claude/hooks/auto-mirror-company-skill.sh
+++ b/.claude/hooks/auto-mirror-company-skill.sh
@@ -60,8 +60,12 @@ else
   exit 0
 fi
 
-PREFIX=$(
-  cd "$PROJECT_DIR" && python3 - "$CO" <<'PY' 2>/dev/null || true
+# NOTE: slurp the program into a variable via a standalone heredoc, then run it
+# with `python3 -c`. A heredoc nested inside a `$( … )` substitution is
+# mis-parsed as an unterminated quote by macOS system bash 3.2
+# (policy indigo-hook-no-heredoc-in-command-substitution).
+prefix_py=""
+IFS= read -r -d '' prefix_py <<'PY' || true
 import sys, yaml
 co = sys.argv[1]
 try:
@@ -72,7 +76,7 @@ try:
 except Exception:
     pass
 PY
-)
+PREFIX=$(cd "$PROJECT_DIR" && python3 -c "$prefix_py" "$CO" 2>/dev/null || true)
 
 if [[ -z "$PREFIX" ]]; then
   echo "auto-mirror: no prefix in manifest for company '$CO' — skipping mirror for $REL" >&2

--- a/.claude/hooks/auto-session-project.sh
+++ b/.claude/hooks/auto-session-project.sh
@@ -40,7 +40,12 @@ PROMPT="$(extract prompt)"
 SESSION_ID="$(extract session_id)"
 [ -z "$SESSION_ID" ] && SESSION_ID="default"
 
-classification_json="$(AUTO_SESSION_PROJECT_PROMPT="$PROMPT" python3 - "$HQ_ROOT" <<'PY'
+# NOTE: slurp the classifier into a variable via a standalone heredoc, then run
+# it with `python3 -c`. A heredoc nested inside a `$( … )` substitution is
+# mis-parsed as an unterminated quote by macOS system bash 3.2
+# (policy indigo-hook-no-heredoc-in-command-substitution).
+classify_py=""
+IFS= read -r -d '' classify_py <<'PY' || true
 import json
 import os
 import pathlib
@@ -109,7 +114,8 @@ if len(title) > 90:
 
 print(json.dumps({"skip": skip, "scope": scope, "company": company, "title": title}))
 PY
-)"
+
+classification_json="$(AUTO_SESSION_PROJECT_PROMPT="$PROMPT" python3 -c "$classify_py" "$HQ_ROOT")"
 
 skip="$(printf '%s' "$classification_json" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("skip", True))' 2>/dev/null || echo True)"
 [ "$skip" = "True" ] && exit 0

--- a/.claude/hooks/observe-patterns.sh
+++ b/.claude/hooks/observe-patterns.sh
@@ -37,7 +37,7 @@ GIT_LOG=$(git log --oneline -50 2>/dev/null || echo "")
 
 # Pattern 1: back-pressure-retry detection (fixup commits indicate retry loop)
 if echo "$GIT_LOG" | grep -qiE '(fixup|amend|rebase|retry|fix.*previous)'; then
-  observations+=("$(cat <<'PATTERN1'
+  IFS= read -r -d '' pattern1 <<'PATTERN1' || true
 {
   "pattern_type": "back-pressure-retry",
   "confidence": 0.8,
@@ -47,13 +47,12 @@ if echo "$GIT_LOG" | grep -qiE '(fixup|amend|rebase|retry|fix.*previous)'; then
   "recommendation": "Extract pattern about what caused retry and how to prevent it next time"
 }
 PATTERN1
-)"
-  )
+  observations+=("$pattern1")
 fi
 
 # Pattern 2: repeated tool failure detection (check for error/fail keywords)
 if echo "$GIT_LOG" | grep -qiE '(fix.*error|resolve.*bug|handle.*fail)'; then
-  observations+=("$(cat <<'PATTERN2'
+  IFS= read -r -d '' pattern2 <<'PATTERN2' || true
 {
   "pattern_type": "repeated-tool-failure",
   "confidence": 0.6,
@@ -63,13 +62,12 @@ if echo "$GIT_LOG" | grep -qiE '(fix.*error|resolve.*bug|handle.*fail)'; then
   "recommendation": "Identify what tool/process failed repeatedly and capture prevention pattern"
 }
 PATTERN2
-)"
-  )
+  observations+=("$pattern2")
 fi
 
 # Pattern 3: workflow improvement detection (new hooks, commands, scripts created)
 if echo "$GIT_LOG" | grep -qiE '(hook|command|script|workflow|automation)'; then
-  observations+=("$(cat <<'PATTERN3'
+  IFS= read -r -d '' pattern3 <<'PATTERN3' || true
 {
   "pattern_type": "workflow-improvement",
   "confidence": 0.6,
@@ -79,13 +77,12 @@ if echo "$GIT_LOG" | grep -qiE '(hook|command|script|workflow|automation)'; then
   "recommendation": "Document the workflow improvement pattern for reuse"
 }
 PATTERN3
-)"
-  )
+  observations+=("$pattern3")
 fi
 
 # Pattern 4: novel pattern detection (check for new file types or integrations)
 if echo "$GIT_LOG" | grep -qiE '(add|new|integrate|extend|support)'; then
-  observations+=("$(cat <<'PATTERN4'
+  IFS= read -r -d '' pattern4 <<'PATTERN4' || true
 {
   "pattern_type": "novel-pattern",
   "confidence": 0.4,
@@ -95,8 +92,7 @@ if echo "$GIT_LOG" | grep -qiE '(add|new|integrate|extend|support)'; then
   "recommendation": "Low confidence: worth noting but verify pattern utility before capture"
 }
 PATTERN4
-)"
-  )
+  observations+=("$pattern4")
 fi
 
 # Only generate output if observations were found

--- a/.claude/hooks/route-company-skill-creation.sh
+++ b/.claude/hooks/route-company-skill-creation.sh
@@ -58,8 +58,12 @@ fi
 # Resolve prefix → company via manifest. If unknown prefix, this isn't a
 # bridged path — let it through (some non-company skills like `hq-deploy` happen
 # to look like prefix-name but don't match any manifest entry).
-CO=$(
-  cd "$PROJECT_DIR" && python3 - "$PREFIX" <<'PY' 2>/dev/null || true
+# NOTE: slurp the program into a variable via a standalone heredoc, then run it
+# with `python3 -c`. A heredoc nested inside a `$( … )` substitution is
+# mis-parsed as an unterminated quote by macOS system bash 3.2
+# (policy indigo-hook-no-heredoc-in-command-substitution).
+co_py=""
+IFS= read -r -d '' co_py <<'PY' || true
 import sys, yaml
 prefix = sys.argv[1]
 try:
@@ -71,7 +75,7 @@ try:
 except Exception:
     pass
 PY
-)
+CO=$(cd "$PROJECT_DIR" && python3 -c "$co_py" "$PREFIX" 2>/dev/null || true)
 
 if [[ -z "$CO" ]]; then
   exit 0

--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,6 +1,6 @@
 version: 1
-hqVersion: "15.0.21"
-updatedAt: "2026-06-19T21:00:00Z"
+hqVersion: "15.0.22"
+updatedAt: "2026-06-19T21:30:00Z"
 # hq-core is the minimal scaffold seed. Rich add-ons ship as `@indigoai-us/hq-pack-*`
 # npm packages installed into `core/packages/` via `hq install`. See `core/packages/README.md`.
 rules:

--- a/core/scripts/tests/hooks-heredoc-syntax.test.sh
+++ b/core/scripts/tests/hooks-heredoc-syntax.test.sh
@@ -16,8 +16,8 @@
 #   2. A structural lint (lint-hook-heredoc-nesting.py) that flags the
 #      bash-3.2 nested-heredoc trap directly — bash-version-independent, since
 #      CI runs bash 5 and does NOT reproduce the 3.2 phantom error.
-#      hq-auto-acl-suggest.sh MUST have zero nesting, and no NEW hook may
-#      introduce the pattern beyond a documented legacy baseline.
+#      hq-auto-acl-suggest.sh MUST have zero nesting, and NO hook anywhere
+#      under .claude/hooks/ may introduce the pattern (zero violations).
 #   3. A runtime smoke of hq-auto-acl-suggest.sh on a sample PostToolUse Bash
 #      payload (clean exit, no stderr parser noise).
 
@@ -31,26 +31,6 @@ TARGET_HOOK="$HOOKS_DIR/hq-auto-acl-suggest.sh"
 fail() {
   echo "FAIL: $*" >&2
   exit 1
-}
-
-# Known pre-existing hooks that still nest a heredoc inside a substitution.
-# These predate this gate and are tracked for a separate fix-forward; the gate
-# allows them but forbids any NEW file from joining the list. DO NOT add
-# entries here to silence a freshly-introduced violation — fix the hook.
-BASELINE="auto-mirror-company-skill.sh
-auto-session-project.sh
-observe-patterns.sh
-route-company-skill-creation.sh"
-
-is_baseline() {
-  local name="$1" b
-  while IFS= read -r b; do
-    [ -n "$b" ] || continue
-    [ "$name" = "$b" ] && return 0
-  done <<EOF
-$BASELINE
-EOF
-  return 1
 }
 
 # ── 1. bash -n over every hook ──────────────────────────────────────────────
@@ -96,24 +76,21 @@ if ! python3 "$LINT" "$TARGET_HOOK" >/dev/null 2>&1; then
 fi
 echo "PASS: hq-auto-acl-suggest.sh has no nested heredoc"
 
-# 2c. No NEW hook may introduce the pattern. Every violating file must be in the
-#     documented legacy baseline.
-new_violations=""
+# 2c. ZERO violations: NO hook may nest a heredoc inside a substitution.
+violations=""
 for hook in "$HOOKS_DIR"/*.sh; do
   [ -f "$hook" ] || continue
-  name="$(basename "$hook")"
   if ! python3 "$LINT" "$hook" >/dev/null 2>&1; then
-    if ! is_baseline "$name"; then
-      new_violations="$new_violations $name"
-    fi
+    violations="$violations $(basename "$hook")"
   fi
 done
-if [ -n "$new_violations" ]; then
-  fail "new hook(s) nest a heredoc inside a substitution (bash-3.2 trap):$new_violations
+if [ -n "$violations" ]; then
+  python3 "$LINT" "$HOOKS_DIR"/*.sh || true
+  fail "hook(s) nest a heredoc inside a substitution (bash-3.2 trap):$violations
 Slurp the heredoc into a top-level variable and run via an argument, e.g.
   prog=\"\"; IFS= read -r -d '' prog <<'PY' || true ... PY ; python3 -c \"\$prog\""
 fi
-echo "PASS: no new hook introduces the nested-heredoc pattern"
+echo "PASS: no hook nests a heredoc inside a substitution (zero violations)"
 
 # ── 3. runtime smoke of the acl hook ────────────────────────────────────────
 sample='{"hook_event_name":"PostToolUse","session_id":"gate-smoke","cwd":"'"$ROOT"'","tool_name":"Bash","tool_input":{"command":"echo hello"},"tool_response":{"stdout":"hello"}}'


### PR DESCRIPTION
## four-hook-heredoc-fixforward — eliminate the bash-3.2 nested-heredoc trap fleet-wide

Follow-up to #59. The heredoc-nesting lint added there surfaced four more hooks
that feed an embedded program to the shell via a heredoc opened **inside** a
`$( … )` command substitution — the identical shape that broke
`hq-auto-acl-suggest.sh`. On macOS system bash (3.2) each is mis-parsed as an
*unterminated quote*, failing the same way on every relevant tool call.

### Fixed (same pattern as the acl hook: slurp to a top-level variable, then run via an argument)
- **auto-session-project.sh** — classifier python → `python3 -c "$classify_py" "$HQ_ROOT"`
- **auto-mirror-company-skill.sh** — manifest prefix lookup → `python3 -c "$prefix_py" "$CO"`
- **route-company-skill-creation.sh** — manifest slug lookup → `python3 -c "$co_py" "$PREFIX"`
- **observe-patterns.sh** — four static JSON pattern literals → `read -r -d '' patternN … ; observations+=("$patternN")`

Behaviour is preserved — argv indices, env vars, and exit codes are unchanged.
Verified by running each embedded program against representative input
(classifier returns the same JSON; prefix/slug lookups return the right values
and degrade to empty on unknown input; observe-patterns still emits valid
observation JSON).

### Gate tightened
`hooks-heredoc-syntax.test.sh` flips from a documented legacy baseline to a
strict **zero-violations** guard now that no hook nests a heredoc in a
substitution. `bash -n` over all 51 hooks, the lint self-test, the acl-hook
assertion, and the runtime smoke all still pass; `hook-path-resolution.test.sh`
(which exercises `observe-patterns.sh`) passes.

-created by dev-executor:dev-3
