### PR TITLE
fix(setup): machine-agnostic env.PATH + toolchain-aware PATH snapshot

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,6 @@
     "defaultMode": "plan"
   },
   "env": {
-    "PATH": "/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin",
     "MAX_THINKING_TOKENS": "31999",
     "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
     "CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "60",

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -151,6 +151,18 @@ jobs:
       - name: Regression test (fixture + live tree + fix present)
         run: bash core/scripts/tests/install-deps.test.sh
 
+  # Installer→Claude PATH gap: the template must not hardcode env.PATH, and
+  # the setup.sh snapshot must include the native installer's managed
+  # toolchain dirs even when the session PATH is missing them (GUI-launched
+  # Claude never sources the shell-profile block that wires them in).
+  compose-settings-path:
+    name: compose-settings-path
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: settings.json PATH snapshot composition
+        run: bash core/scripts/tests/compose-settings-path.test.sh
+
   # feedback_1b307a08: nested manifests were misparsed by a flat col-0 regex.
   manifest-nested-parse:
     name: manifest-nested-parse

--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,5 +1,5 @@
 version: 1
-hqVersion: "15.0.35"
+hqVersion: "15.0.36"
 updatedAt: "2026-07-01T09:57:10Z"
 # hq-core is the minimal scaffold seed. Rich add-ons ship as `@indigoai-us/hq-pack-*`
 # npm packages installed into `core/packages/` via `hq install`. See `core/packages/README.md`.

--- a/core/scripts/compose-settings-path.sh
+++ b/core/scripts/compose-settings-path.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# hq-core: public
+# core/scripts/compose-settings-path.sh — compose the env.PATH value written
+# into .claude/settings.json by setup.sh.
+#
+# Claude Code's env block does LITERAL assignment (no $PATH expansion) and it
+# overrides the inherited environment for every hook and subagent shell, so
+# the snapshot must already contain every directory those shells need.
+#
+# The base is the caller's PATH. But when HQ was installed by the native
+# installer, the managed toolchain (node, qmd, hq, git) lives under
+# "~/Library/Application Support/Indigo HQ/toolchain" and is wired into PATH
+# only via an interactive-shell profile block — which a GUI-launched Claude
+# (Dock, Spotlight, deep link) never sources. Without this correction the
+# snapshot taken from such a session omits the toolchain and hooks fail with
+# "qmd: command not found" until someone re-runs setup from a terminal.
+# Prepend each toolchain bin dir whenever it exists on disk and is missing
+# from the base, matching the installer's PATH ordering (node, npm-global,
+# git first so the toolchain ABI wins over older user-shell tools).
+#
+# Usage: compose-settings-path.sh [BASE_PATH]
+#   BASE_PATH defaults to $PATH. Prints the composed PATH on stdout.
+#   HQ_TOOLCHAIN_DIR overrides the toolchain root (tests).
+set -euo pipefail
+
+BASE="${1:-$PATH}"
+TOOLCHAIN="${HQ_TOOLCHAIN_DIR:-$HOME/Library/Application Support/Indigo HQ/toolchain}"
+
+path_contains() {
+  case ":$1:" in
+    *":$2:"*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+COMPOSED="$BASE"
+# Reverse priority order — each existing-but-missing dir is prepended, so the
+# last one prepended ends up first. Final order: node, npm-global, git, base.
+for dir in "$TOOLCHAIN/git/bin" "$TOOLCHAIN/npm-global/bin" "$TOOLCHAIN/node/bin"; do
+  if [[ -d "$dir" ]] && ! path_contains "$COMPOSED" "$dir"; then
+    COMPOSED="$dir:$COMPOSED"
+  fi
+done
+
+printf '%s\n' "$COMPOSED"

--- a/core/scripts/setup.sh
+++ b/core/scripts/setup.sh
@@ -98,13 +98,17 @@ ok "scripts marked executable"
 # Headless story workers run non-interactive bash that never sources .zshrc,
 # so they'd only see the system PATH. We snapshot the user's current PATH
 # (which includes nvm, bun, pnpm, pyenv, ~/.local/bin, etc.) at install time.
+# compose-settings-path.sh additionally prepends the native installer's
+# managed toolchain dirs when they exist on disk but are missing from this
+# session's PATH (a GUI-launched Claude never sources the profile block that
+# wires them in) — without it, hooks in such sessions can't find qmd/hq.
 
 echo ""
 echo "Configuring PATH for subagents…"
 
 SETTINGS_FILE="$REPO_ROOT/.claude/settings.json"
 if [[ -f "$SETTINGS_FILE" ]]; then
-  CURRENT_PATH="$PATH"
+  CURRENT_PATH="$(bash "$REPO_ROOT/core/scripts/compose-settings-path.sh")"
   UPDATED="$(jq --arg p "$CURRENT_PATH" '.env.PATH = $p' "$SETTINGS_FILE")"
   printf '%s\n' "$UPDATED" > "$SETTINGS_FILE"
   ok "PATH snapshot written to settings.json"

--- a/core/scripts/setup.sh
+++ b/core/scripts/setup.sh
@@ -108,7 +108,8 @@ echo "Configuring PATH for subagents…"
 
 SETTINGS_FILE="$REPO_ROOT/.claude/settings.json"
 if [[ -f "$SETTINGS_FILE" ]]; then
-  CURRENT_PATH="$(bash "$REPO_ROOT/core/scripts/compose-settings-path.sh")"
+  # Composer failure degrades to the plain snapshot — never abort setup here.
+  CURRENT_PATH="$(bash "$REPO_ROOT/core/scripts/compose-settings-path.sh" || printf '%s' "$PATH")"
   UPDATED="$(jq --arg p "$CURRENT_PATH" '.env.PATH = $p' "$SETTINGS_FILE")"
   printf '%s\n' "$UPDATED" > "$SETTINGS_FILE"
   ok "PATH snapshot written to settings.json"

--- a/core/scripts/tests/compose-settings-path.test.sh
+++ b/core/scripts/tests/compose-settings-path.test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# hq-core: public
+# Regression test for compose-settings-path.sh + the setup.sh 3b snapshot and
+# the template settings.json.
+#
+# Covers the installer→Claude PATH gap: the native installer provisions
+# qmd/hq/node into a managed toolchain wired into PATH only via an
+# interactive-shell profile block, while .claude/settings.json's env.PATH is
+# applied LITERALLY to every hook/subagent shell. Two regressions guarded:
+#   1. The shipped template must not hardcode a machine-specific env.PATH
+#      (it used to ship homebrew+system dirs with no toolchain — hooks in
+#      fresh installs couldn't find qmd until setup.sh re-snapshotted).
+#   2. The setup.sh snapshot must include the managed toolchain dirs even
+#      when the current session's PATH is missing them (GUI-launched Claude
+#      never sources the profile block).
+
+set -euo pipefail
+
+SRC_ROOT="$(git rev-parse --show-toplevel)"
+SCRIPT="$SRC_ROOT/core/scripts/compose-settings-path.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# ── 1. Template ships no hardcoded env.PATH ─────────────────────────────────
+
+if command -v jq >/dev/null 2>&1; then
+  TEMPLATE_PATH="$(jq -r '.env.PATH // empty' "$SRC_ROOT/.claude/settings.json")"
+  [[ -z "$TEMPLATE_PATH" ]] ||
+    fail "template .claude/settings.json hardcodes env.PATH ($TEMPLATE_PATH) — it must be machine-agnostic; setup.sh/the installer write the real snapshot"
+else
+  echo "  • template env.PATH check skipped (jq missing)"
+fi
+
+# ── 2. Toolchain dirs on disk but missing from PATH → prepended ─────────────
+
+TOOLCHAIN="$TMP/toolchain"
+mkdir -p "$TOOLCHAIN/node/bin" "$TOOLCHAIN/npm-global/bin" "$TOOLCHAIN/git/bin"
+
+BASE="/usr/bin:/bin"
+OUT="$(HQ_TOOLCHAIN_DIR="$TOOLCHAIN" bash "$SCRIPT" "$BASE")"
+
+[[ "$OUT" == "$TOOLCHAIN/node/bin:$TOOLCHAIN/npm-global/bin:$TOOLCHAIN/git/bin:$BASE" ]] ||
+  fail "toolchain dirs not prepended in installer order — got: $OUT"
+
+# ── 3. Toolchain dirs already on PATH → no duplicates ───────────────────────
+
+OUT="$(HQ_TOOLCHAIN_DIR="$TOOLCHAIN" bash "$SCRIPT" "$OUT")"
+NODE_COUNT="$(tr ':' '\n' <<<"$OUT" | grep -cx "$TOOLCHAIN/node/bin")"
+[[ "$NODE_COUNT" == "1" ]] || fail "toolchain dir duplicated on re-run — got: $OUT"
+
+# ── 4. No toolchain on disk → base passes through untouched ─────────────────
+
+OUT="$(HQ_TOOLCHAIN_DIR="$TMP/does-not-exist" bash "$SCRIPT" "$BASE")"
+[[ "$OUT" == "$BASE" ]] || fail "base PATH altered without a toolchain on disk — got: $OUT"
+
+# ── 5. setup.sh 3b routes the snapshot through the composer ─────────────────
+
+grep -q 'compose-settings-path.sh' "$SRC_ROOT/core/scripts/setup.sh" ||
+  fail "setup.sh no longer snapshots PATH via compose-settings-path.sh"
+
+echo "PASS: compose-settings-path regression suite"


### PR DESCRIPTION
## Problem

The shipped `.claude/settings.json` hardcodes `env.PATH` to homebrew + system dirs. Claude Code applies `env.PATH` literally to every hook and subagent shell, and installer-provisioned machines have qmd/hq/node **only** in the managed toolchain (`~/Library/Application Support/Indigo HQ/toolchain`) — so fresh installs hit `qmd: command not found` in hooks until setup.sh re-snapshots PATH on first Claude startup. Dev machines mask the bug because their qmd lives in `/opt/homebrew/bin`, which the hardcoded value happens to include.

## Fix

- Drop the hardcoded `env.PATH` from the template — a machine-specific PATH baked into a shipped file is wrong for every machine but the author's. setup.sh (and the native installer, fixed in indigoai-us/hq-installer#115) write the real snapshot.
- Route the setup.sh 3b snapshot through new `core/scripts/compose-settings-path.sh`, which prepends the managed toolchain bin dirs when they exist on disk but are missing from the session PATH — a GUI-launched Claude (Dock/Spotlight) never sources the shell-profile block that wires them in, so the plain `$PATH` snapshot from such a session used to bake the gap right back in.

## Tests

`core/scripts/tests/compose-settings-path.test.sh` (wired into pr-checks):
1. Template settings.json stays machine-agnostic (no `env.PATH`).
2. Toolchain dirs on disk but missing from PATH → prepended in installer order (node, npm-global, git).
3. Already present → no duplicates.
4. No toolchain on disk → base passes through untouched.
5. setup.sh keeps routing the snapshot through the composer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)