### PR TITLE
fix: never download qmd model mid-session; pack-aware /plan guidance; lightweight /plan for tiny projects

### DIFF
--- a/.claude/skills/brainstorm/SKILL.md
+++ b/.claude/skills/brainstorm/SKILL.md
@@ -54,9 +54,19 @@ Mode affects Steps 2-4 (premise challenge depth, question framing, research scop
 
 Do not ask questions yet. Build context from HQ first.
 
-**Hybrid search (BM25 + vector + re-ranking):**
-- If anchored + company has `qmd_collections`: `qmd query "<description keywords>" -c {collection} --json -n 10`
-- If not anchored: `qmd query "<description keywords>" --json -n 10`
+**Knowledge search (semantic ladder — gate the model first):** `qmd query` (hybrid, models cached) → `qmd search` (BM25, no model) → Grep. `qmd query` needs local GGUF models (~1.3GB) that qmd downloads on first use — a blocking mid-session download on a fresh/constrained machine. Never let it fire uncached:
+
+```bash
+bash core/scripts/qmd-ready.sh
+```
+
+- **Exit 0** (models cached) — run the hybrid query:
+  - If anchored + company has `qmd_collections`: `qmd query "<description keywords>" -c {collection} --json -n 10`
+  - If not anchored: `qmd query "<description keywords>" --json -n 10`
+- **Exit non-zero** (models not cached, or qmd missing) — downgrade to BM25 with the same query/collection (do NOT trigger the download):
+  - If anchored + company has `qmd_collections`: `qmd search "<description keywords>" -c {collection} --json -n 10`
+  - If not anchored: `qmd search "<description keywords>" --json -n 10`
+  - If qmd itself is absent, fall to Grep over `companies/{co}/projects/` and the knowledge dirs.
 
 **Existing projects:**
 - If anchored: search `companies/{co}/projects/` directly or `qmd search "prd.json" -c {co} --json -n 10`

--- a/.claude/skills/learn/SKILL.md
+++ b/.claude/skills/learn/SKILL.md
@@ -132,7 +132,7 @@ If the input starts with `[` (JSON array), enter batch mode:
 **Batch processing rules:**
 
 1. **Detect batch input:** if the input is a JSON array (starts with `[`), enter batch mode
-2. **Run qmd vsearch dedup ONCE for all items:** concatenate all item `content` fields as a single query string for a single `qmd vsearch` call, then match results against each item individually
+2. **Run qmd dedup ONCE for all items:** concatenate all item `content` fields as a single query string for a single qmd call — gated exactly like Step 4 (`bash core/scripts/qmd-ready.sh && qmd vsearch …`; `qmd search` BM25 when not ready; Grep when qmd is missing) — then match results against each item individually
 3. **Process each item through Steps 2–6 normally:** extract rules, classify scope, create/update policy files — one item at a time using the shared dedup results
 4. **Write a single event log entry** covering all items processed in the batch
 5. **Backward compatibility:** all existing modes (1, 2, 3) work exactly as before — batch is a new detection branch only
@@ -198,15 +198,23 @@ For each extracted rule, determine scope (most specific wins):
 
 ## Step 4: Dedup Check
 
-**Primary (if qmd available):**
+**Search ladder:** `qmd vsearch` (model cached) → `qmd search` (BM25) → Grep. On a fresh machine `qmd vsearch` blocks the session downloading ~1.3GB of models — never let it. Gate with `core/scripts/qmd-ready.sh` first.
+
+**Primary (if qmd available AND its models are already cached):**
 ```bash
-qmd vsearch "{rule text}" --json -n 5
+bash core/scripts/qmd-ready.sh && qmd vsearch "{rule text}" --json -n 5
 ```
 
 Check results for similarity to the new rule:
 - Similarity > 0.85 → **Skip** (already captured somewhere)
 - Similarity 0.6–0.85 → **Merge** (update existing rule to be more precise)
 - Similarity < 0.6 → **Add new**
+
+**BM25 rung (qmd installed but `qmd-ready.sh` exits non-zero — models not cached):**
+```bash
+qmd search "{rule text}" --json -n 5
+```
+Keyword match instead of semantic similarity — treat strong keyword overlap as a **Merge** candidate (review the hit before deciding Skip/Merge/Add). Do NOT run `qmd vsearch`/`qmd query` in this state: it triggers a blocking model download mid-session.
 
 **Fallback (if qmd unavailable):**
 Use Grep to search for key terms from the rule across the policy directories:
@@ -230,7 +238,7 @@ Before creating a new rule, check if an existing policy file already covers this
    # Grep policy titles and rules for keyword overlap
    grep -rl "{key terms from rule}" {policy_dir}/*.md 2>/dev/null
    ```
-   Also check `qmd vsearch` results from Step 4 for hits in policy files.
+   Also check the qmd results from Step 4 (vsearch, or BM25 `qmd search` when the model wasn't cached) for hits in policy files.
 
 3. **If matching policy found:**
    - Read the policy file

--- a/.claude/skills/plan/SKILL.md
+++ b/.claude/skills/plan/SKILL.md
@@ -58,9 +58,10 @@ If `{co}` is anchored, scope all searches to that company.
 - If `{co}` is anchored and a candidate project slug is already clear from the input, also run `bash core/scripts/work-mesh.sh check --company {co} --project {candidate-slug}`. If it reports active owners, blockers, or in-progress threads, surface that before asking whether to create a new PRD. If it prints nothing or reports unavailable/offline, continue normally.
 - A local daemon or long-running HQ instance may run `bash core/scripts/work-mesh.sh watch` to keep `workspace/work-mesh/live-cache.json` current from MQTT. This is optional context; project creation still uses `check` and the reporting verbs below.
 
-**Knowledge (use single qmd hybrid query, not Grep, not vsearch+search pair):**
-- If anchored + company has `qmd_collections`: `qmd query "<description keywords>" -c {collection} --json -n 10`
-- If not anchored: `qmd query "<description keywords>" --json -n 10` — hybrid BM25 + vector + re-ranking for related knowledge, prior work, workers
+**Knowledge (default to BM25 `qmd search` — never triggers a model download):**
+- If anchored + company has `qmd_collections`: `qmd search "<description keywords>" -c {collection} --json -n 10`
+- If not anchored: `qmd search "<description keywords>" --json -n 10`
+- `qmd search` is BM25 keyword search — it needs no embedding model, so it never triggers qmd's blocking ~1.3GB first-use model download (the verified new-user report was a ~1.28GB pull mid-`/plan`). **`/plan` deliberately stays on BM25.** The heavier hybrid `qmd query` (BM25 + vector + re-ranking) is reserved for `/deep-plan`, which gates the model behind `core/scripts/qmd-ready.sh` and is meant for large or strategically important PRDs.
 
 **Company Policies (anchored only):**
 - Already loaded in Step 0 (frontmatter-only). Do NOT re-read here. Note constraints from that scan
@@ -70,7 +71,7 @@ If `{co}` is anchored, scope all searches to that company.
 
 **Target Repo (if repo specified or discovered):**
 - If anchored: company repos already pre-loaded from manifest. Present as options
-- If target repo has a qmd collection (e.g. `my-app`): `qmd query "<description keywords>" -c {collection} --json -n 10` — hybrid search for related code, patterns, existing implementations
+- If target repo has a qmd collection (e.g. `my-app`): `qmd search "<description keywords>" -c {collection} --json -n 10` — BM25 keyword search for related code, patterns, existing implementations (no model download; hybrid `qmd query` stays in `/deep-plan`)
 - Present: "Found related code: {list of relevant files}"
 
 Present:
@@ -560,13 +561,23 @@ If project already exists in state.json, update it instead of duplicating.
 
 ## Step 7: Sync to Beads
 
+**Tiny-project fast path (instruction to the executing agent).** If this PRD is *tiny* — **≤ 2 user stories AND no `repoPath`** (a content/knowledge/one-off, not a code build) — keep the tail of this skill lightweight and skip the heavy machinery that a one-off doesn't need:
+
+- **Step 7 (this step — beads):** run the beads sync only if `tsx` is already available quickly. Probe once, non-blocking: `command -v tsx >/dev/null 2>&1 || npx --no-install tsx --version >/dev/null 2>&1`. If neither resolves (running `npx tsx` would trigger a package download), **skip beads sync**, log one line, and continue — never block PRD completion on a toolchain fetch.
+- **Step 7.5 (auto-learn):** skip — a one-off tiny PRD is not a reusable learning.
+- **Step 7.7 (knowledge-pulse):** skip — no background gardening for a tiny project.
+
+For every other project (≥ 3 stories, or any project with a `repoPath`), run Steps 7, 7.5, and 7.7 normally.
+
 ```bash
 npx tsx core/scripts/prd-to-beads.ts --project={name}
 ```
 
-Silent — just log success/failure.
+Silent — just log success/failure. (Per the fast path above, skip this entirely for a tiny project when `tsx` isn't immediately available.)
 
 ## Step 7.5: Capture Learning (Auto-Learn)
+
+**Skip for tiny projects** (≤ 2 stories AND no `repoPath`) — see the fast path at Step 7. A one-off tiny PRD is not a reusable learning.
 
 Run the `learn` skill (or `/learn` in Claude Code) to register the new project in the learning system:
 
@@ -630,7 +641,7 @@ spawn_task(
 
 Do NOT wait for the pulse to complete — continue immediately to Step 8.
 
-**Skip if:** company has no knowledge directory.
+**Skip if:** company has no knowledge directory, **or** this is a tiny project (≤ 2 stories AND no `repoPath` — see the fast path at Step 7).
 
 ## Step 8: Linear Sync (best-effort, when configured)
 
@@ -683,7 +694,15 @@ Read `metadata.openQuestions[]` from the prd.json just written. **If empty**, sk
 
 ## Step 9: Confirm & STOP
 
-Tell user:
+**Pack-aware execution guidance — probe before you tell the user what to run.** `/run-project` and `/execute-task` ship in `hq-pack-engineering`, NOT in the lean core scaffold (they were extracted in 15.0.0; auto-installed for upgraders, skipped on greenfield installs). A pack-less user handed `/run-project` as an actionable next step hits `Unknown command: /run-project` — the DEV-1716 dead-end. Detect the pack first:
+
+```bash
+bash core/scripts/pack-installed.sh hq-pack-engineering
+```
+
+(Equivalent inline check: `test -f .claude/skills/run-project/SKILL.md`.)
+
+**If the pack IS installed (exit 0)** — the execution commands resolve; tell the user:
 ```
 Project **{name}** created with {N} user stories.
 Decisions resolved: {metadata.decisions.length} (Step 8.5)
@@ -699,19 +718,36 @@ Post-implementation docs needed:
 To execute, start a new session and run:
   /run-project {name}        (multi-story orchestrator)
   /execute-task {name}/US-001 (single story)
-
-  These execution commands ship in the engineering pack. If /run-project
-  isn't available on this install, add the pack once (then run the above):
-    hq install github:indigoai-us/hq-packages#packages/hq-pack-engineering
 ```
 
-> **Pack-aware close.** `/run-project` and `/execute-task` live in
-> `hq-pack-engineering`, which is auto-installed for upgraders but skipped on
-> lean greenfield installs. Always print the install line above alongside the
-> commands so a pack-less user has a resolvable path instead of a dead-end — do
-> not instruct an execution command without it.
+**If the pack is NOT installed (exit non-zero)** — do NOT present `/run-project` or `/execute-task` as if they were runnable. Lead with the install step as the required first action; tell the user:
+```
+Project **{name}** created with {N} user stories.
+Decisions resolved: {metadata.decisions.length} (Step 8.5)
+Open questions remaining: {metadata.openQuestions.length}
 
-**Final step — auto-checkpoint <!-- AUTO-CHECKPOINT-ON-COMPLETION -->.** Do NOT proceed to execution. Rather than asking the user to manually `/handoff`, automatically save a lightweight checkpoint so a fresh session can pick up execution. Write `workspace/threads/T-{UTC YYYYMMDD-HHMMSS}-auto-plan-{project}.json` with `thread_id`, `version: 1`, `type: "auto-checkpoint"`, `created_at`, `updated_at`, `workspace_root`, `cwd`, `git: { branch, current_commit, dirty }`, `conversation_summary` (the project + that its PRD was created), `files_touched` (the `prd.json` + `README.md`), `next_steps` ("in a fresh session run `/run-project {project}` or `/execute-task {project}/US-001`"), and `metadata: { title: "Auto: plan {project}", tags: ["auto-checkpoint", "plan"], trigger: "plan-complete" }`. Keep it cheap (no INDEX/`recent.md`/`qmd` rebuild, no legacy checkpoint). Then tell the user the PRD is ready and a fresh session can start execution from this checkpoint. A full `/handoff` remains available if the user wants the heavier wrap-up.
+Files:
+  companies/{co}/projects/{name}/prd.json   (source of truth — tracks all work)
+  companies/{co}/projects/{name}/README.md  (human-readable view)
+
+Post-implementation docs needed:
+  {list from postImplementation metadata, or "None detected"}
+
+To execute this PRD you first need the engineering pack (it ships the
+execution commands). In a fresh session, run this once:
+  hq install github:indigoai-us/hq-packages#packages/hq-pack-engineering
+
+Once installed, the execution commands become available:
+  /run-project {name}        (multi-story orchestrator)
+  /execute-task {name}/US-001 (single story)
+```
+
+> **Why the branch.** When the pack is absent, the install line is the required
+> first action — never instruct `/run-project` or `/execute-task` as a
+> copy-paste-now command that resolves to a dead-end. When it is present, skip
+> the install line and route straight to the execution commands.
+
+**Final step — auto-checkpoint <!-- AUTO-CHECKPOINT-ON-COMPLETION -->.** Do NOT proceed to execution. Rather than asking the user to manually `/handoff`, automatically save a lightweight checkpoint so a fresh session can pick up execution. Write `workspace/threads/T-{UTC YYYYMMDD-HHMMSS}-auto-plan-{project}.json` with `thread_id`, `version: 1`, `type: "auto-checkpoint"`, `created_at`, `updated_at`, `workspace_root`, `cwd`, `git: { branch, current_commit, dirty }`, `conversation_summary` (the project + that its PRD was created), `files_touched` (the `prd.json` + `README.md`), `next_steps` (**pack-aware** — reuse the Step 9 probe: if `bash core/scripts/pack-installed.sh hq-pack-engineering` exits 0, write "in a fresh session run `/run-project {project}` or `/execute-task {project}/US-001`"; if it exits non-zero, write "in a fresh session install the engineering pack once (`hq install github:indigoai-us/hq-packages#packages/hq-pack-engineering`), then run `/run-project {project}`" — do not record a bare execution command a pack-less session can't resolve), and `metadata: { title: "Auto: plan {project}", tags: ["auto-checkpoint", "plan"], trigger: "plan-complete" }`. Keep it cheap (no INDEX/`recent.md`/`qmd` rebuild, no legacy checkpoint). Then tell the user the PRD is ready and a fresh session can start execution from this checkpoint. A full `/handoff` remains available if the user wants the heavier wrap-up.
 
 ## Story Guidelines
 

--- a/.claude/skills/search/SKILL.md
+++ b/.claude/skills/search/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: search
 description: Search HQ content and indexed repos with qmd, falling back to grep.
-allowed-tools: Read, Grep, Bash(qmd:*), Bash(grep:*), Bash(ls:*)
+allowed-tools: Read, Grep, Bash(qmd:*), Bash(grep:*), Bash(ls:*), Bash(bash core/scripts/qmd-ready.sh:*)
 ---
 
 # Search - HQ + Codebase Search
@@ -40,6 +40,19 @@ which qmd 2>/dev/null && qmd --version 2>/dev/null
 
 If qmd is not available, skip to **Fallback** section.
 
+## Check Semantic Readiness (vsearch / query modes only)
+
+`qmd vsearch` and `qmd query` need local GGUF models (~1.3GB total) that qmd downloads on first use — a blocking mid-session download on a fresh machine. Before running either mode:
+
+```bash
+bash core/scripts/qmd-ready.sh
+```
+
+- **Exit 0** (models cached) — proceed with the requested mode.
+- **Exit non-zero** — downgrade to `search` mode (BM25) with the same query/collection, and note the downgrade in the results header: `(semantic model not cached — used BM25; run 'qmd embed' once to enable)`. Never let vsearch/query trigger the download.
+
+**Search ladder:** `vsearch`/`query` (models cached) → `qmd search` (BM25) → Grep (qmd not installed).
+
 ## Execute Search
 
 Run the matching qmd command. Add `-c $COLLECTION` if a collection was specified or auto-detected:
@@ -49,12 +62,12 @@ Run the matching qmd command. Add `-c $COLLECTION` if a collection was specified
 qmd search "$QUERY" -n $N --json [-c $COLLECTION]
 ```
 
-**Semantic (conceptual match):**
+**Semantic (conceptual match — requires readiness check above):**
 ```bash
 qmd vsearch "$QUERY" -n $N --json [-c $COLLECTION]
 ```
 
-**Hybrid (BM25 + vector + re-rank — best quality, slower):**
+**Hybrid (BM25 + vector + re-rank — best quality, slower; requires readiness check above):**
 ```bash
 qmd query "$QUERY" -n $N --json [-c $COLLECTION]
 ```
@@ -128,6 +141,7 @@ search "case study"                             # Auto-detects → -c {company}
 - Default `search` mode is fastest — use for exact keywords
 - Use `--mode vsearch` for conceptual/semantic queries
 - Use `--mode query` for highest quality (slower, uses LLM re-ranking)
+- vsearch/query silently downgrade to BM25 when `core/scripts/qmd-ready.sh` reports the models aren't cached — never trigger the ~1.3GB model download mid-session
 - Use `-c` to scope to a collection: `hq-infra`, `hq-workers`, `hq-knowledge`, `hq-projects`, `{product}`, + company collections (run `qmd status` for full list)
 - Without `-c`, auto-detects company from context; falls back to all collections
 - Scores 0.0–1.0; above 0.5 is a good match

--- a/.claude/skills/startwork/SKILL.md
+++ b/.claude/skills/startwork/SKILL.md
@@ -241,6 +241,15 @@ Then present numbered options built from context:
 - **Repo mode**: related projects with incomplete work (up to 3) + "Open repo (no project)" + "Something else"
 - **Task mode**: proposed worker pipeline phases (up to 5) + "Run this worker pipeline" + "Modify pipeline" + "Do it directly (no worker)" + "Run /plan for full options" + "Something else"
 
+> **`/execute-task` requires the engineering pack.** It (and `/run-project`)
+> ship in `hq-pack-engineering` (auto-installed for upgraders, skipped on lean
+> greenfield installs). Before presenting a story-execution option, probe once
+> with `bash core/scripts/pack-installed.sh hq-pack-engineering`. If it is NOT
+> installed, do not present `/execute-task` as a runnable next step — route the
+> user through `/run {worker} {skill}` (ships in core), or surface the one-time
+> install line instead of a dead-end:
+> `hq install github:indigoai-us/hq-packages#packages/hq-pack-engineering`.
+
 Output the numbered list and wait for user input. After user picks, proceed directly into the work.
 
 ## Rules

--- a/.claude/skills/storyboard/SKILL.md
+++ b/.claude/skills/storyboard/SKILL.md
@@ -160,6 +160,14 @@ State the outcome in one or two plain lines and point to the next step:
 - **spec-led:** "Design's locked for **{slug}** — {N} changes folded into the PRD. Ready to build with `/run-project {slug}`." Include the preview URL if there is one.
 - **design-led:** "Design explored for **{slug}** — wrote `design/design.md`. Run `/plan {slug}` and it'll pre-fill from the design."
 
+> **`/run-project` requires the engineering pack.** It ships in
+> `hq-pack-engineering` (auto-installed for upgraders, skipped on lean
+> greenfield installs). Before pointing the user at `/run-project` in the
+> spec-led handoff, probe once with `bash core/scripts/pack-installed.sh
+> hq-pack-engineering`. If it isn't installed, surface the one-time install line
+> instead of a dead-end command:
+> `hq install github:indigoai-us/hq-packages#packages/hq-pack-engineering`.
+
 ## Codex Notes
 
 - Replace `Agent` sub-agents with Codex sub-agents when available, or run the same phases inline and persist to the journal / `design/design.md` between phases.

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -151,6 +151,21 @@ jobs:
       - name: Regression test (fixture + live tree + fix present)
         run: bash core/scripts/tests/install-deps.test.sh
 
+  search-model-pack-gate:
+    # New-user report: /learn dedup triggered a blocking ~1.28GB qmd model
+    # download mid-session, and /plan's completion led with /run-project (an
+    # hq-pack-engineering command) on a pack-less install. Guards the two probes
+    # skills now gate on: qmd-ready.sh (semantic model cached? -> else BM25) and
+    # pack-installed.sh (is a pack present? -> else lead with the install line).
+    name: search-model-pack-gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: qmd-ready gate (never blocks on a mid-session model download)
+        run: bash core/scripts/tests/qmd-ready.test.sh
+      - name: pack-installed check (pack-aware skill output)
+        run: bash core/scripts/tests/pack-installed.test.sh
+
   # Installer→Claude PATH gap: the template must not hardcode env.PATH, and
   # the setup.sh snapshot must include the native installer's managed
   # toolchain dirs even when the session PATH is missing them (GUI-launched

--- a/core/scripts/pack-installed.sh
+++ b/core/scripts/pack-installed.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# pack-installed.sh — canonical check: is an hq content pack installed on this HQ?
+#
+# Usage: pack-installed.sh <pack-name> [--explain]
+#   bash core/scripts/pack-installed.sh hq-pack-engineering && echo installed
+#
+# A pack is "installed" when core/packages/<pack-name>/package.yaml exists —
+# the exact marker scan-packages.sh keys on before wiring a pack's
+# contributions. Skills use this to keep completion output pack-aware: e.g.
+# /plan Step 9 only presents /run-project + /execute-task as runnable when
+# hq-pack-engineering is present, and leads with the pack's install line when
+# it is not (the DEV-1716 "Unknown command: /run-project" dead-end).
+#
+# CONTRACT:
+#   exit 0 — pack installed (manifest present)
+#   exit 1 — pack not installed
+#   exit 2 — usage error
+#
+# HQ_ROOT overrides the instance root; defaults to cwd (same as scan-packages.sh).
+
+set -euo pipefail
+
+PACK=""
+EXPLAIN=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --explain) EXPLAIN=1; shift ;;
+    -h|--help)
+      echo "usage: pack-installed.sh <pack-name> [--explain]"
+      echo "exit 0 iff core/packages/<pack-name>/package.yaml exists."
+      exit 0 ;;
+    -*)
+      echo "pack-installed: unknown flag '$1' (usage: pack-installed.sh <pack-name> [--explain])" >&2
+      exit 2 ;;
+    *)
+      if [[ -n "$PACK" ]]; then
+        echo "pack-installed: expected exactly one pack name (usage: pack-installed.sh <pack-name> [--explain])" >&2
+        exit 2
+      fi
+      PACK="$1"; shift ;;
+  esac
+done
+
+if [[ -z "$PACK" ]]; then
+  echo "pack-installed: missing pack name (usage: pack-installed.sh <pack-name> [--explain])" >&2
+  exit 2
+fi
+
+HQ_ROOT="${HQ_ROOT:-$(pwd)}"
+MANIFEST="$HQ_ROOT/core/packages/$PACK/package.yaml"
+
+if [[ -f "$MANIFEST" ]]; then
+  if [[ "$EXPLAIN" == "1" ]]; then
+    echo "installed: $PACK ($MANIFEST)"
+  fi
+  exit 0
+fi
+
+if [[ "$EXPLAIN" == "1" ]]; then
+  echo "not installed: $PACK — no manifest at $MANIFEST"
+  echo "install with: hq install github:indigoai-us/hq-packages#packages/$PACK"
+fi
+exit 1

--- a/core/scripts/qmd-ready.sh
+++ b/core/scripts/qmd-ready.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# qmd-ready.sh — is semantic qmd (vsearch / query / embed) safe to run WITHOUT
+# triggering a model download?
+#
+# WHY: qmd's semantic commands lazily download GGUF models on first use — a
+# ~1.3GB query-expansion model plus embedding + reranker models. On a fresh or
+# constrained machine that download blocks the session (verified new-user
+# report: a ~1.28GB pull mid-/learn dedup). Skills therefore gate every
+# `qmd vsearch` / `qmd query` behind this script and drop to BM25 while the
+# models aren't cached yet:
+#
+#   bash core/scripts/qmd-ready.sh && qmd query "..." --json || qmd search "..." --json
+#
+# Semantic search ladder: vsearch/query (models cached) → qmd search (BM25) → Grep.
+#
+# CONTRACT:
+#   exit 0 — qmd is installed AND all semantic models are already cached locally
+#   exit 1 — not ready (qmd missing, or ≥1 model absent → a semantic call would
+#            block on a download)
+#   exit 2 — usage error
+#
+# Pure filesystem checks (<100ms). NEVER invokes qmd itself — a qmd invocation
+# could be the very thing that starts the download.
+#
+# Model cache locations (union — a model may live in any of them):
+#   $QMD_READY_MODEL_DIRS          colon-separated override (tests / CI)
+#   $XDG_CACHE_HOME/qmd/models     or ~/.cache/qmd/models (Linux/WSL, qmd default)
+#   ~/Library/Caches/qmd/models    (macOS-native cache)
+#   $LOCALAPPDATA/qmd/models      (Windows, when set)
+#
+# Usage: qmd-ready.sh [--explain]
+#   --explain   print why (not) ready to stdout; silent otherwise.
+
+set -euo pipefail
+
+EXPLAIN=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --explain) EXPLAIN=1; shift ;;
+    -h|--help)
+      echo "usage: qmd-ready.sh [--explain]"
+      echo "exit 0 iff qmd is installed and its semantic models are cached locally."
+      exit 0 ;;
+    *)
+      echo "qmd-ready: unknown argument '$1' (usage: qmd-ready.sh [--explain])" >&2
+      exit 2 ;;
+  esac
+done
+
+say() { if [[ "$EXPLAIN" == "1" ]]; then printf '%s\n' "$*"; fi; }
+
+if ! command -v qmd >/dev/null 2>&1; then
+  say "not ready: qmd is not installed — use Grep (bottom rung of the search ladder)"
+  exit 1
+fi
+
+# Candidate model directories, newline-separated (bash-3.2-safe: no arrays).
+candidate_dirs() {
+  if [[ -n "${QMD_READY_MODEL_DIRS:-}" ]]; then
+    printf '%s\n' "$QMD_READY_MODEL_DIRS" | tr ':' '\n'
+    return 0
+  fi
+  printf '%s\n' "${XDG_CACHE_HOME:-$HOME/.cache}/qmd/models"
+  printf '%s\n' "$HOME/Library/Caches/qmd/models"
+  if [[ -n "${LOCALAPPDATA:-}" ]]; then
+    printf '%s\n' "$LOCALAPPDATA/qmd/models"
+  fi
+}
+
+# Role detection by GGUF filename across all candidate dirs. Filenames vary by
+# qmd version/cache (e.g. "hf_ggml-org_embeddinggemma-300M-Q8_0.gguf" vs
+# "embeddinggemma-300M-Q8_0.gguf"), so match on the stable role substrings.
+HAVE_EMBED=0
+HAVE_EXPAND=0
+HAVE_RERANK=0
+DIRS_CHECKED=""
+
+while IFS= read -r dir; do
+  [[ -n "$dir" && -d "$dir" ]] || continue
+  DIRS_CHECKED="${DIRS_CHECKED}${DIRS_CHECKED:+, }${dir}"
+  for f in "$dir"/*.gguf; do
+    [[ -e "$f" ]] || continue
+    name="$(basename "$f" | tr '[:upper:]' '[:lower:]')"
+    case "$name" in *embed*)  HAVE_EMBED=1  ;; esac
+    case "$name" in *expan*)  HAVE_EXPAND=1 ;; esac
+    case "$name" in *rerank*) HAVE_RERANK=1 ;; esac
+  done
+done < <(candidate_dirs)
+
+MISSING=""
+[[ "$HAVE_EMBED"  == 1 ]] || MISSING="${MISSING}${MISSING:+, }embedding"
+[[ "$HAVE_EXPAND" == 1 ]] || MISSING="${MISSING}${MISSING:+, }query-expansion (~1.3GB)"
+[[ "$HAVE_RERANK" == 1 ]] || MISSING="${MISSING}${MISSING:+, }reranker"
+
+if [[ -z "$MISSING" ]]; then
+  say "ready: qmd installed and semantic models cached (${DIRS_CHECKED})"
+  exit 0
+fi
+
+say "not ready: qmd is installed but model(s) not cached yet: ${MISSING}"
+if [[ -n "$DIRS_CHECKED" ]]; then
+  say "checked: ${DIRS_CHECKED}"
+else
+  say "checked: no qmd model directory exists yet"
+fi
+say "running 'qmd vsearch/query/embed' now would BLOCK on a model download."
+say "use 'qmd search' (BM25, no model) instead, or warm up once with: qmd embed"
+exit 1

--- a/core/scripts/setup.sh
+++ b/core/scripts/setup.sh
@@ -236,10 +236,41 @@ if command -v qmd &>/dev/null; then
   qmd context add qmd://hq-projects "Project PRDs and documentation." 2>/dev/null || true
 fi
 
-# Update qmd search index and build embeddings
-qmd update 2>/dev/null || true
-qmd embed 2>/dev/null || true
-ok "qmd index built"
+# Update qmd search index and (optionally) warm up the semantic-search model.
+if command -v qmd &>/dev/null; then
+  qmd update 2>/dev/null || true
+
+  # Warm up the semantic-search model NOW, once, up front. qmd downloads its
+  # GGUF models (~1.3GB) lazily on the FIRST semantic call — `qmd vsearch` /
+  # `qmd query` / `qmd embed`. If we don't fetch them here, that download lands
+  # MID-SESSION the first time /learn dedup or /search runs (the verified
+  # new-user report: a ~1.28GB pull that blocked a live session). Fetching it at
+  # setup keeps it out of the user's working sessions.
+  #
+  # Skippable on constrained machines: set HQ_SKIP_SEARCH_MODEL=1, or just let
+  # the download fail — HQ never hard-fails setup over it. When the model is not
+  # cached, HQ skills automatically stay in BM25 mode: every `qmd vsearch` /
+  # `qmd query` is gated behind core/scripts/qmd-ready.sh, which downgrades to
+  # `qmd search` (BM25, no model). Search still works — it just isn't semantic
+  # until the model lands (re-run `qmd embed` any time to enable it).
+  if [[ "${HQ_SKIP_SEARCH_MODEL:-}" == "1" ]]; then
+    skip "search model download (HQ_SKIP_SEARCH_MODEL=1) — skills stay in BM25 mode"
+  elif bash "$REPO_ROOT/core/scripts/qmd-ready.sh" >/dev/null 2>&1; then
+    ok "search model already cached"
+  else
+    echo "  Downloading search model (~1.3GB, one time)…"
+    echo "  (skip with HQ_SKIP_SEARCH_MODEL=1 on constrained machines — search stays BM25-only)"
+    if qmd embed; then
+      ok "search model ready — semantic search enabled"
+    else
+      fail "search model download failed — continuing without it (setup is NOT blocked)"
+      echo "     HQ skills automatically use BM25 (qmd search) until you re-run: qmd embed"
+    fi
+  fi
+  ok "qmd index built"
+else
+  skip "qmd not installed — knowledge index + search model skipped"
+fi
 
 # ── 7. Recommended content packs (hq-core v12+) ──────────────────────────────
 # hq-core ships as a minimal scaffold; batteries-included UX comes from packs

--- a/core/scripts/tests/pack-installed.test.sh
+++ b/core/scripts/tests/pack-installed.test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Regression coverage for core/scripts/pack-installed.sh — the canonical
+# "is this hq pack installed?" check behind pack-aware skill output (/plan
+# Step 9 must not present /run-project as runnable on a pack-less install —
+# the DEV-1716 "Unknown command: /run-project" dead-end). Asserts the marker
+# is core/packages/<pack>/package.yaml (same as scan-packages.sh), a bare
+# pack dir without a manifest does NOT count, and usage errors exit 2.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+SCRIPT="${ROOT}/core/scripts/pack-installed.sh"
+[[ -f "$SCRIPT" ]] || fail "pack-installed.sh not found at $SCRIPT"
+
+HQ="${TMP}/HQ"
+mkdir -p "${HQ}/core/packages"
+
+run_check() { # run_check [args...] -> echoes exit code, output in out.log
+  local rc=0
+  HQ_ROOT="$HQ" bash "$SCRIPT" "$@" > "${TMP}/out.log" 2>&1 || rc=$?
+  echo "$rc"
+}
+
+# --- Case A: pack absent -> exit 1 -------------------------------------------
+rc="$(run_check hq-pack-engineering --explain)"
+[[ "$rc" == "1" ]] || fail "Case A: expected exit 1 for absent pack, got $rc"
+grep -q "not installed" "${TMP}/out.log" || fail "Case A: --explain should say not installed"
+grep -q "hq install github:indigoai-us/hq-packages#packages/hq-pack-engineering" "${TMP}/out.log" \
+  || fail "Case A: --explain should print the pack's install line"
+
+# --- Case B: pack dir WITHOUT package.yaml -> still exit 1 -------------------
+# (scan-packages.sh skips manifest-less dirs; so must this check)
+mkdir -p "${HQ}/core/packages/hq-pack-engineering"
+rc="$(run_check hq-pack-engineering)"
+[[ "$rc" == "1" ]] || fail "Case B: expected exit 1 for manifest-less pack dir, got $rc"
+
+# --- Case C: manifest present -> exit 0 --------------------------------------
+echo "name: hq-pack-engineering" > "${HQ}/core/packages/hq-pack-engineering/package.yaml"
+rc="$(run_check hq-pack-engineering)"
+[[ "$rc" == "0" ]] || fail "Case C: expected exit 0 for installed pack, got $rc"
+rc="$(run_check hq-pack-engineering --explain)"
+[[ "$rc" == "0" ]] || fail "Case C: expected exit 0 with --explain, got $rc"
+grep -q "installed: hq-pack-engineering" "${TMP}/out.log" || fail "Case C: --explain should say installed"
+
+# --- Case D: other pack still absent -> exit 1 --------------------------------
+rc="$(run_check hq-pack-does-not-exist)"
+[[ "$rc" == "1" ]] || fail "Case D: expected exit 1 for a different absent pack, got $rc"
+
+# --- Case E: usage errors -> exit 2 -------------------------------------------
+rc="$(run_check)"
+[[ "$rc" == "2" ]] || fail "Case E: expected exit 2 with no pack name, got $rc"
+rc="$(run_check one two)"
+[[ "$rc" == "2" ]] || fail "Case E: expected exit 2 with two pack names, got $rc"
+rc="$(run_check --bogus hq-pack-engineering)"
+[[ "$rc" == "2" ]] || fail "Case E: expected exit 2 on unknown flag, got $rc"
+
+echo "PASS: pack-installed (absent -> manifest-less dir -> installed -> usage)"

--- a/core/scripts/tests/qmd-ready.test.sh
+++ b/core/scripts/tests/qmd-ready.test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Regression coverage for core/scripts/qmd-ready.sh — the gate skills run
+# before `qmd vsearch` / `qmd query` so a fresh/constrained machine never
+# blocks on qmd's lazy ~1.3GB GGUF model download mid-session (verified
+# new-user report). Asserts:
+#   (a) not ready when qmd is missing from PATH
+#   (b) not ready when qmd is installed but models are absent / partial
+#   (c) ready when all model roles (embed, expansion, rerank) are cached,
+#       including the union across two cache dirs and both filename shapes
+#   (d) the script NEVER invokes qmd itself (an invocation could trigger
+#       the very download the gate exists to prevent)
+#   (e) usage errors exit 2
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+SCRIPT="${ROOT}/core/scripts/qmd-ready.sh"
+[[ -f "$SCRIPT" ]] || fail "qmd-ready.sh not found at $SCRIPT"
+
+# Fake qmd stub: records every invocation. The gate must never call it.
+FAKEBIN="${TMP}/bin"
+mkdir -p "$FAKEBIN"
+cat > "${FAKEBIN}/qmd" <<STUB
+#!/bin/sh
+echo "invoked \$*" >> "${TMP}/qmd-invocations.log"
+exit 0
+STUB
+chmod +x "${FAKEBIN}/qmd"
+
+DIR_A="${TMP}/models-a"
+DIR_B="${TMP}/models-b"
+mkdir -p "$DIR_A" "$DIR_B"
+
+# Isolated PATH (system utils, no real qmd) + isolated model dirs for all cases.
+BASE_PATH="/usr/bin:/bin"
+MODEL_DIRS="${DIR_A}:${DIR_B}"
+
+run_gate() { # run_gate <with_qmd:0|1> [args...] -> echoes exit code
+  local with_qmd="$1"; shift
+  local path="$BASE_PATH"
+  [[ "$with_qmd" == "1" ]] && path="${FAKEBIN}:${BASE_PATH}"
+  local rc=0
+  PATH="$path" QMD_READY_MODEL_DIRS="$MODEL_DIRS" bash "$SCRIPT" "$@" > "${TMP}/out.log" 2>&1 || rc=$?
+  echo "$rc"
+}
+
+# --- Case A: qmd not installed -> exit 1, explain says so -------------------
+if command -v /usr/bin/qmd >/dev/null 2>&1 || command -v /bin/qmd >/dev/null 2>&1; then
+  echo "SKIP-CASE-A: a real qmd exists in /usr/bin or /bin on this machine"
+else
+  rc="$(run_gate 0 --explain)"
+  [[ "$rc" == "1" ]] || fail "Case A: expected exit 1 without qmd, got $rc"
+  grep -qi "not installed" "${TMP}/out.log" || fail "Case A: --explain should mention qmd is not installed, got: $(cat "${TMP}/out.log")"
+fi
+
+# --- Case B: qmd installed, no models cached -> exit 1 ----------------------
+rc="$(run_gate 1 --explain)"
+[[ "$rc" == "1" ]] || fail "Case B: expected exit 1 with empty model dirs, got $rc"
+grep -qi "query-expansion" "${TMP}/out.log" || fail "Case B: --explain should list the missing query-expansion model, got: $(cat "${TMP}/out.log")"
+
+# --- Case C: partial cache (embedding only) -> still exit 1 -----------------
+# hf_-prefixed shape (as in ~/.cache/qmd/models on qmd 2.x)
+touch "${DIR_A}/hf_ggml-org_embeddinggemma-300M-Q8_0.gguf"
+rc="$(run_gate 1 --explain)"
+[[ "$rc" == "1" ]] || fail "Case C: expected exit 1 with only the embedding model cached, got $rc"
+grep -qi "query-expansion" "${TMP}/out.log" || fail "Case C: --explain should still list query-expansion as missing"
+grep -qi "rerank" "${TMP}/out.log" || fail "Case C: --explain should still list reranker as missing"
+
+# --- Case D: all roles cached across BOTH dirs and BOTH name shapes -> 0 ----
+# bare shape (as in ~/Library/Caches/qmd/models) in dir B for the other roles
+touch "${DIR_B}/qwen3-reranker-0.6b-q8_0.gguf"
+touch "${DIR_B}/hf_tobil_qmd-query-expansion-1.7B-q4_k_m.gguf"
+rc="$(run_gate 1)"
+[[ "$rc" == "0" ]] || fail "Case D: expected exit 0 with all models cached, got $rc (out: $(cat "${TMP}/out.log"))"
+rc="$(run_gate 1 --explain)"
+[[ "$rc" == "0" ]] || fail "Case D: expected exit 0 with --explain too, got $rc"
+grep -qi "ready" "${TMP}/out.log" || fail "Case D: --explain should say ready"
+
+# --- Case E: the gate never invoked qmd across any case ---------------------
+[[ ! -f "${TMP}/qmd-invocations.log" ]] \
+  || fail "Case E: qmd-ready.sh invoked qmd ($(cat "${TMP}/qmd-invocations.log")) — the gate must be pure filesystem checks"
+
+# --- Case F: unknown flag -> exit 2 ------------------------------------------
+rc="$(run_gate 1 --bogus-flag)"
+[[ "$rc" == "2" ]] || fail "Case F: expected exit 2 on unknown flag, got $rc"
+
+echo "PASS: qmd-ready (missing qmd -> partial cache -> full cache union -> no qmd invocation -> usage)"


### PR DESCRIPTION
## The new-user report

A new user on a mid-tier Windows machine hit three sharp edges in a single first session:

- **A — 1.28GB download mid-session.** `/learn` dedup fired `qmd`'s semantic path, which lazily downloads a ~1.28GB embedding/query-expansion model on first use. That download blocked a live working session.
- **B — /plan took ~10 minutes for a minimal 1-story project.** Hybrid `qmd query` in Step 2 forced the same model fetch, and the skill's tail ran beads sync + auto-learn + knowledge-pulse — machinery a one-off project doesn't need.
- **C — `/run-project` dead-end.** `/plan`'s completion led with `/run-project` and `/execute-task`, which ship only in the separately-installed `hq-pack-engineering`. A starter-kit user got `Unknown command: /run-project` (DEV-1716).

## Fixes

**Search never blocks on a model download.**
- `core/scripts/qmd-ready.sh` — a pure-filesystem probe (never invokes `qmd`) that exits 0 only when qmd is installed AND its GGUF models are cached. Skills gate every semantic call behind it and drop to BM25 `qmd search` when the model isn't ready.
- `/brainstorm` Step 2 now uses the gate (was unconditional hybrid `qmd query`), matching the already-landed `/learn` and `/search` ladders.

**/plan stays on BM25 by default.**
- Step 2 knowledge + target-repo lookups use `qmd search` (BM25, no model). The heavier hybrid `qmd query` is reserved for `/deep-plan`, which gates the model. The common planning path triggers no download.

**/plan lightweight tiny-project fast path.**
- For **≤ 2 stories AND no `repoPath`**: skip auto-learn (7.5) and knowledge-pulse (7.7); skip beads sync (Step 7) when `tsx` isn't immediately available (no `npx` package fetch mid-plan).

**Pack-aware completion output (no dead-end commands).**
- `core/scripts/pack-installed.sh` probes for a pack's manifest.
- `/plan` Step 9 and its auto-checkpoint `next_steps`, plus `/startwork` Project mode and `/storyboard` spec-led handoff, now lead with the one-time install line (`hq install github:indigoai-us/hq-packages#packages/hq-pack-engineering`) when the pack is absent — instead of presenting `/run-project`/`/execute-task` as runnable.

**Setup surfaces the model download honestly.**
- `setup.sh` warms the search model as an explicit, user-visible step ("Downloading search model (~1.3GB, one time)…"), **reports** failure instead of swallowing it, and never hard-fails setup. Skippable via `HQ_SKIP_SEARCH_MODEL=1`, after which skills stay in BM25 mode automatically via `qmd-ready.sh`.

## Tests / gates

- New: `core/scripts/tests/qmd-ready.test.sh`, `core/scripts/tests/pack-installed.test.sh` — both pass; wired into `pr-checks.yml` (new `search-model-pack-gate` job).
- Directly-affected existing tests pass: `skill-command-refs.test.sh` (DEV-1716), `auto-checkpoint-planning-cmds.test.sh`.
- Lints green: `lint-skill-command-refs.sh`, `lint-install-deps.sh`.
- Full local `core/scripts/tests/*.test.sh` run: 50/51 pass. The one non-pass (`auto-acl-suggest.test.sh`) is a **pre-existing** macOS bash-3.2 "bad substitution" in an untouched test fixture (byte-identical to origin/main); it passes on CI's ubuntu bash 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)