### PR TITLE
fix(hooks): honor core.yaml excludes in block-core-writes for launch.json

### DIFF
--- a/.claude/hooks/block-core-writes-bash.sh
+++ b/.claude/hooks/block-core-writes-bash.sh
@@ -384,9 +384,11 @@ write_op_targets_protected() {
 
 writes_to_protected() {
   local cmd="$1"
-  # Strip the two user-owned files -- they are allowed exceptions inside .claude/.
-  local stripped
-  stripped=$(echo "$cmd" | sed 's|[^[:space:]]*settings\.local\.json[^[:space:]]*||g; s|settings\.local\.json||g; s|[^[:space:]]*personal-context\.md[^[:space:]]*||g; s|personal-context\.md||g')
+  # Strip core.yaml exclude paths — machine-local artifacts are writable.
+  local stripped core_yaml="$PROJECT_DIR/core/core.yaml"
+  stripped="$(hq_bash_strip_core_yaml_exclude_tokens "$cmd" "$PROJECT_DIR" "$core_yaml")"
+  # personal-context.md is preserve_subpaths (not rules.exclude) but still writable.
+  stripped=$(echo "$stripped" | sed 's|[^[:space:]]*personal-context\.md[^[:space:]]*||g; s|personal-context\.md||g')
 
   # Absolute/live-root forms are always enforced; relative forms only outside a
   # repos/ checkout.

--- a/.claude/hooks/block-core-writes.sh
+++ b/.claude/hooks/block-core-writes.sh
@@ -28,13 +28,14 @@ fi
 
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 
-if [[ "$FILE_PATH" != /* ]]; then
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/core/scripts/hook-lib.sh"
+
+if ! hq_path_is_absolute "$FILE_PATH"; then
   FILE_PATH="$PROJECT_DIR/$FILE_PATH"
 fi
 
-. "$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/core/scripts/hook-lib.sh"
-FILE_PATH="$(hq_normpath "$FILE_PATH" 2>/dev/null || echo "$FILE_PATH")"
-PROJECT_DIR="$(hq_normpath "$PROJECT_DIR" 2>/dev/null || echo "$PROJECT_DIR")"
+FILE_PATH="$(hq_canonical_path "$FILE_PATH")"
+PROJECT_DIR="$(hq_canonical_path "$PROJECT_DIR")"
 
 CORE_DIR="$PROJECT_DIR/core"
 CLAUDE_DIR="$PROJECT_DIR/.claude"
@@ -42,8 +43,8 @@ AGENTS_DIR="$PROJECT_DIR/.agents"
 CODEX_DIR="$PROJECT_DIR/.codex"
 OBSIDIAN_DIR="$PROJECT_DIR/.obsidian"
 AGENTS_MD="$PROJECT_DIR/AGENTS.md"
-SETTINGS_LOCAL="$PROJECT_DIR/.claude/settings.local.json"
-PERSONAL_CONTEXT="$PROJECT_DIR/.claude/personal-context.md"
+SETTINGS_LOCAL="$(hq_canonical_path "$PROJECT_DIR/.claude/settings.local.json")"
+PERSONAL_CONTEXT="$(hq_canonical_path "$PROJECT_DIR/.claude/personal-context.md")"
 
 # Only concerned with protected paths.
 case "$FILE_PATH" in
@@ -76,15 +77,21 @@ if is_bypass_authorized; then
   exit 0
 fi
 
+# core/core.yaml rules.exclude — machine-local paths are always writable.
+CORE_YAML="$PROJECT_DIR/core/core.yaml"
+if hq_path_matches_core_yaml_exclude "$PROJECT_DIR" "$FILE_PATH" "$CORE_YAML"; then
+  exit 0
+fi
+
 # Specific file redirects — give a helpful pointer before the generic block.
-if [[ "$FILE_PATH" == "$PROJECT_DIR/.claude/CLAUDE.md" ]]; then
+if [[ "$FILE_PATH" == "$(hq_canonical_path "$PROJECT_DIR/.claude/CLAUDE.md")" ]]; then
   cat >&2 <<MSG
 BLOCKED: .claude/CLAUDE.md is the locked HQ charter.
   Edit personal/CLAUDE.md for your personal additions instead.
 MSG
   exit 2
 fi
-if [[ "$FILE_PATH" == "$PROJECT_DIR/.claude/settings.json" ]]; then
+if [[ "$FILE_PATH" == "$(hq_canonical_path "$PROJECT_DIR/.claude/settings.json")" ]]; then
   cat >&2 <<MSG
 BLOCKED: .claude/settings.json is locked.
   Edit .claude/settings.local.json for local overrides instead.

--- a/.claude/hooks/protect-core.sh
+++ b/.claude/hooks/protect-core.sh
@@ -158,14 +158,9 @@ norm_path() {
 }
 
 # Check exclude list first — always allowed.
-EXCLUDE_PATHS=$(yq eval '.rules.exclude[]' "$CORE_YAML" 2>/dev/null) || EXCLUDE_PATHS=""
-while IFS= read -r exc_path; do
-  [[ -z "$exc_path" ]] && continue
-  exc_abs="$(norm_path "${HQ_ROOT}/${exc_path%/}")"
-  if [[ "$FILE_PATH" == "$exc_abs" ]] || [[ "$FILE_PATH" == "$exc_abs/"* ]]; then
-    exit 0
-  fi
-done <<< "$EXCLUDE_PATHS"
+if hq_path_matches_core_yaml_exclude "$HQ_ROOT" "$FILE_PATH" "$CORE_YAML"; then
+  exit 0
+fi
 
 # Specific file redirects — give a helpful pointer before the generic block.
 CLAUDE_MD_ABS="$(norm_path "${HQ_ROOT}/.claude/CLAUDE.md")"

--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,10 +1,10 @@
 version: 1
-hqVersion: "15.0.70"
+hqVersion: "15.0.71"
 agentSessionContractVersion: 1
 # Provider adapter contract version (US-500). Must match
 # HQ_ADAPTER_CONTRACT_VERSION in core/scripts/lib/provider-adapter-version.sh.
 adapterContractVersion: "1.0.0"
-updatedAt: "2026-07-28T23:13:45Z"
+updatedAt: "2026-07-31T01:50:00Z"
 # hq-core is the minimal scaffold seed. Rich add-ons ship as `@indigoai-us/hq-pack-*`
 # npm packages installed into `core/packages/` via `hq install`. See `core/packages/README.md`.
 rules:

--- a/core/scripts/hook-lib.sh
+++ b/core/scripts/hook-lib.sh
@@ -162,6 +162,84 @@ hq_hook_session_key_from_payload() {
   hq_hook_safe_session_key "$key"
 }
 
+# hq_path_is_absolute <path>
+#   exit 0 for Unix or Windows drive-letter absolutes.
+hq_path_is_absolute() {
+  case "$1" in
+    /*|[a-zA-Z]:/*|[a-zA-Z]:\\*) return 0 ;;
+  esac
+  return 1
+}
+
+# hq_canonical_path <path>
+#   Normalize for hook comparisons. On MSYS/Git Bash, cygpath -m unifies
+#   /tmp/... and C:/Users/.../Temp/... forms of the same directory.
+hq_canonical_path() {
+  local p="$1"
+  p="$(hq_normpath "$p" 2>/dev/null || printf '%s' "$p")"
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -m "$p" 2>/dev/null || printf '%s' "$p"
+    return 0
+  fi
+  printf '%s' "$p"
+}
+
+# hq_path_matches_core_yaml_exclude <hq_root> <file_path> [<core_yaml>]
+#   exit 0 when file_path matches a core/core.yaml rules.exclude entry (file or
+#   directory prefix). Requires yq and a readable core_yaml; otherwise exit 1.
+hq_path_matches_core_yaml_exclude() {
+  local hq_root="$1"
+  local file_path="$2"
+  local core_yaml="${3:-$hq_root/core/core.yaml}"
+  local exc_path exc_abs exclude_paths
+
+  [ -n "$hq_root" ] || return 1
+  [ -n "$file_path" ] || return 1
+  [ -f "$core_yaml" ] || return 1
+  command -v yq >/dev/null 2>&1 || return 1
+
+  file_path="$(hq_canonical_path "$file_path")"
+  hq_root="$(hq_canonical_path "$hq_root")"
+
+  exclude_paths="$(yq eval '.rules.exclude[]' "$core_yaml" 2>/dev/null)" || exclude_paths=""
+  while IFS= read -r exc_path; do
+    [ -n "$exc_path" ] || continue
+    exc_abs="$(hq_normpath "${hq_root}/${exc_path%/}")"
+    case "$file_path" in
+      "$exc_abs"|"$exc_abs"/*) return 0 ;;
+    esac
+  done <<< "$exclude_paths"
+  return 1
+}
+
+# hq_bash_strip_core_yaml_exclude_tokens <command> <hq_root> [<core_yaml>]
+#   Best-effort removal of command tokens that reference rules.exclude paths.
+#   Mirrors the fixed exceptions block-core-writes-bash.sh already strips.
+hq_bash_strip_core_yaml_exclude_tokens() {
+  local cmd="$1"
+  local hq_root="$2"
+  local core_yaml="${3:-$hq_root/core/core.yaml}"
+  local exc_path base esc sed_script exclude_paths
+
+  [ -n "$cmd" ] || { printf '%s' "$cmd"; return 0; }
+  [ -f "$core_yaml" ] || { printf '%s' "$cmd"; return 0; }
+  command -v yq >/dev/null 2>&1 || { printf '%s' "$cmd"; return 0; }
+
+  sed_script=''
+  exclude_paths="$(yq eval '.rules.exclude[]' "$core_yaml" 2>/dev/null)" || exclude_paths=""
+  while IFS= read -r exc_path; do
+    [ -n "$exc_path" ] || continue
+    base="${exc_path%/}"
+    base="${base##*/}"
+    [ -n "$base" ] || continue
+    esc="$(printf '%s' "$base" | sed 's/[][\\.*^$(){}?+|]/\\&/g')"
+    sed_script="${sed_script}s|[^[:space:]]*${esc}[^[:space:]]*||g; s|${esc}||g;"
+  done <<< "$exclude_paths"
+
+  [ -n "$sed_script" ] || { printf '%s' "$cmd"; return 0; }
+  printf '%s' "$cmd" | sed "$sed_script"
+}
+
 hq_path_within_root() {
   local root="$1"
   local path="$2"

--- a/core/scripts/tests/block-core-writes-bash.test.sh
+++ b/core/scripts/tests/block-core-writes-bash.test.sh
@@ -7,7 +7,7 @@
 #   - the 2026-06-14 boundary fix: VAR=<protected path> assignments and
 #     colon-joined paths are now caught (previously slipped through because
 #     '=' / ':' were not treated as token boundaries);
-#   - .claude/settings.local.json and the durable personal context remain writable;
+#   - .claude/settings.local.json and core.yaml exclude paths remain writable;
 #   - companies/_template/ (a locked path per core.yaml) is blocked, while a
 #     real tenant dir (companies/<co>/) stays writable;
 #   - the settings.local.json HQ_BYPASS_CORE_PROTECT escape hatch still works
@@ -20,7 +20,11 @@ HOOK="$ROOT/.claude/hooks/block-core-writes-bash.sh"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
+command -v jq >/dev/null 2>&1 || { echo "SKIP: jq not available"; exit 0; }
+command -v yq >/dev/null 2>&1 || { echo "SKIP: yq not available"; exit 0; }
+
 mkdir -p "$TMP/.claude" "$TMP/core/packages/x" "$TMP/personal" "$TMP/repos/private/app" "$TMP/companies/_template/knowledge" "$TMP/companies/acme/data"
+cp "$ROOT/core/core.yaml" "$TMP/core/core.yaml"
 printf '{}' > "$TMP/.claude/settings.local.json"   # no bypass by default
 
 PASS=0
@@ -67,6 +71,8 @@ run 2 "P=/x:$TMP/core/y; cp /tmp/z \$P"      'colon-joined core path + cp blocke
 # --- Allowed: exceptions and non-protected targets -----------------------
 run 0 "echo x > $TMP/.claude/settings.local.json"  'settings.local.json writable'
 run 0 "echo x > $TMP/.claude/personal-context.md"   'personal-context.md writable'
+run 0 "echo x > $TMP/.claude/launch.json"           'launch.json writable via core.yaml exclude'
+run 0 "echo x > $TMP/.claude/scheduled-tasks/job.json" 'scheduled-tasks store writable via core.yaml exclude'
 run 0 "mv /tmp/y $TMP/repos/private/app/s"         'write into repos/ allowed'
 run 0 "mv /tmp/y $TMP/personal/p.md"               'write into personal/ allowed'
 run 0 "cat $C/s.json"                              'read-only cat of core allowed'

--- a/core/scripts/tests/block-core-writes-native-context.test.sh
+++ b/core/scripts/tests/block-core-writes-native-context.test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Regression: the update-preserved native personal context is editable without
 # opening the rest of the release-owned .claude/ tree to direct writes.
+# Also verifies core/core.yaml rules.exclude paths (launch.json, scheduled-tasks/).
 
 set -euo pipefail
 
@@ -13,9 +14,11 @@ fail() { echo "FAIL: $*" >&2; exit 1; }
 pass() { echo "  ok: $*"; }
 
 command -v jq >/dev/null 2>&1 || { echo "SKIP: jq not available"; exit 0; }
+command -v yq >/dev/null 2>&1 || { echo "SKIP: yq not available"; exit 0; }
 [ -x "$HOOK" ] || fail "hook is not executable: $HOOK"
 
 mkdir -p "$TMP/.claude" "$TMP/core"
+cp "$ROOT/core/core.yaml" "$TMP/core/core.yaml"
 printf '{}' >"$TMP/.claude/settings.local.json"
 
 run() {
@@ -28,9 +31,13 @@ run() {
   pass "$label"
 }
 
+run 0 "$TMP/.claude/launch.json" 'machine-local launch.json is writable'
+mkdir -p "$TMP/.claude/scheduled-tasks"
+run 0 "$TMP/.claude/scheduled-tasks/job.json" 'scheduled-tasks store is writable'
 run 0 "$TMP/.claude/personal-context.md" 'native personal context is writable'
 run 0 "$TMP/.claude/settings.local.json" 'machine-local settings stay writable'
 run 2 "$TMP/.claude/CLAUDE.md" 'locked charter stays protected'
+run 2 "$TMP/.claude/settings.json" 'locked settings.json stays protected'
 run 2 "$TMP/core/core.yaml" 'core stays protected'
 
 echo "PASS: block-core-writes native context exception"


### PR DESCRIPTION
## Summary
- Teach the block-core-writes hook to respect `core.yaml` exclude patterns so legitimate edits (e.g. VS Code `launch.json`) are not blocked when they match configured exclusions.

## Test plan
- [ ] Run hook regression tests for block-core-writes / core.yaml excludes
- [ ] Confirm `launch.json` under an excluded path is writable while other core paths remain protected