### PR TITLE
fix(scripts): add export-skill-catalog wrapper for desktop Claude bootstrap

### DIFF
--- a/core/scripts/export-skill-catalog.sh
+++ b/core/scripts/export-skill-catalog.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# export-skill-catalog.sh — print the bounded SessionStart skill catalog body.
+#
+# Thin wrapper around session-skill-catalog.sh for CLI tools, desktop bootstrap,
+# and regression tests. Prints name + one-line description lines only.
+#
+# Usage:
+#   bash core/scripts/export-skill-catalog.sh --root <hq-root> --company <slug>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=lib/session-skill-catalog.sh
+source "$SCRIPT_DIR/lib/session-skill-catalog.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: export-skill-catalog.sh --root <hq-root> --company <slug>
+
+Builds the bounded HQ skill catalog (company scope first, then root, then
+packages) and prints the rendered markdown body on stdout.
+EOF
+}
+
+HQ_ROOT=""
+COMPANY=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --root)
+      [ "$#" -ge 2 ] || { echo "--root requires a path" >&2; usage >&2; exit 64; }
+      HQ_ROOT="$2"
+      shift 2
+      ;;
+    --company)
+      [ "$#" -ge 2 ] || { echo "--company requires a slug" >&2; usage >&2; exit 64; }
+      COMPANY="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage >&2
+      exit 64
+      ;;
+  esac
+done
+
+[ -n "$HQ_ROOT" ] || { echo "--root is required" >&2; usage >&2; exit 64; }
+[ -n "$COMPANY" ] || { echo "--company is required" >&2; usage >&2; exit 64; }
+
+HQ_ROOT="$(cd "$HQ_ROOT" && pwd -P)"
+session_skill_catalog_build "$HQ_ROOT" "$COMPANY" >/dev/null
+if [ -n "${SESSION_SKILL_CATALOG_BODY:-}" ]; then
+  printf '%s\n' "$SESSION_SKILL_CATALOG_BODY"
+else
+  printf '(no skills available)\n'
+fi

--- a/core/scripts/tests/export-skill-catalog.test.sh
+++ b/core/scripts/tests/export-skill-catalog.test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Regression tests for export-skill-catalog.sh
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+EXPORTER="$ROOT/core/scripts/export-skill-catalog.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "  ok: $*"; }
+
+write_skill() {
+  local dir="$1" name="$2" description="$3"
+  mkdir -p "$dir"
+  cat >"$dir/SKILL.md" <<EOF
+---
+name: $name
+description: $description
+---
+
+body
+EOF
+}
+
+scaffold_hq() {
+  local root="$1"
+  mkdir -p "$root/.claude/skills" "$root/companies/demo/skills" "$root/core/packages/hq-pack-engineering/skills"
+}
+
+echo "[1] company skills shadow root names in exported catalog"
+HQ="$TMP/hq-shadow"
+scaffold_hq "$HQ"
+write_skill "$HQ/companies/demo/skills/startwork" startwork "company copy"
+write_skill "$HQ/.claude/skills/startwork" startwork "root copy"
+out="$(bash "$EXPORTER" --root "$HQ" --company demo)"
+printf '%s\n' "$out" | grep -Fq '/startwork — company copy' || fail "company skill missing: $out"
+printf '%s\n' "$out" | grep -Fq 'root copy' && fail "root shadow should not appear: $out"
+pass "company precedence honored"
+
+echo "[2] root and package skills export when present"
+HQ="$TMP/hq-mix"
+scaffold_hq "$HQ"
+write_skill "$HQ/.claude/skills/handoff" handoff "wrap sessions"
+write_skill "$HQ/core/packages/hq-pack-engineering/skills/land" land "ship code"
+out="$(bash "$EXPORTER" --root "$HQ" --company demo)"
+printf '%s\n' "$out" | grep -Fq '/handoff — wrap sessions' || fail "root skill missing: $out"
+printf '%s\n' "$out" | grep -Fq '/land — ship code' || fail "package skill missing: $out"
+pass "root and package skills export"
+
+echo "[3] missing args fail clearly"
+set +e
+out_missing="$(bash "$EXPORTER" 2>&1)"
+rc=$?
+set -e
+[ "$rc" -ne 0 ] || fail "expected failure without args"
+printf '%s\n' "$out_missing" | grep -Fq -- '--root is required' || fail "missing --root message absent: $out_missing"
+pass "usage guardrails"
+
+echo "export-skill-catalog tests passed"


### PR DESCRIPTION
## Summary
- Add `core/scripts/export-skill-catalog.sh` CLI wrapper around `session-skill-catalog.sh` so desktop and shell tooling share one bounded catalog contract.
- Add regression tests in `core/scripts/tests/export-skill-catalog.test.sh`.

## Companion PR
- hq-desktop-app: https://github.com/indigoai-us/hq-desktop-app/pull/308

## Test plan
- [x] `bash core/scripts/tests/export-skill-catalog.test.sh`
- [ ] Merge with desktop PR and verify Claude Code bootstrap injects catalog from HQ root context