### PR TITLE
fix: harden session handoff finalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# This is a single-writer session pointer, not mergeable text.  Treating it as
+# binary preserves the current valid value in the worktree rather than writing
+# conflict-marker bytes that consumers could mistake for a filesystem path.
+.claude/state/active-session-project merge=binary

--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,6 +1,6 @@
 version: 1
-hqVersion: "15.0.52"
-updatedAt: "2026-07-18T22:13:20Z"
+hqVersion: "15.0.53"
+updatedAt: "2026-07-20T23:51:38Z"
 # hq-core is the minimal scaffold seed. Rich add-ons ship as `@indigoai-us/hq-pack-*`
 # npm packages installed into `core/packages/` via `hq install`. See `core/packages/README.md`.
 rules:

--- a/core/scripts/handoff-finalize.sh
+++ b/core/scripts/handoff-finalize.sh
@@ -61,6 +61,10 @@ done
 # -------- changeset path extraction / validation --------
 SKIPPED_PATHS_JSON="[]"
 SAFE_STAGE_PATHS=()
+MIRROR_COMPANIES_JSON="[]"
+MIRRORED_COMPANIES=()
+MIRRORED_COMPANIES_JSON="[]"
+MIRROR_STAGE_PATHS=()
 
 record_skip() {
   local path="$1"
@@ -130,6 +134,15 @@ done < <(
   ' 2>/dev/null || true
 )
 
+# Company workspace mirrors are scoped from the already-validated changeset,
+# never from ambient repository state. A handoff can legitimately touch more
+# than one company, so preserve all unique slugs in durable thread metadata.
+MIRROR_COMPANIES_JSON=$(printf '%s\n' "${SAFE_STAGE_PATHS[@]:-}" | jq -R -s -c '
+  split("\n")
+  | [ .[] | select(length > 0) | try (capture("^companies/(?<company>[a-z][a-z0-9_-]*)/").company) ]
+  | unique
+' 2>/dev/null || printf '[]')
+
 # -------- bg git reap (if launched by caller) --------
 GIT_BG_ERRORS=""
 if [[ -f /tmp/handoff-git-bg.pid ]]; then
@@ -179,6 +192,7 @@ jq -n \
   --argjson files_touched "$FILES_TOUCHED_JSON" \
   --argjson learnings "$LEARNINGS_JSON" \
   --argjson tags "$TAGS_JSON" \
+  --argjson companies "$MIRROR_COMPANIES_JSON" \
   '{
     thread_id: $thread_id,
     version: 1,
@@ -193,8 +207,29 @@ jq -n \
     next_steps: $next_steps,
     files_touched: $files_touched,
     learnings: $learnings,
-    metadata: { title: $title, tags: $tags }
+    metadata: { title: $title, tags: $tags, company: $companies }
   }' > "$THREAD_PATH"
+
+# `handoff-finalize.sh` writes from a shell subprocess, so its thread creation
+# does not pass through editor PostToolUse hooks. Replay the installed mirror
+# hook with Bash: hooks are source files and do not require an executable bit.
+MIRROR_HOOK="$HQ_ROOT/.claude/hooks/mirror-thread-to-company.sh"
+if [[ -f "$MIRROR_HOOK" ]]; then
+  jq -n --arg file_path "$HQ_ROOT/$THREAD_PATH" \
+    '{tool_name:"Write", tool_input:{file_path:$file_path}}' | \
+    bash "$MIRROR_HOOK" >/dev/null 2>&1 || true
+fi
+while IFS= read -r company; do
+  [[ -n "$company" ]] || continue
+  if [[ -f "companies/${company}/workspace/sessions/${THREAD_ID}.json" ]]; then
+    MIRRORED_COMPANIES+=("$company")
+    MIRROR_STAGE_PATHS+=(
+      "companies/${company}/workspace/index.jsonl"
+      "companies/${company}/workspace/.gitignore"
+    )
+  fi
+done < <(jq -r '.[]' <<<"$MIRROR_COMPANIES_JSON")
+MIRRORED_COMPANIES_JSON=$(printf '%s\n' "${MIRRORED_COMPANIES[@]:-}" | jq -R -s -c 'split("\n") | map(select(length > 0))')
 
 jq -n \
   --arg thread_id "$THREAD_ID" \
@@ -263,6 +298,7 @@ fi
 HQ_COMMITTED="false"
 EXPLICIT_PATHS=(
   "${SAFE_STAGE_PATHS[@]:-}"
+  "${MIRROR_STAGE_PATHS[@]:-}"
   "workspace/threads/${THREAD_ID}.json"
   "workspace/threads/${THREAD_ID}.changeset.json"
   "workspace/threads/handoff.json"
@@ -323,6 +359,7 @@ jq -n \
   --arg commit_after_finalize "$COMMIT_AFTER" \
   --arg next_command "$NEXT_COMMAND" \
   --argjson clipboard_copied "$CLIPBOARD_COPIED" \
+  --argjson mirror_companies "$MIRRORED_COMPANIES_JSON" \
   '{
     thread_id: $thread_id,
     thread_path: $thread_path,
@@ -337,5 +374,6 @@ jq -n \
     qmd_pid: $qmd_pid,
     git_bg_errors: $git_bg_errors,
     next_command: $next_command,
-    clipboard_copied: $clipboard_copied
+    clipboard_copied: $clipboard_copied,
+    mirror_companies: $mirror_companies
   }'

--- a/core/scripts/handoff-post.sh
+++ b/core/scripts/handoff-post.sh
@@ -93,6 +93,24 @@ else
   log "work-mesh-close: skipped (hook absent)"
 fi
 
+# --- 3c. Push company handoff mirrors promptly (best effort) ---
+# Session snapshots are intentionally gitignored, so a completed mirror needs
+# the sync client to make the handoff available to a second device. Trust only
+# the finalizer's lowercase company-slug metadata before constructing a path.
+if [[ -n "$THREAD_PATH" && -f "$THREAD_PATH" ]] && command -v hq >/dev/null 2>&1; then
+  while IFS= read -r company; do
+    [[ "$company" =~ ^[a-z][a-z0-9_-]*$ ]] || continue
+    [[ -d "$HQ_ROOT/companies/$company/workspace" ]] || continue
+    if hq sync push "companies/$company/workspace" >>"$LOG_MAIN" 2>&1; then
+      log "workspace-sync: pushed companies/$company/workspace"
+    else
+      log "workspace-sync: failed companies/$company/workspace"
+    fi
+  done < <(jq -r '.metadata.company // empty | if type == "array" then .[] else . end' "$THREAD_PATH" 2>/dev/null || true)
+elif [[ -n "$THREAD_PATH" && -f "$THREAD_PATH" ]]; then
+  log "workspace-sync: skipped (hq CLI unavailable)"
+fi
+
 # --- 4. qmd reindex (background, fire-and-forget) ---
 if command -v qmd >/dev/null 2>&1; then
   nohup bash -c 'qmd cleanup 2>/dev/null; qmd update 2>/dev/null && qmd embed 2>/dev/null' \

--- a/core/scripts/session-project.sh
+++ b/core/scripts/session-project.sh
@@ -234,6 +234,26 @@ function setActivePointer(projectDir) {
   fs.writeFileSync(path.join(state, "active-session-project"), String(projectDir) + "\n");
 }
 
+function readActivePointer(pointer) {
+  let raw;
+  try { raw = fs.readFileSync(pointer, "utf8"); } catch (e) { return null; }
+
+  // This pointer is a one-line project directory, not arbitrary file content.
+  // In particular, never reinterpret merge conflict markers as directory names.
+  const match = raw.match(/^([^\r\n]+)(?:\r?\n)?$/);
+  if (!match || /<<<<<<<|=======|>>>>>>>/.test(match[1])) return null;
+
+  const projectDir = path.resolve(HQ_ROOT, match[1]);
+  const rel = path.relative(HQ_ROOT, projectDir);
+  const parts = rel.split(path.sep).filter(Boolean);
+  const isPersonalProject = parts.length >= 3 && parts[0] === "personal" && parts[1] === "projects";
+  const isCompanyProject = parts.length >= 4 && parts[0] === "companies" && parts[2] === "projects";
+  if (rel === "" || rel === ".." || rel.startsWith(".." + path.sep) || path.isAbsolute(rel) ||
+      (!isPersonalProject && !isCompanyProject)) return null;
+
+  return projectDir;
+}
+
 function ensureProject(args) {
   const query = [args.title || "", args.prompt || ""].join(" ").trim();
   let reuse = null;
@@ -293,7 +313,11 @@ function resolveProjectDir(project, requiredMsg) {
   if (project) {
     projectDir = path.join(HQ_ROOT, project);
   } else if (fs.existsSync(pointer)) {
-    projectDir = fs.readFileSync(pointer, "utf8").trim();
+    projectDir = readActivePointer(pointer);
+    if (!projectDir) {
+      process.stderr.write("session-project: invalid active project pointer\n");
+      process.exit(2);
+    }
   } else if (requiredMsg) {
     process.stderr.write(requiredMsg + "\n");
     process.exit(1);

--- a/core/scripts/tests/handoff-finalize-smoke.sh
+++ b/core/scripts/tests/handoff-finalize-smoke.sh
@@ -19,11 +19,14 @@ assert_eq() {
 
 cp "$SRC_ROOT/scripts/handoff-finalize.sh" "$TMP_ROOT/handoff-finalize.sh"
 cp "$SRC_ROOT/scripts/hq-status-summary.sh" "$TMP_ROOT/hq-status-summary.sh"
+cp "$SRC_ROOT/../.claude/hooks/mirror-thread-to-company.sh" "$TMP_ROOT/mirror-thread-to-company.sh"
 
-mkdir -p "$TMP_ROOT/repo/core/scripts" "$TMP_ROOT/repo/workspace/baseline" "$TMP_ROOT/repo/workspace/threads" "$TMP_ROOT/repo/workspace/orchestrator"
+mkdir -p "$TMP_ROOT/repo/core/scripts" "$TMP_ROOT/repo/.claude/hooks" "$TMP_ROOT/repo/workspace/baseline" "$TMP_ROOT/repo/workspace/threads" "$TMP_ROOT/repo/workspace/orchestrator"
 cp "$TMP_ROOT/handoff-finalize.sh" "$TMP_ROOT/repo/core/scripts/handoff-finalize.sh"
 cp "$TMP_ROOT/hq-status-summary.sh" "$TMP_ROOT/repo/core/scripts/hq-status-summary.sh"
+cp "$TMP_ROOT/mirror-thread-to-company.sh" "$TMP_ROOT/repo/.claude/hooks/mirror-thread-to-company.sh"
 chmod +x "$TMP_ROOT/repo/core/scripts/"*.sh
+chmod -x "$TMP_ROOT/repo/.claude/hooks/mirror-thread-to-company.sh"
 
 cat > "$TMP_ROOT/repo/core/scripts/rebuild-threads-index.sh" <<'SH'
 #!/usr/bin/env bash
@@ -151,5 +154,29 @@ empty_changeset=$(jq -r '.changeset_path' <<<"$empty_out")
 [[ -f "$empty_changeset" ]] || fail "empty changeset file missing"
 assert_eq "$(jq -r '.staged_paths | length' "$empty_changeset")" "0" "empty changeset has zero staged_paths"
 
+# Regression: a company-scoped handoff mirrors even when the helper lacks an
+# executable bit. The finalizer runs it through Bash because a shell hook is
+# not an executable contract.
+mkdir -p companies/winks/projects/offer
+echo "offer" > companies/winks/projects/offer/README.md
+[[ ! -x .claude/hooks/mirror-thread-to-company.sh ]] || fail "mirror hook unexpectedly executable"
+mirror_out=$(bash core/scripts/handoff-finalize.sh \
+  --title "Handoff: Winks offer" \
+  --summary "Mirror handoff across devices" \
+  --message "Mirror handoff" \
+  --next-steps-json '[]' \
+  --files-touched-json '["companies/winks/projects/offer/README.md"]' \
+  --learnings-json '[]' \
+  --tags-json '["test"]' \
+  --slug "winks-offer")
+mirror_thread_path=$(jq -r '.thread_path' <<<"$mirror_out")
+mirror_thread_id=$(jq -r '.thread_id' <<<"$mirror_out")
+assert_eq "$(jq -c '.mirror_companies' <<<"$mirror_out")" '["winks"]' "mirrored company output"
+jq -e '.metadata.company == ["winks"]' "$mirror_thread_path" >/dev/null \
+  || fail "handoff metadata omitted touched company"
+[[ -f "companies/winks/workspace/sessions/${mirror_thread_id}.json" ]] \
+  || fail "non-executable mirror hook was not replayed"
+git show "HEAD:companies/winks/workspace/index.jsonl" | grep -q "${mirror_thread_id}" \
+  || fail "mirror index was not committed with handoff"
 
 echo "handoff-finalize smoke: ok"

--- a/core/scripts/tests/handoff-post-no-claude.test.sh
+++ b/core/scripts/tests/handoff-post-no-claude.test.sh
@@ -12,7 +12,7 @@ fail() {
   exit 1
 }
 
-mkdir -p "$TMP_ROOT/repo/core/scripts" "$TMP_ROOT/repo/workspace/threads" "$TMP_ROOT/bin" "$TMP_ROOT/logs"
+mkdir -p "$TMP_ROOT/repo/core/scripts" "$TMP_ROOT/repo/workspace/threads" "$TMP_ROOT/repo/companies/acme/workspace" "$TMP_ROOT/bin" "$TMP_ROOT/logs"
 cp "$SRC_ROOT/scripts/handoff-post.sh" "$TMP_ROOT/repo/core/scripts/handoff-post.sh"
 chmod +x "$TMP_ROOT/repo/core/scripts/handoff-post.sh"
 
@@ -39,11 +39,18 @@ exit 42
 SH
 chmod +x "$TMP_ROOT/bin/claude"
 
+cat > "$TMP_ROOT/bin/hq" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$HQ_SYNC_SENTINEL"
+SH
+chmod +x "$TMP_ROOT/bin/hq"
+
 cat > "$TMP_ROOT/repo/workspace/threads/T-test.json" <<'JSON'
 {
   "files_touched": [
     "companies/acme/knowledge/release-note.md"
-  ]
+  ],
+  "metadata": {"company": ["acme"]}
 }
 JSON
 cat > "$TMP_ROOT/learnings.json" <<'JSON'
@@ -55,12 +62,15 @@ JSON
 (
   cd "$TMP_ROOT/repo"
   CLAUDE_SENTINEL="$TMP_ROOT/claude-called" \
+  HQ_SYNC_SENTINEL="$TMP_ROOT/hq-sync-called" \
   HANDOFF_LOG_DIR="$TMP_ROOT/logs" \
   PATH="$TMP_ROOT/bin:/usr/bin:/bin" \
     bash core/scripts/handoff-post.sh workspace/threads/T-test.json "$TMP_ROOT/learnings.json"
 )
 
 [[ ! -e "$TMP_ROOT/claude-called" ]] || fail "handoff-post invoked claude"
+grep -qx 'sync push companies/acme/workspace' "$TMP_ROOT/hq-sync-called" \
+  || fail "handoff-post did not push the mirrored company workspace"
 grep -q "learn: eligible and pending runtime dispatch" "$TMP_ROOT/logs/handoff-post.log" \
   || fail "eligible learnings were not logged as pending"
 grep -q "document-release: eligible and pending runtime dispatch" "$TMP_ROOT/logs/handoff-post.log" \

--- a/core/scripts/tests/session-project.test.sh
+++ b/core/scripts/tests/session-project.test.sh
@@ -66,4 +66,19 @@ plans = data.get("metadata", {}).get("nativePlans", [])
 assert plans and plans[-1]["path"].endswith("-native-plan.md")
 PY
 
+# Regression: a conflicted pointer is not a project path. It must fail closed
+# rather than creating a directory tree whose names contain merge markers.
+mkdir -p "$TMP/.claude/state"
+printf '<<<<<<< HEAD\npersonal/projects/one\n=======\npersonal/projects/two\n>>>>>>> topic\n' \
+  > "$TMP/.claude/state/active-session-project"
+set +e
+bad_pointer_out=$(printf '## Plan\n' | HQ_ROOT="$TMP" "$HELPER" ingest-plan 2>&1)
+bad_pointer_status=$?
+set -e
+[[ "$bad_pointer_status" -ne 0 ]] || fail "conflicted active pointer was accepted"
+assert_contains "$bad_pointer_out" "invalid active project pointer" "conflicted pointer rejection"
+[[ ! -e "$TMP/<<<<<<< HEAD" ]] || fail "conflicted pointer created a filesystem path"
+grep -qxF '.claude/state/active-session-project merge=binary' "$ROOT/.gitattributes" \
+  || fail "active project pointer lacks binary merge protection"
+
 echo "session-project smoke: ok"


### PR DESCRIPTION
## Summary
- reject malformed or conflict-marked active project pointers before they become filesystem paths
- protect the pointer from text conflict-marker contents and replay company handoff mirroring through Bash
- push completed company workspace mirrors best-effort for cross-device availability

## Root cause
The project pointer was treated as arbitrary path content, and shell-generated handoff threads bypassed the editor hook that performs company mirroring.

## Validation
- `bash core/scripts/tests/session-project.test.sh`
- `bash core/scripts/tests/auto-session-project.test.sh`
- `bash core/scripts/tests/handoff-finalize-smoke.sh`
- `bash core/scripts/tests/handoff-post-no-claude.test.sh`
- `bash core/scripts/tests/handoff-followups-runtime.test.sh`
- `bash core/scripts/tests/hooks-heredoc-syntax.test.sh`
- `bash -n` on changed scripts/tests and `git diff --check`

Pre-landing review: no findings.