### PR TITLE
fix(work-mesh): tolerate realtime topics this client does not know yet

### DIFF
--- a/core/scripts/__tests__/work-mesh.test.mjs
+++ b/core/scripts/__tests__/work-mesh.test.mjs
@@ -507,3 +507,56 @@ test("project rollups remain linear with 10,000 distinct owners on one project",
     elapsedMs: Number(elapsedMs.toFixed(2)),
   }));
 });
+
+/**
+ * The topics map must tolerate topics this client does not know yet.
+ *
+ * `parseTopics` used to require an EXACT key count, which froze the map: the
+ * moment the server learned to advertise a new topic — `meeting`, for live
+ * meeting participation — every deployed watcher would throw "topics are
+ * invalid" and lose realtime outright. The response is fetched over TLS from
+ * our own authenticated API and is documented as additive, so rejecting unknown
+ * keys bought nothing while coupling every future server-side topic to a client
+ * rollout.
+ */
+test("realtime v2 tolerates a topic key this client does not know", () => {
+  const config = parseRealtimeV2Config(
+    v2({ topics: { ...topics(), meeting: `hq/${PERSON}/meeting` } }),
+  );
+  assert.equal(config.topics.work, topics().work);
+});
+
+test("realtime v2 tolerates several unknown topic keys at once", () => {
+  const config = parseRealtimeV2Config(
+    v2({ topics: { ...topics(), meeting: "a", future: "b", another: "c" } }),
+  );
+  assert.equal(config.topics.dm, topics().dm);
+});
+
+test("realtime v2 does not surface unknown topics to callers", () => {
+  const config = parseRealtimeV2Config(
+    v2({ topics: { ...topics(), meeting: `hq/${PERSON}/meeting` } }),
+  );
+  assert.deepEqual(Object.keys(config.topics).sort(), [
+    "dm",
+    "notifications",
+    "sessions",
+    "work",
+  ]);
+});
+
+test("realtime v1 tolerates unknown topic keys too (shared parser)", () => {
+  const config = parseRealtimeV1Config(
+    v1({ topics: { ...topics(), meeting: `hq/${PERSON}/meeting` } }),
+  );
+  assert.equal(config.topics.work, topics().work);
+});
+
+test("realtime v2 still rejects a topics map missing a key we read", () => {
+  const { work: _dropped, ...withoutWork } = topics();
+  assert.throws(() => parseRealtimeV2Config(v2({ topics: withoutWork })), /topics are invalid/);
+});
+
+test("realtime v2 still rejects a non-object topics value", () => {
+  assert.throws(() => parseRealtimeV2Config(v2({ topics: "nope" })), /topics are invalid/);
+});

--- a/core/scripts/work-mesh.mjs
+++ b/core/scripts/work-mesh.mjs
@@ -967,8 +967,22 @@ function parseCredentials(value, version) {
   return parsed;
 }
 
+/**
+ * Validate the topics map WITHOUT rejecting keys we do not know yet.
+ *
+ * This used to require an exact key count, which made the map effectively
+ * frozen: the response comes from our own authenticated server and is
+ * documented as additive, so any new topic it learns to advertise would make
+ * every deployed watcher throw "topics are invalid" and lose realtime outright.
+ * Rejecting unknown keys bought nothing — an attacker cannot add keys to a
+ * response we fetched over TLS from our own API — while coupling every future
+ * server-side topic to a client rollout.
+ *
+ * So: require the keys we actually read, validate those, and ignore the rest.
+ * Only known keys are returned, so an unexpected key can never reach a caller.
+ */
 function parseTopics(value, version) {
-  if (!hasExactKeys(value, REALTIME_TOPIC_KEYS)) {
+  if (!isRecord(value) || !REALTIME_TOPIC_KEYS.every((key) => Object.hasOwn(value, key))) {
     throw new WorkMeshContractError(`realtime v${version} topics are invalid`);
   }
   return Object.fromEntries(REALTIME_TOPIC_KEYS.map((key) => [key, requiredString(value[key], 256, `realtime ${key} topic`)]));


### PR DESCRIPTION
Opened against the wrong repository. hq-core changes flow through the staging repo and are promoted from there; this bypassed that pipeline.

Closing without merge. No action needed.
