### PR TITLE
Add MIT LICENSE + landing README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Indigo AI, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,75 @@
+<p align="center">
+  <strong>HQ</strong> — the team AI operating system
+</p>
+
+<p align="center">
+  <em>Your AI agents have amnesia. HQ gives them your company's memory.</em>
+</p>
+
+<p align="center">
+  <img src="docs/images/magic-moment.svg" alt="A terminal: before HQ the agent has no memory of your codebase; after npx create-hq it answers who owns billing with the team, the decision record, and the on-call." width="760"/>
+</p>
+
+<p align="center">
+  <a href="https://github.com/indigoai-us/hq-core/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-6b7cff.svg" alt="License: MIT"/></a>
+  <a href="https://www.npmjs.com/package/create-hq"><img src="https://img.shields.io/npm/v/create-hq?color=6b7cff&label=create-hq" alt="create-hq on npm"/></a>
+  <a href="https://docs.getindigo.ai"><img src="https://img.shields.io/badge/docs-getindigo.ai-6b7cff.svg" alt="Docs"/></a>
+</p>
+
+---
+
+## What is HQ?
+
+HQ is an open-source **team AI operating system** — a shared, synced context and capability
+layer over **Claude Code, Cursor, and Codex**. It gives your AI coding agents your whole
+company's memory — knowledge, decisions, people, skills, and policies — so they stop
+forgetting everything every session.
+
+We call that default failure **[Agent Amnesia](https://www.hqforwork.com/agent-amnesia)**:
+every session, the agent knows nothing about your stack, your conventions, or the call you
+made last week. You re-explain. It re-discovers. Nothing compounds. HQ is the cure.
+
+## Quick start
+
+```bash
+npx create-hq
+```
+
+That scaffolds your HQ and wires it into the agents you already use. Prefer Homebrew?
+
+```bash
+brew install coreyepstein/tap/hq
+```
+
+## The 30-second version
+
+1. **Agent, day one** → asks "who owns billing in our codebase?" and has *no idea*.
+2. **`npx create-hq`** → HQ indexes the company: repos, decisions, people, skills.
+3. **Same question, now** → "`services/billing` — Sarah's team, see ADR-014, last touched
+   in PR #482." It knows your whole company.
+
+## What's inside
+
+- **Shared context layer** — one place for your company's knowledge, decisions, and people,
+  read by your agents automatically and synced across the team.
+- **Skills & workers** — reusable capabilities and specialized agents you build once and
+  share, instead of re-deriving them every session.
+- **Policies** — durable rules that travel with the company so every agent obeys them.
+- **Packs** — rich add-ons ship as [`@indigoai-us/hq-pack-*`](https://www.npmjs.com/search?q=%40indigoai-us%2Fhq-pack)
+  packages.
+
+## Why it compounds
+
+The more org memory accumulates in HQ, the smarter your agents get — and the higher the
+cost of starting over somewhere else. The memory is both the moat and the marketing.
+Read the thesis: **[Context is the moat](https://www.hqforwork.com/manifesto)**.
+
+## Learn more
+
+- **Docs** — https://docs.getindigo.ai
+- **Agent Amnesia** (the anti-pattern HQ solves) — https://www.hqforwork.com/agent-amnesia
+- **Manifesto** — https://www.hqforwork.com/manifesto
+
+## License
+
+[MIT](LICENSE) © Indigo AI, Inc.

--- a/docs/images/magic-moment.svg
+++ b/docs/images/magic-moment.svg
@@ -1,0 +1,88 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 332" width="760" height="332" font-family="ui-monospace, 'SF Mono', 'JetBrains Mono', Menlo, Consolas, monospace" role="img" aria-label="Before HQ, an AI agent has no memory of your company. After HQ, it knows your whole company.">
+  <defs>
+    <clipPath id="screen"><rect x="8" y="8" width="744" height="316" rx="11"/></clipPath>
+  </defs>
+
+  <!-- chrome -->
+  <rect x="8" y="8" width="744" height="316" rx="11" fill="#0d0f13" stroke="#262b35" stroke-width="1"/>
+  <g clip-path="url(#screen)">
+    <rect x="8" y="8" width="744" height="46" fill="#14171d"/>
+  </g>
+  <line x1="8" y1="54" x2="752" y2="54" stroke="#262b35" stroke-width="1"/>
+  <circle cx="30" cy="31" r="5.5" fill="#ff6b6b"/>
+  <circle cx="50" cy="31" r="5.5" fill="#f5b441"/>
+  <circle cx="70" cy="31" r="5.5" fill="#4ade80"/>
+  <text x="96" y="36" font-size="12.5" letter-spacing="0.14em" fill="#6a7079">hq · your company's memory</text>
+
+  <!-- ============ BEAT 1 — AMNESIA ============ -->
+  <g>
+    <text x="30" y="104" font-size="15" fill="#e7e9ec"><tspan fill="#7B9BC7">$ </tspan>claude "who owns billing in our codebase?"</text>
+    <animate attributeName="opacity" dur="13s" repeatCount="indefinite" calcMode="linear" keyTimes="0;0.0308;0.0500;0.2308;0.2500;1" values="0;0;1;1;0;0"/>
+  </g>
+  <g>
+    <rect x="430" y="91" width="9" height="17" fill="#7B9BC7">
+      <animate attributeName="opacity" dur="1.06s" repeatCount="indefinite" keyTimes="0;0.48;0.5;0.98;1" values="1;1;0;0;1"/>
+    </rect>
+    <animate attributeName="opacity" dur="13s" repeatCount="indefinite" calcMode="linear" keyTimes="0;0.0308;0.0500;0.2308;0.2500;1" values="0;0;1;1;0;0"/>
+  </g>
+  <g>
+    <text x="30" y="134" font-size="15" fill="#ff6b6b">✗  no idea — I have zero memory of your company.</text>
+    <animate attributeName="opacity" dur="13s" repeatCount="indefinite" calcMode="linear" keyTimes="0;0.0769;0.0962;0.2308;0.2500;1" values="0;0;1;1;0;0"/>
+  </g>
+  <g>
+    <text x="730" y="104" font-size="10.5" letter-spacing="0.18em" text-anchor="end" fill="#ff6b6b">AMNESIA</text>
+    <animate attributeName="opacity" dur="13s" repeatCount="indefinite" calcMode="linear" keyTimes="0;0.0769;0.0962;0.2308;0.2500;1" values="0;0;1;1;0;0"/>
+  </g>
+
+  <!-- ============ BEAT 2 — THE CURE ============ -->
+  <g>
+    <text x="30" y="104" font-size="15" fill="#e7e9ec"><tspan fill="#7B9BC7">$ </tspan>npx create-hq</text>
+    <animate attributeName="opacity" dur="13s" repeatCount="indefinite" calcMode="linear" keyTimes="0;0.2769;0.2962;0.4769;0.4962;1" values="0;0;1;1;0;0"/>
+  </g>
+  <g>
+    <rect x="170" y="91" width="9" height="17" fill="#7B9BC7">
+      <animate attributeName="opacity" dur="1.06s" repeatCount="indefinite" keyTimes="0;0.48;0.5;0.98;1" values="1;1;0;0;1"/>
+    </rect>
+    <animate attributeName="opacity" dur="13s" repeatCount="indefinite" calcMode="linear" keyTimes="0;0.2769;0.2962;0.4769;0.4962;1" values="0;0;1;1;0;0"/>
+  </g>
+  <g>
+    <text x="30" y="134" font-size="15" fill="#9ca3ad">↳  indexing repos · decisions · people · skills …</text>
+    <animate attributeName="opacity" dur="13s" repeatCount="indefinite" calcMode="linear" keyTimes="0;0.3231;0.3423;0.4769;0.4962;1" values="0;0;1;1;0;0"/>
+  </g>
+  <g>
+    <text x="30" y="162" font-size="15" fill="#4ade80">✓  HQ online. your context now persists.</text>
+    <animate attributeName="opacity" dur="13s" repeatCount="indefinite" calcMode="linear" keyTimes="0;0.3769;0.3962;0.4769;0.4962;1" values="0;0;1;1;0;0"/>
+  </g>
+
+  <!-- ============ BEAT 3 — TOTAL RECALL ============ -->
+  <g>
+    <text x="30" y="98" font-size="15" fill="#e7e9ec"><tspan fill="#7B9BC7">$ </tspan>claude "who owns billing in our codebase?"</text>
+    <animate attributeName="opacity" dur="13s" repeatCount="indefinite" calcMode="linear" keyTimes="0;0.5231;0.5423;0.9692;0.9885;1" values="0;0;1;1;0;0"/>
+  </g>
+  <g>
+    <rect x="430" y="85" width="9" height="17" fill="#7B9BC7">
+      <animate attributeName="opacity" dur="1.06s" repeatCount="indefinite" keyTimes="0;0.48;0.5;0.98;1" values="1;1;0;0;1"/>
+    </rect>
+    <animate attributeName="opacity" dur="13s" repeatCount="indefinite" calcMode="linear" keyTimes="0;0.5231;0.5423;0.9692;0.9885;1" values="0;0;1;1;0;0"/>
+  </g>
+  <g>
+    <text x="30" y="134" font-size="15" fill="#e7e9ec"><tspan fill="#7B9BC7">→  </tspan>services/billing — owned by Sarah's team</text>
+    <animate attributeName="opacity" dur="13s" repeatCount="indefinite" calcMode="linear" keyTimes="0;0.5846;0.6038;0.9692;0.9885;1" values="0;0;1;1;0;0"/>
+  </g>
+  <g>
+    <text x="30" y="162" font-size="15" fill="#9ca3ad">   decision: ADR-014 · last touched in PR #482</text>
+    <animate attributeName="opacity" dur="13s" repeatCount="indefinite" calcMode="linear" keyTimes="0;0.6385;0.6577;0.9692;0.9885;1" values="0;0;1;1;0;0"/>
+  </g>
+  <g>
+    <text x="30" y="190" font-size="15" fill="#9ca3ad">   oncall: @marco · ask in #billing</text>
+    <animate attributeName="opacity" dur="13s" repeatCount="indefinite" calcMode="linear" keyTimes="0;0.6923;0.7115;0.9692;0.9885;1" values="0;0;1;1;0;0"/>
+  </g>
+  <g>
+    <text x="730" y="98" font-size="10.5" letter-spacing="0.18em" text-anchor="end" fill="#4ade80">TOTAL RECALL</text>
+    <animate attributeName="opacity" dur="13s" repeatCount="indefinite" calcMode="linear" keyTimes="0;0.5846;0.6038;0.9692;0.9885;1" values="0;0;1;1;0;0"/>
+  </g>
+
+  <!-- ============ FOOTER (pinned) ============ -->
+  <line x1="30" y1="278" x2="730" y2="278" stroke="#262b35" stroke-width="1"/>
+  <text x="30" y="305" font-size="11" letter-spacing="0.16em" fill="#6a7079">AGENT AMNESIA<tspan fill="#7B9BC7">  →  </tspan>HQ<tspan fill="#7B9BC7">  →  </tspan>IT KNOWS YOUR WHOLE COMPANY</text>
+</svg>


### PR DESCRIPTION
Makes hq-core's open-source posture real and gives the repo a landing page.

**LICENSE** — MIT, © Indigo AI, Inc. The repo described itself as open source but had no
license file (GitHub detected none), which left it legally all-rights-reserved and blocked
every OSS-filtered directory listing. *Please confirm the copyright entity + merge — it's a
legal assertion.*

**README** — landing-page-grade: the Agent Amnesia hook, the animated magic-moment hero
(`docs/images/magic-moment.svg`), `npx create-hq` + `brew install` paths, what HQ is,
and links to docs + the new marketing pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)