### PR TITLE
fix(setup,hq-sync): stop telling invited members they are solo

### DIFF
--- a/.claude/skills/hq-sync/SKILL.md
+++ b/.claude/skills/hq-sync/SKILL.md
@@ -54,6 +54,8 @@ the user:
 - `{"type":"conflict", path, direction, resolution}` → "⚠️ Conflict: {path} ({direction}) — {resolution}"
 - `{"type":"complete", company, filesDownloaded, filesUploaded, conflicts, ...}` → "✓ {company}: {filesDownloaded}↓ {filesUploaded}↑ {conflicts}⚠"
 - `{"type":"all-complete", companiesAttempted, conflictPaths, errors}` → final summary
+- `{"type":"setup-needed", reason, pendingInviteCount?}` → the run could not
+  proceed. NOT a silent success — see Step 5b.
 
 ### Step 4 — Final summary
 
@@ -132,13 +134,18 @@ fi
 # avoids ${PIPESTATUS[0]} (bash-only) and ${pipestatus[1]} (zsh-only, 1-based).
 echo "Spawning hq-sync-runner (this is the same engine the HQ Desktop App uses)..."
 output_file="$(mktemp)"
+# Keep stderr in its own file. Folding it into stdout with `2>&1` left the
+# runner's diagnostics (claim-dance skips, manifest reconciliation) buried in
+# the ndjson stream where nobody read them — the failures that make a joiner
+# look solo were being reported and then lost.
+err_file="$(mktemp)"
 set +e
 set -o pipefail 2>/dev/null || true
 npx -y --package=@indigoai-us/hq-cloud@latest hq-sync-runner \
   --companies \
   --direction "$direction" \
   --on-conflict "$on_conflict" \
-  --hq-root "$hq_root" 2>&1 | tee "$output_file"
+  --hq-root "$hq_root" 2>"$err_file" | tee "$output_file"
 # zsh reserves $status (mirrors $?), so we use cli_status to avoid
 # `read-only variable: status` errors when the slash command runs under zsh.
 cli_status=$?
@@ -168,6 +175,61 @@ if [ -n "$final_event" ]; then
     echo ""
     echo "Run /resolve-conflicts to walk them interactively."
   fi
+fi
+
+# Step 5b: setup-needed. The runner exits 0 here on purpose (a non-zero exit
+# would make the watch loop report spurious crashes), so without this branch a
+# user who is blocked sees a silent, successful-looking run.
+setup_event="$(grep -E '^\{"type":"setup-needed"' "$output_file" | tail -1 || true)"
+if [ -n "$setup_event" ]; then
+  reason=$(printf '%s' "$setup_event" | jq -r '.reason // "unknown"')
+  pending=$(printf '%s' "$setup_event" | jq -r '.pendingInviteCount // 0')
+
+  echo ""
+  echo "=== Sync could not complete ==="
+  if [ "$pending" -gt 0 ]; then
+    echo "You have $pending invite(s) waiting to be accepted — that is why no"
+    echo "company synced. You are NOT solo."
+    echo ""
+    echo "Run: /accept <link-or-token>"
+    echo "Then re-run /hq-sync."
+  else
+    case "$reason" in
+      no-memberships)
+        echo "You are signed in, but you do not belong to any cloud company yet."
+        echo "If you were expecting an invite, ask whoever invited you to re-send"
+        echo "it, then run /accept <link-or-token>."
+        ;;
+      no-person-entity)
+        echo "You are signed in, but you have no personal entity to sync into."
+        echo "This usually means a legacy magic-link invite that still needs"
+        echo "redeeming: /accept <link-or-token>"
+        ;;
+      *)
+        echo "The runner reported it could not proceed, without a reason"
+        echo "(reason: $reason). This is usually an older runner. Try"
+        echo "/accept <link-or-token> if you are expecting an invite."
+        ;;
+    esac
+  fi
+fi
+
+# Step 5c: neither event. Say so — a run that reports nothing is not a success,
+# and silently treating it as one is how a broken sync passes for a clean one.
+if [ -z "${final_event:-}" ] && [ -z "${setup_event:-}" ]; then
+  echo ""
+  echo "=== Sync finished without a final status ==="
+  echo "The runner emitted neither all-complete nor setup-needed (exit"
+  echo "$cli_status). Treat this as an incomplete sync, not a clean one."
+fi
+
+# Step 5d: surface the runner's diagnostics. These are the breadcrumbs for
+# "why did nothing land" — claim-dance skips, manifest reconciliation, and
+# activeCompany seeding all report here.
+if [ -s "$err_file" ]; then
+  echo ""
+  echo "=== Runner diagnostics ==="
+  cat "$err_file"
 fi
 
 # Step 6: reindex qmd so freshly-synced knowledge is searchable immediately.

--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -127,23 +127,58 @@ Once signed in, run a full sync via the `/hq-sync` skill (engine:
 the claim dance — auto-accepting any email-keyed pending invites — and pulls
 every cloud company the user belongs to.
 
-- If the sync-runner emits `setup-needed` (pending invites but no person entity
-  yet), the user likely has a **legacy magic-link** invite — point them to
+The runner emits `setup-needed` when a run cannot proceed. It carries a `reason`
+and, when relevant, a `pendingInviteCount` — read both and act on them. Do NOT
+fall through to the solo path on a bare `setup-needed`:
+
+- `reason: "no-memberships"` with `pendingInviteCount > 0` — the user has an
+  invite that has not been accepted. Say so, and tell them to run
+  `/accept <link-or-token>`, then re-run sync. This is the single most common
+  reason someone is wrongly told they are solo.
+- `reason: "no-memberships"` with no pending invites — genuinely no company yet.
+  The solo path is correct here.
+- `reason: "no-person-entity"` — signed in, but there is no personal entity to
+  sync into. Usually a **legacy magic-link** invite; point them to
   `/accept <link-or-token>` to redeem it, then re-run sync.
-- If sync errors (network, no membership), report it plainly and continue — a
-  solo HQ has nothing to pull.
+- If sync errors (network, transport), report it plainly and continue.
+
+An older runner emits `setup-needed` with no `reason` at all. Treat that as
+"unknown — do not conclude solo", and offer `/accept` rather than asserting the
+user has no team.
 
 ### 3. Report what landed
 
-After sync, read the now-present companies and state them plainly:
+**Membership is the source of truth here, not the manifest file.** A newly
+invited member's `companies/manifest.yaml` arrives as the stock empty template
+synced from their personal vault, so grepping it reports "solo" for someone who
+demonstrably belongs to a company. That is the exact bug this step exists to
+avoid re-introducing.
+
+Resolve the company list in this order:
+
+1. **The runner's `fanout-plan` event** from the sync you just ran. It lists
+   every company target the run resolved, with slug and name. This is free —
+   you already have it.
+2. **`GET /membership/me`** via the vault client, if you need to resolve
+   membership without a sync in hand.
+3. **The manifest grep, fallback only** — use it when the API is unreachable,
+   and say that the answer is local-only:
 
 ```bash
 grep -E "^  [a-z0-9-]+:" companies/manifest.yaml 2>/dev/null | sed -E 's/^  ([a-z0-9-]+):.*/\1/'
 ```
 
-- Cloud companies present → "You're connected and synced. You're in: {names}."
-- None → "You're signed in. No cloud companies yet — you're solo for now, that's
-  fine."
+Then report:
+
+- Companies resolved → "You're connected and synced. You're in: {names}." Name
+  the companies. A user who was just told they are on a team and cannot see
+  which one has not actually been told anything.
+- API says companies exist but the manifest grep disagrees → report the API
+  answer, and note that local routing has been repaired (the sync runner
+  reconciles the manifest entry and seeds `activeCompany` on the way through;
+  a freshly written manifest propagates on the NEXT sync).
+- Nothing resolved, and no pending invites → "You're signed in. No cloud
+  companies yet — you're solo for now, that's fine."
 
 Keep Phase 0c to a few plain lines; the heavy lifting is the reused skills.
 
@@ -670,7 +705,13 @@ hq secrets generate-link <SECRET_PATH> [--personal | --company {slug}]
 
 ### 5c. Team / cloud detection (shapes the strongest recommendation)
 
-Silently check whether this is a team / cloud-backed context:
+Use the membership list already resolved in Phase 0c step 3 — do not re-derive
+this from a manifest grep. If the user has at least one active company
+membership, this is a team / cloud context, full stop. A joiner whose manifest
+has not caught up yet is still on a team.
+
+Only when membership could not be resolved at all (API unreachable), fall back
+to the local signals:
 
 ```bash
 grep -l 'cloud' companies/*/manifest.yaml 2>/dev/null | head -1
@@ -710,6 +751,13 @@ to the launch list, do NOT run inline). See the Rules for the inline/handoff lin
   - *Do now:* `/newcompany {slug}` (new — lightweight scaffold) or `/onboard`
     (join existing). If Phase 1.6 was skipped and they're an existing Claude
     user, re-offer `/import-claude` here to hydrate the skeleton.
+  - **Never offer `/newcompany` for a slug the user already has an active
+    membership in.** Check the membership list resolved in Phase 0c step 3
+    first. Routing a joiner to `/newcompany` for a company they already belong
+    to is what produced the duplicate companies this flow exists to prevent —
+    they end up owning a second, empty company with the same name as the real
+    one. If the slug matches an existing membership, the answer is "you're
+    already in that one" plus `/startwork {slug}`, not a scaffold.
   - *Recommend:* first deliverable → `/brainstorm` / `/plan` / `/startwork {slug}`.
     If team/cloud, fold in the shareable-asset + `/deploy` recommendation.
 - **Personal projects** → "What's the first thing you want a worker to do?"

--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,6 +1,6 @@
 version: 1
-hqVersion: "15.0.53"
-updatedAt: "2026-07-21T06:51:40Z"
+hqVersion: "15.0.54"
+updatedAt: "2026-07-21T16:20:00Z"
 # hq-core is the minimal scaffold seed. Rich add-ons ship as `@indigoai-us/hq-pack-*`
 # npm packages installed into `core/packages/` via `hq install`. See `core/packages/README.md`.
 rules:


### PR DESCRIPTION
Companion to indigoai-us/hq-cloud#214. That PR fixes the sync engine; this one fixes the two skills users actually run. A local-only edit under the HQ root reaches nobody — `/update-hq` distributes from here.

## The bug

Both skills concluded "you have no team" from local file state that a joiner does not have yet.

`companies/manifest.yaml` is written only by the company-*creation* path. A newly invited member receives it as the stock empty template synced from their personal vault. Grepping it reports solo for someone who demonstrably belongs to a company — and then routes them to `/newcompany`, which is how affected users ended up owning a duplicate, empty copy of the company they had already joined.

## `/setup`

- **Phase 0c step 3** resolves companies from live membership — the runner's `fanout-plan` event first, `GET /membership/me` second — and demotes the manifest grep to a fallback used only when the API is unreachable, with the answer labelled local-only.
- When the API says companies exist but the manifest disagrees, it reports the API answer and notes that local routing was repaired.
- `setup-needed` is no longer a silent fall-through to the solo path. Each reason gets its own instruction, and a pending invite produces an explicit `/accept <link-or-token>` instead of "you're solo for now, that's fine".
- A reason-less `setup-needed` from an older runner is treated as "unknown — do not conclude solo", rather than assuming the user has no team.
- **Phase 5c** reuses the resolved membership list instead of re-deriving team/cloud status from `grep -l 'cloud' companies/*/manifest.yaml`.
- **Phase 5d** must not offer `/newcompany` for a slug the user already has an active membership in. That specific misroute is what produced the duplicate companies.

## `/hq-sync`

- Parses `setup-needed` alongside `all-complete` and prints the reason in plain language, with the `/accept` instruction when invites are pending. The runner exits 0 here deliberately — a non-zero exit would make the watch loop report spurious crashes — so without this branch the user saw a silent, successful-looking run while being blocked.
- A run emitting **neither** event now says so explicitly instead of printing nothing. Silence was reading as success.
- Runner stderr moves out of `2>&1` into its own file and is surfaced under a `Runner diagnostics` heading. Folded into the ndjson stream it was technically visible and practically lost — including the claim-dance skips that explain why nothing landed.
- Exit-code handling is unchanged.

## Verification

Shell blocks checked with `bash -n` and `zsh -n`. Event parsing exercised against the exact shapes emitted by the companion PR (`{"type":"setup-needed","reason":"no-memberships","pendingInviteCount":2}` and the no-count variant), confirming the `/accept` branch fires on the first and the per-reason branch on the second.

These are prompt/skill files, so there is no test suite to run here. The behaviour they depend on is covered by the end-to-end regression in the companion PR.

## Merge order

Land indigoai-us/hq-cloud#214 first. `/setup` reads `reason` and `pendingInviteCount` off the `setup-needed` event, and the reason-less fallback path above is what keeps this safe in the interim if the order slips.

https://claude.ai/code/session_012psMN7GJQC46PimjmwHA3K