### PR TITLE
Single-flight handoff qmd reindex

### DIFF
--- a/.claude/audit/suppressions.yaml
+++ b/.claude/audit/suppressions.yaml
@@ -39,7 +39,7 @@
 
 - path: "core/scripts/tests/qmd-handoff-reindex.test.sh"
   scanners: [pii]
-  reason: "Disposable git-config identity in throwaway test fixtures uses an RFC 2606 reserved example.com address (test@example.com — never resolvable in DNS, no real mailbox); synthetic dead-PID integer 2147483646 for stale-owner reclaim is not a phone number; neither is real personal data."
+  reason: "Disposable git-config identity in throwaway test fixtures uses an RFC-reserved example.com disposable git identity (never a real mailbox); synthetic dead-PID integer 2147483646 for stale-owner reclaim is not a phone number; neither is real personal data."
 
 - path: "core/scripts/__tests__/work-mesh.test.mjs"
   scanners: [pii]

--- a/.claude/audit/suppressions.yaml
+++ b/.claude/audit/suppressions.yaml
@@ -39,7 +39,7 @@
 
 - path: "core/scripts/tests/qmd-handoff-reindex.test.sh"
   scanners: [pii]
-  reason: "Disposable git-config identity in throwaway test fixtures uses an RFC-reserved example.com disposable git identity (never a real mailbox); synthetic dead-PID integer 2147483646 for stale-owner reclaim is not a phone number; neither is real personal data."
+  reason: "Disposable git-config identity in throwaway test fixtures uses an RFC-reserved example.com disposable git identity (never a real mailbox); synthetic INT_MAX-adjacent dead-PID sentinel for stale-owner reclaim is not a phone number; neither is real personal data."
 
 - path: "core/scripts/__tests__/work-mesh.test.mjs"
   scanners: [pii]

--- a/.claude/audit/suppressions.yaml
+++ b/.claude/audit/suppressions.yaml
@@ -37,6 +37,10 @@
   scanners: [pii]
   reason: "Disposable git-config identity in throwaway test fixtures uses an RFC 2606 reserved .invalid address (example.invalid — never resolvable in DNS, no real mailbox); placeholder, not PII."
 
+- path: "core/scripts/tests/qmd-handoff-reindex.test.sh"
+  scanners: [pii]
+  reason: "Disposable git-config identity in throwaway test fixtures uses an RFC 2606 reserved example.com address (test@example.com — never resolvable in DNS, no real mailbox); synthetic dead-PID integer 2147483646 for stale-owner reclaim is not a phone number; neither is real personal data."
+
 - path: "core/scripts/__tests__/work-mesh.test.mjs"
   scanners: [pii]
   reason: "Work Mesh unit-test fixtures use loopback IPs, an RFC 2606 .test address, UUID-shaped IDs, and integer boundary values; none are real personal data."

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -62,7 +62,7 @@ Pass the resolved project directory that owns this session's journal. The helper
 - Regenerates thread INDEX + recent.md + orchestrator INDEX via dedicated bash scripts (`rebuild-threads-index.sh`, `rebuild-orchestrator-index.sh`) — zero Claude context
 - Commits HQ via explicit paths: thread/index files plus the validated `--files-touched-json` paths (never `git add -A`)
 - Classifies noisy HQ root status via `core/scripts/hq-status-summary.sh` so baseline local files do not become accidental handoff scope
-- Schedules single-flight qmd reindex via `qmd-handoff-reindex.sh` (shared with post; lock prevents double mutation)
+- Schedules single-flight qmd reindex via `qmd-handoff-reindex.sh` (shared with post; lock + recent-completion dedupe prevent double mutation)
 
 First write the changeset to a workspace temp file, then pass its path — never inline the changeset into `--files-touched-json`. On Windows Git Bash the OS caps a command line at ~32KB (~8KB under cmd.exe), and a large changeset rides argv through several hops (status-summary, jq) and aborts the handoff. The file form keeps it off argv. This mirrors the learnings temp-file pattern from Step 2. Use `mktemp` under `workspace/threads/.handoff-tmp/` (gitignored, exists on Git Bash — do **not** use `/tmp`, which some Windows setups lack; do **not** use a slug-only deterministic path under `workspace/threads/` — concurrent sessions collide and unignored temps flip `git.dirty`). Clean it up whether the finalizer succeeds or fails, and propagate a non-zero finalize exit status:
 
@@ -133,9 +133,9 @@ nohup bash core/scripts/handoff-post.sh \
 1. Archives threads older than 60 days into `workspace/threads/archive/YYYY-MM/` (gated once per 24h)
 2. Regenerates INDEX files again (captures any archive moves)
 3. Records eligible learn/doc-release work as pending until the handoff reports dispatch proof
-4. Schedules the same single-flight qmd reindex helper as finalize (`qmd-handoff-reindex.sh`). If finalize already owns the flight, this is a quiet no-op — not a second independent `qmd cleanup/update/embed`.
+4. Schedules the same single-flight qmd reindex helper as finalize (`qmd-handoff-reindex.sh`). If finalize already owns the flight, or just finished within the helper's short dedupe window, this is a quiet no-op — not a second independent `qmd cleanup/update/embed`.
 
-Logs land at `/tmp/handoff-post.log` and `/tmp/qmd-handoff.log` (one bounded qmd log; only the lock winner truncates it). If the session dies while the post-script runs, the script keeps going — `handoff.json` is already valid.
+Logs land at `/tmp/handoff-post.log` and `/tmp/qmd-handoff.log` (one bounded qmd log; only the lock winner truncates/writes it, then enforces a modest byte cap). If the session dies while the post-script runs, the script keeps going — `handoff.json` is already valid.
 
 ### 4.5 Dispatch runtime-appropriate model follow-ups
 

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -62,7 +62,7 @@ Pass the resolved project directory that owns this session's journal. The helper
 - Regenerates thread INDEX + recent.md + orchestrator INDEX via dedicated bash scripts (`rebuild-threads-index.sh`, `rebuild-orchestrator-index.sh`) — zero Claude context
 - Commits HQ via explicit paths: thread/index files plus the validated `--files-touched-json` paths (never `git add -A`)
 - Classifies noisy HQ root status via `core/scripts/hq-status-summary.sh` so baseline local files do not become accidental handoff scope
-- Launches qmd reindex fire-and-forget
+- Schedules single-flight qmd reindex via `qmd-handoff-reindex.sh` (shared with post; lock prevents double mutation)
 
 First write the changeset to a workspace temp file, then pass its path — never inline the changeset into `--files-touched-json`. On Windows Git Bash the OS caps a command line at ~32KB (~8KB under cmd.exe), and a large changeset rides argv through several hops (status-summary, jq) and aborts the handoff. The file form keeps it off argv. This mirrors the learnings temp-file pattern from Step 2. Use `mktemp` under `workspace/threads/.handoff-tmp/` (gitignored, exists on Git Bash — do **not** use `/tmp`, which some Windows setups lack; do **not** use a slug-only deterministic path under `workspace/threads/` — concurrent sessions collide and unignored temps flip `git.dirty`). Clean it up whether the finalizer succeeds or fails, and propagate a non-zero finalize exit status:
 
@@ -133,9 +133,9 @@ nohup bash core/scripts/handoff-post.sh \
 1. Archives threads older than 60 days into `workspace/threads/archive/YYYY-MM/` (gated once per 24h)
 2. Regenerates INDEX files again (captures any archive moves)
 3. Records eligible learn/doc-release work as pending until the handoff reports dispatch proof
-4. Launches qmd reindex (qmd cleanup/update/embed)
+4. Schedules the same single-flight qmd reindex helper as finalize (`qmd-handoff-reindex.sh`). If finalize already owns the flight, this is a quiet no-op — not a second independent `qmd cleanup/update/embed`.
 
-Logs land at `/tmp/handoff-post.log` and `/tmp/qmd-handoff.log`. If the session dies while the post-script runs, the script keeps going — `handoff.json` is already valid.
+Logs land at `/tmp/handoff-post.log` and `/tmp/qmd-handoff.log` (one bounded qmd log; only the lock winner truncates it). If the session dies while the post-script runs, the script keeps going — `handoff.json` is already valid.
 
 ### 4.5 Dispatch runtime-appropriate model follow-ups
 
@@ -200,7 +200,7 @@ Background work dispatched:
   - handoff-post.sh PID {from nohup} → /tmp/handoff-post.log
   - /learn → {Codex spawn_agent | Claude Task/Agent | synchronous Skill | durably pending}
   - /document-release → {Codex spawn_agent | Claude Task/Agent | synchronous Skill | durably pending}
-  - qmd reindex → /tmp/qmd-handoff.log
+  - qmd reindex (single-flight helper) → /tmp/qmd-handoff.log
 
 To continue in a fresh session:
   1. Start a new session

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -422,6 +422,8 @@ jobs:
         run: bash core/scripts/tests/handoff-finalize-smoke.sh
       - name: Handoff finalizer accepts a large file-backed changeset
         run: bash core/scripts/tests/handoff-finalize-large-changeset.test.sh
+      - name: Handoff qmd reindex is single-flight (managed + developer fallback)
+        run: bash core/scripts/tests/qmd-handoff-reindex.test.sh
 
   journal-session-isolation:
     name: journal-session-isolation

--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,10 +1,10 @@
 version: 1
-hqVersion: "15.0.72"
+hqVersion: "15.0.73"
 agentSessionContractVersion: 1
 # Provider adapter contract version (US-500). Must match
 # HQ_ADAPTER_CONTRACT_VERSION in core/scripts/lib/provider-adapter-version.sh.
 adapterContractVersion: "1.0.0"
-updatedAt: "2026-07-31T11:19:15Z"
+updatedAt: "2026-07-31T18:54:33Z"
 # hq-core is the minimal scaffold seed. Rich add-ons ship as `@indigoai-us/hq-pack-*`
 # npm packages installed into `core/packages/` via `hq install`. See `core/packages/README.md`.
 rules:

--- a/core/scripts/handoff-finalize.sh
+++ b/core/scripts/handoff-finalize.sh
@@ -3,8 +3,8 @@
 #
 # Folds steps 1/2/3b/4/5/7 of the handoff skill into a single subprocess so the
 # model doesn't narrate each step. Writes the thread file, handoff.json,
-# regenerates INDEX files, commits HQ via explicit paths, and launches qmd
-# reindex fire-and-forget.
+# regenerates INDEX files, commits HQ via explicit paths, and schedules the
+# single-flight qmd reindex helper (shared with handoff-post.sh).
 #
 # Usage (all args optional):
 #   handoff-finalize.sh \
@@ -478,11 +478,16 @@ if [[ $STAGE_FAILURE_COUNT -gt 0 && "$HQ_COMMIT_STATUS" != "failed" ]]; then
 fi
 COMMIT_AFTER=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
-# -------- qmd reindex fire-and-forget --------
+# -------- qmd reindex fire-and-forget (single-flight helper) --------
+# Shared with handoff-post.sh via qmd-handoff-reindex.sh. Agent ritual calls
+# finalize only; full /handoff also calls post — the helper's user lock ensures
+# at most one managed/raw mutation. On agent boxes the helper prefers the
+# managed user-half (no raw qmd, no --embed).
 QMD_PID=""
-if command -v qmd >/dev/null 2>&1; then
-  nohup bash -c 'qmd cleanup 2>/dev/null; qmd update 2>/dev/null && qmd embed 2>/dev/null' \
-    > /tmp/qmd-handoff.log 2>&1 &
+QMD_HELPER="$HQ_ROOT/core/scripts/qmd-handoff-reindex.sh"
+if [[ -f "$QMD_HELPER" ]]; then
+  # Helper owns lock, log truncate, managed/raw routing. Detach; never block.
+  nohup bash "$QMD_HELPER" </dev/null >/dev/null 2>&1 &
   QMD_PID=$!
 fi
 

--- a/core/scripts/handoff-finalize.sh
+++ b/core/scripts/handoff-finalize.sh
@@ -480,13 +480,14 @@ COMMIT_AFTER=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
 # -------- qmd reindex fire-and-forget (single-flight helper) --------
 # Shared with handoff-post.sh via qmd-handoff-reindex.sh. Agent ritual calls
-# finalize only; full /handoff also calls post — the helper's user lock ensures
-# at most one managed/raw mutation. On agent boxes the helper prefers the
-# managed user-half (no raw qmd, no --embed).
+# finalize only; full /handoff also calls post — the helper's user lock plus a
+# short recent-completion dedupe window ensure at most one managed/raw mutation
+# (sequential finalize→post collapses; ~15m ritual still refreshes). On agent
+# boxes the helper prefers the managed user-half (no raw qmd, no --embed).
 QMD_PID=""
 QMD_HELPER="$HQ_ROOT/core/scripts/qmd-handoff-reindex.sh"
 if [[ -f "$QMD_HELPER" ]]; then
-  # Helper owns lock, log truncate, managed/raw routing. Detach; never block.
+  # Helper owns lock, log truncate/cap, managed/raw routing. Detach; never block.
   nohup bash "$QMD_HELPER" </dev/null >/dev/null 2>&1 &
   QMD_PID=$!
 fi

--- a/core/scripts/handoff-post.sh
+++ b/core/scripts/handoff-post.sh
@@ -6,8 +6,8 @@
 #   1. Archive old threads (60d), then regen thread INDEX.md + recent.md (bash)
 #   2. Regen orchestrator INDEX.md (bash)
 #   3. Schedule single-flight qmd reindex (shared helper with finalize; the
-#      helper's lock makes a second launch a quiet no-op when finalize already
-#      owns the flight)
+#      helper's lock + recent-completion dedupe make a second launch a quiet
+#      no-op when finalize already owns or just finished the flight)
 #
 # Model work is intentionally not launched from this detached shell. /learn and
 # /document-release follow-ups run from the handoff skill itself, so auth
@@ -117,12 +117,13 @@ fi
 # --- 4. qmd reindex (single-flight helper; fire-and-forget) ---
 # Shared with handoff-finalize.sh. Do not inline raw qmd here — on agent boxes
 # the helper routes to the managed user-half; on developer machines it takes
-# one nonblocking user lock before cleanup/update/embed.
+# one nonblocking user lock before cleanup/update/embed. If finalize already
+# completed a flight within the helper's short dedupe window, this is a no-op.
 QMD_HELPER="$HQ_ROOT/core/scripts/qmd-handoff-reindex.sh"
 if [[ -f "$QMD_HELPER" ]]; then
   # Propagate HANDOFF_LOG_DIR so the helper shares this post's log root;
-  # helper decides managed vs raw and only the lock winner truncates the log.
-  # HQ_QMD_INDEX_USER / QMD_HANDOFF_LOG inherit from the caller when set.
+  # helper decides managed vs raw; only the lock winner truncates/writes/caps
+  # the log. HQ_QMD_INDEX_USER / QMD_HANDOFF_LOG inherit from the caller when set.
   HANDOFF_LOG_DIR="$LOG_DIR" nohup bash "$QMD_HELPER" </dev/null >/dev/null 2>&1 &
   log "qmd: scheduled single-flight helper PID $!"
 else

--- a/core/scripts/handoff-post.sh
+++ b/core/scripts/handoff-post.sh
@@ -5,7 +5,9 @@
 # that used to burn foreground-session tokens:
 #   1. Archive old threads (60d), then regen thread INDEX.md + recent.md (bash)
 #   2. Regen orchestrator INDEX.md (bash)
-#   3. Background qmd cleanup + update + embed
+#   3. Schedule single-flight qmd reindex (shared helper with finalize; the
+#      helper's lock makes a second launch a quiet no-op when finalize already
+#      owns the flight)
 #
 # Model work is intentionally not launched from this detached shell. /learn and
 # /document-release follow-ups run from the handoff skill itself, so auth
@@ -24,7 +26,8 @@ LEARNINGS_FILE="${2:-}"
 
 LOG_DIR="${HANDOFF_LOG_DIR:-/tmp}"
 LOG_MAIN="${LOG_DIR}/handoff-post.log"
-LOG_QMD="${LOG_DIR}/qmd-handoff.log"
+# qmd log path is owned by qmd-handoff-reindex.sh (QMD_HANDOFF_LOG /
+# HANDOFF_LOG_DIR); this script must not truncate it.
 
 TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
@@ -111,13 +114,19 @@ elif [[ -n "$THREAD_PATH" && -f "$THREAD_PATH" ]]; then
   log "workspace-sync: skipped (hq CLI unavailable)"
 fi
 
-# --- 4. qmd reindex (background, fire-and-forget) ---
-if command -v qmd >/dev/null 2>&1; then
-  nohup bash -c 'qmd cleanup 2>/dev/null; qmd update 2>/dev/null && qmd embed 2>/dev/null' \
-    > "$LOG_QMD" 2>&1 &
-  log "qmd: launched PID $!"
+# --- 4. qmd reindex (single-flight helper; fire-and-forget) ---
+# Shared with handoff-finalize.sh. Do not inline raw qmd here — on agent boxes
+# the helper routes to the managed user-half; on developer machines it takes
+# one nonblocking user lock before cleanup/update/embed.
+QMD_HELPER="$HQ_ROOT/core/scripts/qmd-handoff-reindex.sh"
+if [[ -f "$QMD_HELPER" ]]; then
+  # Propagate HANDOFF_LOG_DIR so the helper shares this post's log root;
+  # helper decides managed vs raw and only the lock winner truncates the log.
+  # HQ_QMD_INDEX_USER / QMD_HANDOFF_LOG inherit from the caller when set.
+  HANDOFF_LOG_DIR="$LOG_DIR" nohup bash "$QMD_HELPER" </dev/null >/dev/null 2>&1 &
+  log "qmd: scheduled single-flight helper PID $!"
 else
-  log "qmd: skipped (CLI unavailable)"
+  log "qmd: skipped (helper missing)"
 fi
 
 log "handoff-post complete"

--- a/core/scripts/qmd-handoff-reindex.sh
+++ b/core/scripts/qmd-handoff-reindex.sh
@@ -261,25 +261,38 @@ mkdir -p "$(dirname "$LOG_PATH")" 2>/dev/null || true
 
 if [[ "$mode" == "managed" ]]; then
   # Lexical-only: do not pass --embed. Managed timer owns embed cadence.
-  if ! "$MANAGED_BIN" >>"$LOG_PATH" 2>&1; then
+  # Stamp only on true success so a failed flight does not suppress the
+  # sequential finalize→post second chance for DEDUPE_SEC.
+  managed_ok=0
+  if "$MANAGED_BIN" >>"$LOG_PATH" 2>&1; then
+    managed_ok=1
+  else
     echo "qmd-handoff-reindex: managed user-half failed (non-blocking)" >>"$LOG_PATH" 2>/dev/null || true
   fi
   echo "qmd-handoff-reindex done mode=managed" >>"$LOG_PATH" 2>/dev/null || true
-  write_completion_stamp
+  if [[ "$managed_ok" -eq 1 ]]; then
+    write_completion_stamp
+  fi
   cap_log
   exit 0
 fi
 
 # Developer fallback: one raw cleanup → update → embed pipeline.
 # Preserve original short-circuit: embed only runs when update succeeds.
+# cleanup/embed remain best-effort; update is the mutation gate for success
+# (stamp only when update exits 0 so a failed flight can be retried).
+raw_ok=0
 {
   qmd cleanup 2>/dev/null || true
   if qmd update 2>/dev/null; then
+    raw_ok=1
     qmd embed 2>/dev/null || true
   fi
   echo "qmd-handoff-reindex done mode=raw"
 } >>"$LOG_PATH" 2>&1 || true
 
-write_completion_stamp
+if [[ "$raw_ok" -eq 1 ]]; then
+  write_completion_stamp
+fi
 cap_log
 exit 0

--- a/core/scripts/qmd-handoff-reindex.sh
+++ b/core/scripts/qmd-handoff-reindex.sh
@@ -15,25 +15,40 @@
 #      nonblocking portable user lock under ${HOME}/.hq/locks/ and run
 #      cleanup → update → embed. Busy means quiet success.
 #
+# Single-flight / dedupe
+#   - Portable mkdir lock with an owner record (pid + timestamp + nonce).
+#   - Live owners are never stolen; dead owners (and owner-less locks past a
+#     short grace window) are reclaimed atomically via rename (nonblocking).
+#   - Recent-completion stamp collapses sequential finalize → post into one
+#     mutation (default window 90s). Agent ritual (~15m) is well outside the
+#     window and still refreshes. Override via QMD_HANDOFF_DEDUPE_SEC (0 disables).
+#
 # Logging / process discipline
 #   - One bounded log (default /tmp/qmd-handoff.log; override via
 #     QMD_HANDOFF_LOG, or HANDOFF_LOG_DIR/qmd-handoff.log).
-#   - Only the lock winner truncates/writes the log.
+#   - Only the lock winner truncates/writes the log; losers never touch it.
+#   - After the winning run, enforce QMD_HANDOFF_LOG_MAX_BYTES (default 65536)
+#     by retaining the useful tail (completion evidence).
 #   - No unbounded retry loop; failures stay non-blocking (always exit 0).
 #   - Managed component stamp owns health on agent boxes.
 #
 # Env (production defaults; overrides are for tests / rare diagnostics)
-#   HQ_QMD_INDEX_USER  managed user-half path
-#   QMD_HANDOFF_LOG    full log path
-#   HANDOFF_LOG_DIR    log directory when QMD_HANDOFF_LOG unset (default /tmp)
-#   HOME               lock root parent (${HOME}/.hq/locks/)
+#   HQ_QMD_INDEX_USER          managed user-half path
+#   QMD_HANDOFF_LOG            full log path
+#   HANDOFF_LOG_DIR            log directory when QMD_HANDOFF_LOG unset (default /tmp)
+#   QMD_HANDOFF_DEDUPE_SEC     recent-completion skip window seconds (default 90; 0=off)
+#   QMD_HANDOFF_LOG_MAX_BYTES  post-run log cap in bytes (default 65536)
+#   QMD_HANDOFF_LOCK_GRACE_SEC owner-less lock treated as live for this many
+#                              seconds after mkdir (default 5) so reclaim cannot
+#                              steal during the owner-write window
+#   HOME                       lock root parent (${HOME}/.hq/locks/)
 #
 # Exit: always 0 (handoff must not block on search reindex).
 
 set -u
 
-# Resolve log path without truncating yet — busy callers must not wipe a
-# winner's evidence.
+# Resolve log path without truncating yet — busy/deduped callers must not wipe
+# a winner's evidence.
 if [[ -n "${QMD_HANDOFF_LOG:-}" ]]; then
   LOG_PATH="$QMD_HANDOFF_LOG"
 else
@@ -54,8 +69,6 @@ else
   exit 0
 fi
 
-# Portable nonblocking user lock (mkdir). Shared across finalize + post and
-# overlapping handoffs so at most one mutation runs.
 LOCK_ROOT="${HOME:-}/.hq/locks"
 if [[ -z "${HOME:-}" ]]; then
   # No HOME → cannot take a user lock safely; skip rather than race.
@@ -63,17 +76,182 @@ if [[ -z "${HOME:-}" ]]; then
 fi
 mkdir -p "$LOCK_ROOT" 2>/dev/null || true
 LOCK_DIR="${LOCK_ROOT}/qmd-handoff-reindex.lock"
+OWNER_FILE="${LOCK_DIR}/owner"
+COMPLETE_STAMP="${LOCK_ROOT}/qmd-handoff-reindex.completed"
+DEDUPE_SEC="${QMD_HANDOFF_DEDUPE_SEC:-90}"
+LOG_MAX_BYTES="${QMD_HANDOFF_LOG_MAX_BYTES:-65536}"
+LOCK_GRACE_SEC="${QMD_HANDOFF_LOCK_GRACE_SEC:-5}"
 
-if ! mkdir "$LOCK_DIR" 2>/dev/null; then
-  # Busy: another handoff reindex owns the flight. Quiet success; do not
+now_epoch() {
+  date +%s 2>/dev/null || echo 0
+}
+
+lock_mtime() {
+  # Portable-ish mtime; fail soft → 0.
+  if stat -c %Y "$LOCK_DIR" 2>/dev/null; then
+    return 0
+  fi
+  if stat -f %m "$LOCK_DIR" 2>/dev/null; then
+    return 0
+  fi
+  echo 0
+}
+
+# Quiet skip when a recent successful flight already finished. Collapses
+# sequential finalize → post without sleeping; ritual cadence (~15m) still runs.
+recently_completed() {
+  local last now
+  # Non-numeric / empty / zero window → never dedupe.
+  case "${DEDUPE_SEC}" in
+    ''|*[!0-9]*) return 1 ;;
+    0) return 1 ;;
+  esac
+  [[ -f "$COMPLETE_STAMP" ]] || return 1
+  last="$(awk -F= '/^ts=/{print $2; exit}' "$COMPLETE_STAMP" 2>/dev/null || true)"
+  case "${last}" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  now="$(now_epoch)"
+  [[ "$now" -ge "$last" ]] 2>/dev/null || return 1
+  [[ $((now - last)) -lt "$DEDUPE_SEC" ]] 2>/dev/null
+}
+
+write_completion_stamp() {
+  {
+    echo "ts=$(now_epoch)"
+    echo "pid=$$"
+    echo "mode=${mode}"
+  } >"$COMPLETE_STAMP" 2>/dev/null || true
+}
+
+write_owner_record() {
+  {
+    echo "pid=$$"
+    echo "ts=$(now_epoch)"
+    echo "nonce=$$.$RANDOM"
+  } >"$OWNER_FILE" 2>/dev/null || true
+}
+
+# True when we must not steal: live PID owner, or owner-less lock still inside
+# the post-mkdir grace window (owner write in progress).
+owner_is_live() {
+  local opid mt now age grace
+  [[ -d "$LOCK_DIR" ]] || return 1
+
+  if [[ -f "$OWNER_FILE" ]]; then
+    opid="$(awk -F= '/^pid=/{print $2; exit}' "$OWNER_FILE" 2>/dev/null || true)"
+    case "${opid}" in
+      ''|*[!0-9]*) ;;
+      *)
+        # Same-user liveness probe; never treat a live PID as reclaimable.
+        if kill -0 "$opid" 2>/dev/null; then
+          return 0
+        fi
+        # Owner record present but process is dead → reclaimable.
+        return 1
+        ;;
+    esac
+  fi
+
+  # No usable owner record: only reclaim once past grace (covers mkdir→write
+  # window and legacy empty lock dirs after SIGKILL).
+  grace="${LOCK_GRACE_SEC}"
+  case "${grace}" in
+    ''|*[!0-9]*) grace=5 ;;
+  esac
+  mt="$(lock_mtime)"
+  case "${mt}" in
+    ''|*[!0-9]*) return 0 ;; # unknown age → conservative: treat as live
+  esac
+  now="$(now_epoch)"
+  age=$((now - mt))
+  [[ "$age" -lt 0 ]] && age=0
+  [[ "$age" -lt "$grace" ]]
+}
+
+release_lock() {
+  # Only remove the lock if we still own it (avoid clobbering a reclaimer).
+  local opid
+  if [[ -f "$OWNER_FILE" ]]; then
+    opid="$(awk -F= '/^pid=/{print $2; exit}' "$OWNER_FILE" 2>/dev/null || true)"
+    if [[ "$opid" == "$$" ]]; then
+      rm -rf "$LOCK_DIR" 2>/dev/null || true
+    fi
+  fi
+}
+
+# Enforce modest byte cap after the winning run. Losers never call this.
+cap_log() {
+  local size max tmp keep
+  max="${LOG_MAX_BYTES}"
+  case "${max}" in
+    ''|*[!0-9]*) return 0 ;;
+    0) return 0 ;;
+  esac
+  [[ -f "$LOG_PATH" ]] || return 0
+  size="$(wc -c <"$LOG_PATH" 2>/dev/null | tr -d '[:space:]' || echo 0)"
+  case "${size}" in
+    ''|*[!0-9]*) return 0 ;;
+  esac
+  [[ "$size" -gt "$max" ]] 2>/dev/null || return 0
+  # Retain the useful tail (done/completion lines are written last).
+  keep="$max"
+  tmp="${LOG_PATH}.cap.$$"
+  if tail -c "$keep" "$LOG_PATH" >"$tmp" 2>/dev/null; then
+    mv "$tmp" "$LOG_PATH" 2>/dev/null || rm -f "$tmp" 2>/dev/null || true
+  else
+    rm -f "$tmp" 2>/dev/null || true
+  fi
+}
+
+# Atomic nonblocking acquire via mkdir. On contention: quiet success for live
+# owners; reclaim only when the owner is definitely dead or past grace.
+try_acquire_lock() {
+  local steal
+
+  if mkdir "$LOCK_DIR" 2>/dev/null; then
+    write_owner_record
+    return 0
+  fi
+
+  # Contended. Never delete a live owner's lock.
+  if owner_is_live; then
+    return 1
+  fi
+
+  # Dead / stale owner (or empty lock past grace): atomic steal.
+  # rename is the single-winner primitive; only the stealer who moves the dir
+  # proceeds to recreate it.
+  steal="${LOCK_DIR}.stale.$$.$RANDOM"
+  rm -rf "$steal" 2>/dev/null || true
+  if mv "$LOCK_DIR" "$steal" 2>/dev/null; then
+    rm -rf "$steal" 2>/dev/null || true
+    if mkdir "$LOCK_DIR" 2>/dev/null; then
+      write_owner_record
+      return 0
+    fi
+  fi
+  return 1
+}
+
+if recently_completed; then
+  # Sequential finalize → post (or other rapid double schedule): one mutation.
+  exit 0
+fi
+
+if ! try_acquire_lock; then
+  # Live owner still flying, or lost reclaim race. Quiet success; do not
   # touch the shared log.
   exit 0
 fi
 
-release_lock() {
-  rmdir "$LOCK_DIR" 2>/dev/null || true
-}
 trap release_lock EXIT INT TERM HUP
+
+# Re-check stamp after lock: covers a tiny gap where another flight finished
+# and released just before we acquired.
+if recently_completed; then
+  exit 0
+fi
 
 # Winner only: truncate log and record this flight.
 mkdir -p "$(dirname "$LOG_PATH")" 2>/dev/null || true
@@ -87,6 +265,8 @@ if [[ "$mode" == "managed" ]]; then
     echo "qmd-handoff-reindex: managed user-half failed (non-blocking)" >>"$LOG_PATH" 2>/dev/null || true
   fi
   echo "qmd-handoff-reindex done mode=managed" >>"$LOG_PATH" 2>/dev/null || true
+  write_completion_stamp
+  cap_log
   exit 0
 fi
 
@@ -100,4 +280,6 @@ fi
   echo "qmd-handoff-reindex done mode=raw"
 } >>"$LOG_PATH" 2>&1 || true
 
+write_completion_stamp
+cap_log
 exit 0

--- a/core/scripts/qmd-handoff-reindex.sh
+++ b/core/scripts/qmd-handoff-reindex.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# qmd-handoff-reindex.sh — single-flight handoff search reindex.
+#
+# Shared by handoff-finalize.sh and handoff-post.sh so agent ritual
+# (finalize-only, ~every 15m) and full developer /handoff (finalize then post)
+# cannot double-launch raw qmd writers or race hq-pro's managed timer.
+#
+# Modes
+#   1. Managed (agent boxes): if HQ_QMD_INDEX_USER (default
+#      /usr/local/lib/hq-agent/qmd-index-user) is an executable file, invoke it
+#      WITHOUT --embed. Lexical refresh uses the one canonical ec2-user lock;
+#      the managed timer owns embed cadence. Never call raw
+#      qmd cleanup/update/embed when the managed wrapper exists.
+#   2. Developer fallback: when the managed wrapper is absent, acquire one
+#      nonblocking portable user lock under ${HOME}/.hq/locks/ and run
+#      cleanup → update → embed. Busy means quiet success.
+#
+# Logging / process discipline
+#   - One bounded log (default /tmp/qmd-handoff.log; override via
+#     QMD_HANDOFF_LOG, or HANDOFF_LOG_DIR/qmd-handoff.log).
+#   - Only the lock winner truncates/writes the log.
+#   - No unbounded retry loop; failures stay non-blocking (always exit 0).
+#   - Managed component stamp owns health on agent boxes.
+#
+# Env (production defaults; overrides are for tests / rare diagnostics)
+#   HQ_QMD_INDEX_USER  managed user-half path
+#   QMD_HANDOFF_LOG    full log path
+#   HANDOFF_LOG_DIR    log directory when QMD_HANDOFF_LOG unset (default /tmp)
+#   HOME               lock root parent (${HOME}/.hq/locks/)
+#
+# Exit: always 0 (handoff must not block on search reindex).
+
+set -u
+
+# Resolve log path without truncating yet — busy callers must not wipe a
+# winner's evidence.
+if [[ -n "${QMD_HANDOFF_LOG:-}" ]]; then
+  LOG_PATH="$QMD_HANDOFF_LOG"
+else
+  LOG_DIR="${HANDOFF_LOG_DIR:-/tmp}"
+  LOG_PATH="${LOG_DIR}/qmd-handoff.log"
+fi
+
+MANAGED_DEFAULT="/usr/local/lib/hq-agent/qmd-index-user"
+MANAGED_BIN="${HQ_QMD_INDEX_USER:-$MANAGED_DEFAULT}"
+
+mode=""
+if [[ -n "$MANAGED_BIN" && -x "$MANAGED_BIN" && -f "$MANAGED_BIN" ]]; then
+  mode="managed"
+elif command -v qmd >/dev/null 2>&1; then
+  mode="raw"
+else
+  # Nothing to do — no managed wrapper and no qmd CLI.
+  exit 0
+fi
+
+# Portable nonblocking user lock (mkdir). Shared across finalize + post and
+# overlapping handoffs so at most one mutation runs.
+LOCK_ROOT="${HOME:-}/.hq/locks"
+if [[ -z "${HOME:-}" ]]; then
+  # No HOME → cannot take a user lock safely; skip rather than race.
+  exit 0
+fi
+mkdir -p "$LOCK_ROOT" 2>/dev/null || true
+LOCK_DIR="${LOCK_ROOT}/qmd-handoff-reindex.lock"
+
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  # Busy: another handoff reindex owns the flight. Quiet success; do not
+  # touch the shared log.
+  exit 0
+fi
+
+release_lock() {
+  rmdir "$LOCK_DIR" 2>/dev/null || true
+}
+trap release_lock EXIT INT TERM HUP
+
+# Winner only: truncate log and record this flight.
+mkdir -p "$(dirname "$LOG_PATH")" 2>/dev/null || true
+{
+  echo "qmd-handoff-reindex start mode=${mode} ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown) pid=$$"
+} >"$LOG_PATH" 2>/dev/null || true
+
+if [[ "$mode" == "managed" ]]; then
+  # Lexical-only: do not pass --embed. Managed timer owns embed cadence.
+  if ! "$MANAGED_BIN" >>"$LOG_PATH" 2>&1; then
+    echo "qmd-handoff-reindex: managed user-half failed (non-blocking)" >>"$LOG_PATH" 2>/dev/null || true
+  fi
+  echo "qmd-handoff-reindex done mode=managed" >>"$LOG_PATH" 2>/dev/null || true
+  exit 0
+fi
+
+# Developer fallback: one raw cleanup → update → embed pipeline.
+# Preserve original short-circuit: embed only runs when update succeeds.
+{
+  qmd cleanup 2>/dev/null || true
+  if qmd update 2>/dev/null; then
+    qmd embed 2>/dev/null || true
+  fi
+  echo "qmd-handoff-reindex done mode=raw"
+} >>"$LOG_PATH" 2>&1 || true
+
+exit 0

--- a/core/scripts/tests/qmd-handoff-reindex.test.sh
+++ b/core/scripts/tests/qmd-handoff-reindex.test.sh
@@ -4,9 +4,11 @@
 # Guards the agent qmd concurrency fix:
 #   - managed user-half wins when present (no raw qmd mutation)
 #   - finalize + post share one in-flight mutation
+#   - sequential finalize → post collides via recent-completion dedupe
 #   - developer fallback runs cleanup → update → embed under a user lock
+#   - live owner lock preserved; dead/stale owner reclaimed
 #   - lock contention / failures stay non-blocking for handoff
-#   - log truncate only happens for the winner
+#   - log truncate only happens for the winner; post-run byte cap enforced
 #   - finalize-only (agent ritual) still schedules a refresh
 
 set -euo pipefail
@@ -34,6 +36,8 @@ BIN="$TMP/bin"
 LOG="$TMP/qmd-handoff.log"
 MUTATION_LOG="$TMP/mutations.log"
 MANAGED="$TMP/managed/qmd-index-user"
+LOCK_DIR="$HOME_DIR/.hq/locks/qmd-handoff-reindex.lock"
+COMPLETE_STAMP="$HOME_DIR/.hq/locks/qmd-handoff-reindex.completed"
 mkdir -p "$HOME_DIR/.hq/locks" "$BIN" "$TMP/managed" "$TMP/logs" "$TMP/repo/core/scripts" \
   "$TMP/repo/workspace/threads" "$TMP/repo/workspace/baseline" "$TMP/repo/workspace/orchestrator"
 
@@ -66,6 +70,16 @@ if [[ -n "${MANAGED_HOLD_FILE:-}" && -f "${MANAGED_HOLD_FILE}" ]]; then
     sleep 0.05
   done
 fi
+if [[ "${MANAGED_OVERFLOW_BYTES:-0}" -gt 0 ]]; then
+  # Oversized stdout to exercise post-run log cap (winner-only).
+  python3 - <<PY
+import os
+n = int(os.environ["MANAGED_OVERFLOW_BYTES"])
+print("OVERFLOW_START")
+print("x" * n)
+print("OVERFLOW_END")
+PY
+fi
 if [[ "${MANAGED_FAIL:-0}" == "1" ]]; then
   echo "managed boom" >&2
   exit "${MANAGED_FAIL_RC:-1}"
@@ -87,11 +101,15 @@ run_helper() {
     MANAGED_HOLD_FILE="${MANAGED_HOLD_FILE:-}" \
     MANAGED_FAIL="${MANAGED_FAIL:-0}" \
     MANAGED_FAIL_RC="${MANAGED_FAIL_RC:-1}" \
+    MANAGED_OVERFLOW_BYTES="${MANAGED_OVERFLOW_BYTES:-0}" \
+    QMD_HANDOFF_DEDUPE_SEC="${QMD_HANDOFF_DEDUPE_SEC:-90}" \
+    QMD_HANDOFF_LOG_MAX_BYTES="${QMD_HANDOFF_LOG_MAX_BYTES:-65536}" \
+    QMD_HANDOFF_LOCK_GRACE_SEC="${QMD_HANDOFF_LOCK_GRACE_SEC:-5}" \
     bash "$HELPER"
 }
 
 reset_state() {
-  rm -f "$MUTATION_LOG" "$LOG"
+  rm -f "$MUTATION_LOG" "$LOG" "$COMPLETE_STAMP"
   rm -rf "$HOME_DIR/.hq/locks"
   mkdir -p "$HOME_DIR/.hq/locks"
   : > "$MUTATION_LOG"
@@ -246,6 +264,7 @@ HOLD="$TMP/hold-log"
 : > "$HOLD"
 env -i PATH="$BIN:/usr/bin:/bin" HOME="$HOME_DIR" MUTATION_LOG="$MUTATION_LOG" \
   QMD_HANDOFF_LOG="$LOG" QMD_HOLD_FILE="$HOLD" HQ_QMD_INDEX_USER="$TMP/nope" \
+  QMD_HANDOFF_DEDUPE_SEC=0 \
   bash "$HELPER" &
 wpid=$!
 for _ in $(seq 1 100); do
@@ -254,7 +273,7 @@ for _ in $(seq 1 100); do
 done
 echo "KEEP_ME" >> "$LOG"
 size_before=$(wc -c < "$LOG")
-HQ_QMD_INDEX_USER="$TMP/nope" run_helper
+QMD_HANDOFF_DEDUPE_SEC=0 HQ_QMD_INDEX_USER="$TMP/nope" run_helper
 size_after=$(wc -c < "$LOG")
 [[ "$size_before" -eq "$size_after" ]] || fail "loser changed log size"
 grep -q 'KEEP_ME' "$LOG" || fail "loser wiped KEEP_ME"
@@ -262,9 +281,25 @@ rm -f "$HOLD"
 wait "$wpid" || true
 ok "busy caller leaves winner log untouched"
 
+# Oversized managed output is capped by the winner; completion tail retained.
+reset_state
+MAX_BYTES=4096
+OVERFLOW=20000
+MANAGED_OVERFLOW_BYTES="$OVERFLOW" QMD_HANDOFF_LOG_MAX_BYTES="$MAX_BYTES" \
+  HQ_QMD_INDEX_USER="$MANAGED" run_helper
+[[ -f "$LOG" ]] || fail "log missing after oversized managed run"
+log_size=$(wc -c <"$LOG" | tr -d '[:space:]')
+[[ "$log_size" -le "$MAX_BYTES" ]] \
+  || fail "log not capped: size=$log_size max=$MAX_BYTES"
+grep -q 'qmd-handoff-reindex done mode=managed' "$LOG" \
+  || fail "capped log lost completion evidence"
+grep -q '^managed' "$MUTATION_LOG" || fail "oversized managed run did not mutate"
+ok "oversized managed log is capped while retaining completion tail"
+
 # =============================================================================
 # 7) finalize-only path schedules the helper (agent ritual compatible)
 # =============================================================================
+reset_state
 cp "$FINALIZE" "$TMP/repo/core/scripts/handoff-finalize.sh"
 cp "$HELPER" "$TMP/repo/core/scripts/qmd-handoff-reindex.sh"
 cp "$ROOT/core/scripts/hq-status-summary.sh" "$TMP/repo/core/scripts/hq-status-summary.sh"
@@ -305,13 +340,14 @@ chmod +x "$REAL_HELPER" "$TMP/repo/core/scripts/qmd-handoff-reindex.real.sh"
   git commit -qm base
   echo changed > tracked.txt
 
-  rm -f "$TMP/helper-scheduled.log" "$MUTATION_LOG"
+  rm -f "$TMP/helper-scheduled.log" "$MUTATION_LOG" "$COMPLETE_STAMP"
   : > "$MUTATION_LOG"
   out=$(
     env -i PATH="$BIN:/usr/bin:/bin" HOME="$HOME_DIR" \
       MUTATION_LOG="$MUTATION_LOG" \
       QMD_HANDOFF_LOG="$LOG" \
       HQ_QMD_INDEX_USER="$TMP/nope" \
+      QMD_HANDOFF_DEDUPE_SEC=0 \
       bash core/scripts/handoff-finalize.sh \
         --title "Handoff: qmd ritual" \
         --summary "finalize-only schedules reindex" \
@@ -342,6 +378,7 @@ ok "finalize-only (agent ritual) schedules single-flight helper"
 # =============================================================================
 # 8) finalize + post both route through helper; single flight under managed
 # =============================================================================
+reset_state
 cp "$POST" "$TMP/repo/core/scripts/handoff-post.sh"
 chmod +x "$TMP/repo/core/scripts/handoff-post.sh"
 cat > "$TMP/repo/core/scripts/archive-old-threads.sh" <<'SH'
@@ -350,7 +387,7 @@ exit 0
 SH
 chmod +x "$TMP/repo/core/scripts/archive-old-threads.sh"
 
-rm -f "$TMP/helper-scheduled.log" "$MUTATION_LOG"
+rm -f "$TMP/helper-scheduled.log" "$MUTATION_LOG" "$COMPLETE_STAMP"
 : > "$MUTATION_LOG"
 : > "$TMP/helper-scheduled.log"
 
@@ -363,11 +400,13 @@ HOLD="$TMP/hold-fp"
   env -i PATH="$BIN:/usr/bin:/bin" HOME="$HOME_DIR" \
     MUTATION_LOG="$MUTATION_LOG" QMD_HANDOFF_LOG="$LOG" \
     HQ_QMD_INDEX_USER="$MANAGED" MANAGED_HOLD_FILE="$HOLD" \
+    QMD_HANDOFF_DEDUPE_SEC=0 \
     bash core/scripts/qmd-handoff-reindex.sh &
   env -i PATH="$BIN:/usr/bin:/bin" HOME="$HOME_DIR" \
     MUTATION_LOG="$MUTATION_LOG" QMD_HANDOFF_LOG="$LOG" \
     HQ_QMD_INDEX_USER="$MANAGED" MANAGED_HOLD_FILE="$HOLD" \
     HANDOFF_LOG_DIR="$TMP/logs" \
+    QMD_HANDOFF_DEDUPE_SEC=0 \
     bash core/scripts/handoff-post.sh workspace/threads/T-missing.json ""
   sleep 0.1
   rm -f "$HOLD"
@@ -388,6 +427,7 @@ reset_state
   env -i PATH="$BIN:/usr/bin:/bin" HOME="$HOME_DIR" \
     MUTATION_LOG="$MUTATION_LOG" QMD_HANDOFF_LOG="$LOG" \
     HQ_QMD_INDEX_USER="$MANAGED" HANDOFF_LOG_DIR="$TMP/logs" \
+    QMD_HANDOFF_DEDUPE_SEC=0 \
     bash core/scripts/handoff-post.sh workspace/threads/T-missing.json ""
   for _ in $(seq 1 100); do
     grep -q '^managed' "$MUTATION_LOG" 2>/dev/null && break
@@ -419,5 +459,99 @@ if grep -nE "nohup bash -c 'qmd |qmd cleanup|qmd update && qmd embed" "$POST" | 
   fail "handoff-post.sh still launches raw qmd inline"
 fi
 ok "finalize and post delegate to shared helper (no inline raw pipeline)"
+
+# =============================================================================
+# 10) sequential finalize + post after first fully completed → one mutation
+#     (dedupe window override; no sleeps)
+# =============================================================================
+reset_state
+QMD_HANDOFF_DEDUPE_SEC=60 HQ_QMD_INDEX_USER="$MANAGED" run_helper
+[[ -f "$COMPLETE_STAMP" ]] || fail "completion stamp missing after first run"
+first_mut="$(cat "$MUTATION_LOG")"
+managed_n=$(grep -c '^managed' "$MUTATION_LOG" || true)
+[[ "$managed_n" -eq 1 ]] || fail "first sequential call expected 1 managed, got $managed_n"
+
+# Second call after first fully completed (sync). Within window → no mutation.
+QMD_HANDOFF_DEDUPE_SEC=60 HQ_QMD_INDEX_USER="$MANAGED" run_helper
+second_mut="$(cat "$MUTATION_LOG")"
+[[ "$first_mut" == "$second_mut" ]] \
+  || fail "sequential second call mutated: before=[$first_mut] after=[$second_mut]"
+managed_n=$(grep -c '^managed' "$MUTATION_LOG" || true)
+[[ "$managed_n" -eq 1 ]] || fail "sequential dedupe expected 1 managed total, got $managed_n"
+ok "sequential finalize+post after completion: one managed mutation (dedupe)"
+
+# Window disabled → second call runs a full mutation (ritual still works).
+reset_state
+QMD_HANDOFF_DEDUPE_SEC=0 HQ_QMD_INDEX_USER="$MANAGED" run_helper
+QMD_HANDOFF_DEDUPE_SEC=0 HQ_QMD_INDEX_USER="$MANAGED" run_helper
+managed_n=$(grep -c '^managed' "$MUTATION_LOG" || true)
+[[ "$managed_n" -eq 2 ]] || fail "dedupe=0 expected 2 managed, got $managed_n"
+ok "dedupe window override 0 allows sequential re-run (ritual cadence)"
+
+# Raw sequential path also collapses to one pipeline.
+reset_state
+QMD_HANDOFF_DEDUPE_SEC=90 HQ_QMD_INDEX_USER="$TMP/nope" run_helper
+QMD_HANDOFF_DEDUPE_SEC=90 HQ_QMD_INDEX_USER="$TMP/nope" run_helper
+cleanup_n=$(grep -c '^qmd cleanup' "$MUTATION_LOG" || true)
+update_n=$(grep -c '^qmd update' "$MUTATION_LOG" || true)
+embed_n=$(grep -c '^qmd embed' "$MUTATION_LOG" || true)
+[[ "$cleanup_n" -eq 1 && "$update_n" -eq 1 && "$embed_n" -eq 1 ]] \
+  || fail "sequential raw dedupe expected one pipeline, got c=$cleanup_n u=$update_n e=$embed_n"
+ok "sequential raw finalize+post: one mutation pipeline via dedupe"
+
+# =============================================================================
+# 11) stale-owner recovery: live owner preserved; dead owner reclaimed
+# =============================================================================
+reset_state
+# Live owner: plant lock with this shell's PID and keep process alive.
+mkdir -p "$LOCK_DIR"
+{
+  echo "pid=$$"
+  echo "ts=$(date +%s)"
+  echo "nonce=live-test"
+} >"$LOCK_DIR/owner"
+before_mut="$(cat "$MUTATION_LOG")"
+QMD_HANDOFF_DEDUPE_SEC=0 HQ_QMD_INDEX_USER="$MANAGED" run_helper
+after_mut="$(cat "$MUTATION_LOG")"
+[[ "$before_mut" == "$after_mut" ]] || fail "live owner lock was stolen (mutation occurred)"
+[[ -d "$LOCK_DIR" ]] || fail "live owner lock dir was removed"
+[[ -f "$LOCK_DIR/owner" ]] || fail "live owner record was removed"
+grep -q "^pid=$$" "$LOCK_DIR/owner" || fail "live owner pid rewritten"
+ok "live owner lock is preserved (no reclaim, no mutation)"
+
+# Dead/stale owner: PID that is definitely not alive.
+reset_state
+mkdir -p "$LOCK_DIR"
+DEAD_PID=$(( $$ + 1000000 ))
+# Ensure kill -0 fails for this synthetic pid (and does not match us).
+if kill -0 "$DEAD_PID" 2>/dev/null; then
+  # Extremely unlikely; pick a high unused number.
+  DEAD_PID=2147483646
+  kill -0 "$DEAD_PID" 2>/dev/null && fail "could not find a dead pid for stale-owner test"
+fi
+{
+  echo "pid=$DEAD_PID"
+  echo "ts=1"
+  echo "nonce=dead-test"
+} >"$LOCK_DIR/owner"
+QMD_HANDOFF_DEDUPE_SEC=0 HQ_QMD_INDEX_USER="$MANAGED" run_helper
+managed_n=$(grep -c '^managed' "$MUTATION_LOG" || true)
+[[ "$managed_n" -eq 1 ]] || fail "stale/dead owner should be reclaimed; managed=$managed_n"
+# Lock should be released after successful flight.
+if [[ -d "$LOCK_DIR" ]]; then
+  fail "lock dir still present after reclaimed run completed"
+fi
+[[ -f "$COMPLETE_STAMP" ]] || fail "completion stamp missing after reclaim run"
+ok "dead/stale owner lock is reclaimed; mutation proceeds"
+
+# Empty pre-owner lock dir (legacy / SIGKILL before owner write) is reclaimable
+# once past the owner-write grace window (simulate age via grace=0).
+reset_state
+mkdir -p "$LOCK_DIR"
+QMD_HANDOFF_DEDUPE_SEC=0 QMD_HANDOFF_LOCK_GRACE_SEC=0 \
+  HQ_QMD_INDEX_USER="$MANAGED" run_helper
+managed_n=$(grep -c '^managed' "$MUTATION_LOG" || true)
+[[ "$managed_n" -eq 1 ]] || fail "empty lock dir should be reclaimed; managed=$managed_n"
+ok "empty lock dir without owner is reclaimed"
 
 echo "PASS: qmd-handoff-reindex ($ASSERTIONS assertions)"

--- a/core/scripts/tests/qmd-handoff-reindex.test.sh
+++ b/core/scripts/tests/qmd-handoff-reindex.test.sh
@@ -1,0 +1,423 @@
+#!/usr/bin/env bash
+# qmd-handoff-reindex.test.sh — single-flight handoff reindex helper.
+#
+# Guards the agent qmd concurrency fix:
+#   - managed user-half wins when present (no raw qmd mutation)
+#   - finalize + post share one in-flight mutation
+#   - developer fallback runs cleanup → update → embed under a user lock
+#   - lock contention / failures stay non-blocking for handoff
+#   - log truncate only happens for the winner
+#   - finalize-only (agent ritual) still schedules a refresh
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+HELPER="$ROOT/core/scripts/qmd-handoff-reindex.sh"
+FINALIZE="$ROOT/core/scripts/handoff-finalize.sh"
+POST="$ROOT/core/scripts/handoff-post.sh"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "  ok: $*"; }
+
+ASSERTIONS=0
+ok() { ASSERTIONS=$((ASSERTIONS + 1)); pass "$1"; }
+
+[[ -f "$HELPER" ]] || fail "missing helper: $HELPER"
+[[ -f "$FINALIZE" ]] || fail "missing finalize: $FINALIZE"
+[[ -f "$POST" ]] || fail "missing post: $POST"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/qmd-handoff-reindex-test.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+HOME_DIR="$TMP/home"
+BIN="$TMP/bin"
+LOG="$TMP/qmd-handoff.log"
+MUTATION_LOG="$TMP/mutations.log"
+MANAGED="$TMP/managed/qmd-index-user"
+mkdir -p "$HOME_DIR/.hq/locks" "$BIN" "$TMP/managed" "$TMP/logs" "$TMP/repo/core/scripts" \
+  "$TMP/repo/workspace/threads" "$TMP/repo/workspace/baseline" "$TMP/repo/workspace/orchestrator"
+
+# --- fake qmd: records ordered mutations; optional hold for concurrency ---
+cat > "$BIN/qmd" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+cmd="${1:-}"
+printf 'qmd %s\n' "$cmd" >> "${MUTATION_LOG:?}"
+if [[ -n "${QMD_HOLD_FILE:-}" && -f "${QMD_HOLD_FILE}" ]]; then
+  # Hold while the marker exists so a second caller can race the lock.
+  while [[ -f "${QMD_HOLD_FILE}" ]]; do
+    sleep 0.05
+  done
+fi
+if [[ -n "${QMD_FAIL_CMD:-}" && "$cmd" == "$QMD_FAIL_CMD" ]]; then
+  exit "${QMD_FAIL_RC:-1}"
+fi
+exit 0
+SH
+chmod +x "$BIN/qmd"
+
+# --- fake managed user-half ---
+cat > "$MANAGED" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'managed %s\n' "$*" >> "${MUTATION_LOG:?}"
+if [[ -n "${MANAGED_HOLD_FILE:-}" && -f "${MANAGED_HOLD_FILE}" ]]; then
+  while [[ -f "${MANAGED_HOLD_FILE}" ]]; do
+    sleep 0.05
+  done
+fi
+if [[ "${MANAGED_FAIL:-0}" == "1" ]]; then
+  echo "managed boom" >&2
+  exit "${MANAGED_FAIL_RC:-1}"
+fi
+exit 0
+SH
+chmod +x "$MANAGED"
+
+run_helper() {
+  env -i \
+    PATH="$BIN:/usr/bin:/bin" \
+    HOME="$HOME_DIR" \
+    MUTATION_LOG="$MUTATION_LOG" \
+    QMD_HANDOFF_LOG="$LOG" \
+    HQ_QMD_INDEX_USER="${HQ_QMD_INDEX_USER:-}" \
+    QMD_HOLD_FILE="${QMD_HOLD_FILE:-}" \
+    QMD_FAIL_CMD="${QMD_FAIL_CMD:-}" \
+    QMD_FAIL_RC="${QMD_FAIL_RC:-}" \
+    MANAGED_HOLD_FILE="${MANAGED_HOLD_FILE:-}" \
+    MANAGED_FAIL="${MANAGED_FAIL:-0}" \
+    MANAGED_FAIL_RC="${MANAGED_FAIL_RC:-1}" \
+    bash "$HELPER"
+}
+
+reset_state() {
+  rm -f "$MUTATION_LOG" "$LOG"
+  rm -rf "$HOME_DIR/.hq/locks"
+  mkdir -p "$HOME_DIR/.hq/locks"
+  : > "$MUTATION_LOG"
+}
+
+# =============================================================================
+# 1) managed present: routes to managed without --embed; raw qmd never runs
+# =============================================================================
+reset_state
+HQ_QMD_INDEX_USER="$MANAGED" run_helper
+grep -q '^managed' "$MUTATION_LOG" || fail "managed wrapper was not invoked"
+if grep -q '^managed .*--embed' "$MUTATION_LOG"; then
+  fail "managed wrapper must be invoked without --embed"
+fi
+if grep -q '^qmd ' "$MUTATION_LOG"; then
+  fail "raw qmd must not run when managed wrapper exists"
+fi
+ok "managed present routes to user-half without --embed; raw qmd idle"
+
+# =============================================================================
+# 2) managed absent: fallback cleanup → update → embed
+# =============================================================================
+reset_state
+HQ_QMD_INDEX_USER="$TMP/managed/does-not-exist" run_helper
+mapfile -t steps < <(grep '^qmd ' "$MUTATION_LOG" || true)
+[[ "${#steps[@]}" -eq 3 ]] || fail "expected 3 raw qmd steps, got ${#steps[@]}: $(cat "$MUTATION_LOG")"
+[[ "${steps[0]}" == "qmd cleanup" ]] || fail "step1 want cleanup, got ${steps[0]}"
+[[ "${steps[1]}" == "qmd update" ]] || fail "step2 want update, got ${steps[1]}"
+[[ "${steps[2]}" == "qmd embed" ]] || fail "step3 want embed, got ${steps[2]}"
+ok "developer fallback runs cleanup → update → embed"
+
+# =============================================================================
+# 3) fallback lock contention: second caller does not mutate or truncate log
+# =============================================================================
+reset_state
+HOLD="$TMP/hold-raw"
+: > "$HOLD"
+env -i PATH="$BIN:/usr/bin:/bin" HOME="$HOME_DIR" MUTATION_LOG="$MUTATION_LOG" \
+  QMD_HANDOFF_LOG="$LOG" QMD_HOLD_FILE="$HOLD" HQ_QMD_INDEX_USER="$TMP/nope" \
+  bash "$HELPER" &
+winner_pid=$!
+
+# Wait until winner has acquired lock and started mutating (and truncated log).
+for _ in $(seq 1 100); do
+  if grep -q '^qmd cleanup' "$MUTATION_LOG" 2>/dev/null; then
+    break
+  fi
+  sleep 0.05
+done
+grep -q '^qmd cleanup' "$MUTATION_LOG" || fail "winner never started raw pipeline"
+
+# Plant evidence in the log that a loser must not wipe.
+echo "WINNER_EVIDENCE" >> "$LOG"
+before_log="$(cat "$LOG")"
+before_mut="$(cat "$MUTATION_LOG")"
+
+HQ_QMD_INDEX_USER="$TMP/nope" run_helper
+after_log="$(cat "$LOG")"
+after_mut="$(cat "$MUTATION_LOG")"
+
+[[ "$before_log" == "$after_log" ]] || fail "loser truncated/changed winner log"
+[[ "$before_mut" == "$after_mut" ]] || fail "loser performed extra raw mutation"
+grep -q 'WINNER_EVIDENCE' "$LOG" || fail "winner log evidence missing after loser"
+
+rm -f "$HOLD"
+wait "$winner_pid" || true
+ok "fallback lock contention: loser is quiet and does not truncate log"
+
+# =============================================================================
+# 4) concurrent finalize-style + post-style helper calls: at most one mutation set
+# =============================================================================
+reset_state
+HOLD="$TMP/hold-concurrent"
+: > "$HOLD"
+for _ in 1 2; do
+  env -i PATH="$BIN:/usr/bin:/bin" HOME="$HOME_DIR" MUTATION_LOG="$MUTATION_LOG" \
+    QMD_HANDOFF_LOG="$LOG" QMD_HOLD_FILE="$HOLD" HQ_QMD_INDEX_USER="$TMP/nope" \
+    bash "$HELPER" &
+done
+# Let both race the lock.
+sleep 0.2
+rm -f "$HOLD"
+wait || true
+cleanup_n=$(grep -c '^qmd cleanup' "$MUTATION_LOG" || true)
+update_n=$(grep -c '^qmd update' "$MUTATION_LOG" || true)
+embed_n=$(grep -c '^qmd embed' "$MUTATION_LOG" || true)
+[[ "$cleanup_n" -eq 1 && "$update_n" -eq 1 && "$embed_n" -eq 1 ]] \
+  || fail "expected one raw pipeline, got cleanup=$cleanup_n update=$update_n embed=$embed_n ($(cat "$MUTATION_LOG"))"
+ok "concurrent helpers: at most one raw mutation pipeline"
+
+# Concurrent managed: at most one managed invocation
+reset_state
+HOLD="$TMP/hold-managed"
+: > "$HOLD"
+for _ in 1 2; do
+  env -i PATH="$BIN:/usr/bin:/bin" HOME="$HOME_DIR" MUTATION_LOG="$MUTATION_LOG" \
+    QMD_HANDOFF_LOG="$LOG" HQ_QMD_INDEX_USER="$MANAGED" MANAGED_HOLD_FILE="$HOLD" \
+    bash "$HELPER" &
+done
+sleep 0.2
+rm -f "$HOLD"
+wait || true
+managed_n=$(grep -c '^managed' "$MUTATION_LOG" || true)
+[[ "$managed_n" -eq 1 ]] || fail "expected one managed call, got $managed_n"
+if grep -q '^qmd ' "$MUTATION_LOG"; then
+  fail "raw qmd ran under concurrent managed mode"
+fi
+ok "concurrent helpers: at most one managed mutation"
+
+# =============================================================================
+# 5) managed/raw failure is non-blocking (exit 0)
+# =============================================================================
+reset_state
+set +e
+MANAGED_FAIL=1 HQ_QMD_INDEX_USER="$MANAGED" run_helper
+rc=$?
+set -e
+[[ "$rc" -eq 0 ]] || fail "managed failure should exit 0, got $rc"
+ok "managed failure is non-blocking (exit 0)"
+
+reset_state
+set +e
+QMD_FAIL_CMD=update QMD_FAIL_RC=7 HQ_QMD_INDEX_USER="$TMP/nope" run_helper
+rc=$?
+set -e
+[[ "$rc" -eq 0 ]] || fail "raw qmd failure should exit 0, got $rc"
+grep -q '^qmd cleanup' "$MUTATION_LOG" || fail "cleanup should still run before failed update"
+if grep -q '^qmd embed' "$MUTATION_LOG"; then
+  fail "embed should not run after failed update"
+fi
+ok "raw qmd failure is non-blocking (exit 0)"
+
+# =============================================================================
+# 6) log behavior is bounded and deterministic (winner truncates once)
+# =============================================================================
+reset_state
+python3 - <<'PY' > "$LOG"
+print("OLD_LINE\n" * 500, end="")
+PY
+HQ_QMD_INDEX_USER="$TMP/nope" run_helper
+if grep -q 'OLD_LINE' "$LOG"; then
+  fail "winner should truncate prior log content"
+fi
+[[ -f "$LOG" ]] || fail "log missing after run"
+lines=$(wc -l < "$LOG")
+[[ "$lines" -lt 100 ]] || fail "log not bounded: $lines lines"
+ok "log truncate is deterministic and bounded"
+
+# Busy loser does not create/truncate when log already has winner content
+reset_state
+HOLD="$TMP/hold-log"
+: > "$HOLD"
+env -i PATH="$BIN:/usr/bin:/bin" HOME="$HOME_DIR" MUTATION_LOG="$MUTATION_LOG" \
+  QMD_HANDOFF_LOG="$LOG" QMD_HOLD_FILE="$HOLD" HQ_QMD_INDEX_USER="$TMP/nope" \
+  bash "$HELPER" &
+wpid=$!
+for _ in $(seq 1 100); do
+  grep -q '^qmd cleanup' "$MUTATION_LOG" 2>/dev/null && break
+  sleep 0.05
+done
+echo "KEEP_ME" >> "$LOG"
+size_before=$(wc -c < "$LOG")
+HQ_QMD_INDEX_USER="$TMP/nope" run_helper
+size_after=$(wc -c < "$LOG")
+[[ "$size_before" -eq "$size_after" ]] || fail "loser changed log size"
+grep -q 'KEEP_ME' "$LOG" || fail "loser wiped KEEP_ME"
+rm -f "$HOLD"
+wait "$wpid" || true
+ok "busy caller leaves winner log untouched"
+
+# =============================================================================
+# 7) finalize-only path schedules the helper (agent ritual compatible)
+# =============================================================================
+cp "$FINALIZE" "$TMP/repo/core/scripts/handoff-finalize.sh"
+cp "$HELPER" "$TMP/repo/core/scripts/qmd-handoff-reindex.sh"
+cp "$ROOT/core/scripts/hq-status-summary.sh" "$TMP/repo/core/scripts/hq-status-summary.sh"
+cat > "$TMP/repo/core/scripts/rebuild-threads-index.sh" <<'SH'
+#!/usr/bin/env bash
+mkdir -p workspace/threads
+echo "# Threads" > workspace/threads/INDEX.md
+echo "- recent" > workspace/threads/recent.md
+SH
+cat > "$TMP/repo/core/scripts/rebuild-orchestrator-index.sh" <<'SH'
+#!/usr/bin/env bash
+mkdir -p workspace/orchestrator
+echo "# Orchestrator" > workspace/orchestrator/INDEX.md
+SH
+chmod +x "$TMP/repo/core/scripts/"*.sh
+
+cat > "$TMP/repo/workspace/baseline/hq-local-baseline.json" <<'JSON'
+{"categories":[{"name":"baseline","patterns":["workspace/*"]}]}
+JSON
+
+# Interpose helper via a wrapper that records scheduling, then execs real helper.
+REAL_HELPER="$TMP/repo/core/scripts/qmd-handoff-reindex.sh"
+mv "$REAL_HELPER" "$TMP/repo/core/scripts/qmd-handoff-reindex.real.sh"
+cat > "$REAL_HELPER" <<SH
+#!/usr/bin/env bash
+printf 'scheduled\n' >> "$TMP/helper-scheduled.log"
+exec bash "$TMP/repo/core/scripts/qmd-handoff-reindex.real.sh" "\$@"
+SH
+chmod +x "$REAL_HELPER" "$TMP/repo/core/scripts/qmd-handoff-reindex.real.sh"
+
+(
+  cd "$TMP/repo"
+  git init -q
+  git config user.email test@example.com
+  git config user.name "QMD Handoff Test"
+  echo base > tracked.txt
+  git add tracked.txt core/scripts workspace/baseline
+  git commit -qm base
+  echo changed > tracked.txt
+
+  rm -f "$TMP/helper-scheduled.log" "$MUTATION_LOG"
+  : > "$MUTATION_LOG"
+  out=$(
+    env -i PATH="$BIN:/usr/bin:/bin" HOME="$HOME_DIR" \
+      MUTATION_LOG="$MUTATION_LOG" \
+      QMD_HANDOFF_LOG="$LOG" \
+      HQ_QMD_INDEX_USER="$TMP/nope" \
+      bash core/scripts/handoff-finalize.sh \
+        --title "Handoff: qmd ritual" \
+        --summary "finalize-only schedules reindex" \
+        --message "ritual" \
+        --next-steps-json '[]' \
+        --files-touched-json '["tracked.txt"]' \
+        --learnings-json '[]' \
+        --tags-json '["test"]' \
+        --slug "qmd-ritual"
+  )
+  echo "$out" > "$TMP/finalize-out.json"
+  qmd_pid=$(jq -r '.qmd_pid // empty' <<<"$out")
+  [[ -n "$qmd_pid" ]] || fail "finalize-only did not report qmd_pid"
+  for _ in $(seq 1 100); do
+    [[ -f "$TMP/helper-scheduled.log" ]] && break
+    sleep 0.05
+  done
+  [[ -f "$TMP/helper-scheduled.log" ]] || fail "finalize-only never scheduled helper"
+  for _ in $(seq 1 100); do
+    grep -q '^qmd embed' "$MUTATION_LOG" 2>/dev/null && break
+    sleep 0.05
+  done
+  grep -q '^qmd cleanup' "$MUTATION_LOG" || fail "finalize-only helper did not run raw pipeline"
+)
+
+ok "finalize-only (agent ritual) schedules single-flight helper"
+
+# =============================================================================
+# 8) finalize + post both route through helper; single flight under managed
+# =============================================================================
+cp "$POST" "$TMP/repo/core/scripts/handoff-post.sh"
+chmod +x "$TMP/repo/core/scripts/handoff-post.sh"
+cat > "$TMP/repo/core/scripts/archive-old-threads.sh" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$TMP/repo/core/scripts/archive-old-threads.sh"
+
+rm -f "$TMP/helper-scheduled.log" "$MUTATION_LOG"
+: > "$MUTATION_LOG"
+: > "$TMP/helper-scheduled.log"
+
+HOLD="$TMP/hold-fp"
+: > "$HOLD"
+
+(
+  cd "$TMP/repo"
+  # Mirror full /handoff double-schedule: helper from finalize + post.
+  env -i PATH="$BIN:/usr/bin:/bin" HOME="$HOME_DIR" \
+    MUTATION_LOG="$MUTATION_LOG" QMD_HANDOFF_LOG="$LOG" \
+    HQ_QMD_INDEX_USER="$MANAGED" MANAGED_HOLD_FILE="$HOLD" \
+    bash core/scripts/qmd-handoff-reindex.sh &
+  env -i PATH="$BIN:/usr/bin:/bin" HOME="$HOME_DIR" \
+    MUTATION_LOG="$MUTATION_LOG" QMD_HANDOFF_LOG="$LOG" \
+    HQ_QMD_INDEX_USER="$MANAGED" MANAGED_HOLD_FILE="$HOLD" \
+    HANDOFF_LOG_DIR="$TMP/logs" \
+    bash core/scripts/handoff-post.sh workspace/threads/T-missing.json ""
+  sleep 0.1
+  rm -f "$HOLD"
+  wait || true
+)
+
+managed_n=$(grep -c '^managed' "$MUTATION_LOG" || true)
+[[ "$managed_n" -eq 1 ]] || fail "finalize+post managed single-flight expected 1, got $managed_n ($(cat "$MUTATION_LOG"))"
+if grep -q '^qmd ' "$MUTATION_LOG"; then
+  fail "raw qmd ran when managed present via post path"
+fi
+ok "finalize+post route managed single-flight; raw qmd idle"
+
+# post alone with managed present
+reset_state
+(
+  cd "$TMP/repo"
+  env -i PATH="$BIN:/usr/bin:/bin" HOME="$HOME_DIR" \
+    MUTATION_LOG="$MUTATION_LOG" QMD_HANDOFF_LOG="$LOG" \
+    HQ_QMD_INDEX_USER="$MANAGED" HANDOFF_LOG_DIR="$TMP/logs" \
+    bash core/scripts/handoff-post.sh workspace/threads/T-missing.json ""
+  for _ in $(seq 1 100); do
+    grep -q '^managed' "$MUTATION_LOG" 2>/dev/null && break
+    sleep 0.05
+  done
+)
+grep -q '^managed' "$MUTATION_LOG" || fail "post did not invoke managed helper path"
+if grep -q '^qmd ' "$MUTATION_LOG"; then
+  fail "post managed path invoked raw qmd"
+fi
+ok "post routes through helper to managed user-half"
+
+# =============================================================================
+# 9) structural: callers no longer inline raw qmd cleanup/update/embed
+# =============================================================================
+if grep -nE "nohup bash -c 'qmd |qmd cleanup|qmd update && qmd embed" "$FINALIZE" | grep -vE '^\s*#|:\s*#' >/dev/null 2>&1; then
+  # Live inline launches are forbidden; comments may mention the old pattern.
+  live=$(grep -nE "nohup bash -c 'qmd |[^#]*\bqmd cleanup\b|[^#]*\bqmd update\b.*\bqmd embed\b" "$FINALIZE" || true)
+  if [[ -n "$live" ]]; then
+    # Filter comment-only lines
+    if echo "$live" | grep -vE '^[0-9]+:[[:space:]]*#' >/dev/null; then
+      fail "handoff-finalize.sh still launches raw qmd inline: $live"
+    fi
+  fi
+fi
+grep -q 'qmd-handoff-reindex' "$FINALIZE" || fail "finalize does not call qmd-handoff-reindex"
+grep -q 'qmd-handoff-reindex' "$POST" || fail "post does not call qmd-handoff-reindex"
+if grep -nE "nohup bash -c 'qmd |qmd cleanup|qmd update && qmd embed" "$POST" | grep -vE '^[0-9]+:[[:space:]]*#' >/dev/null 2>&1; then
+  fail "handoff-post.sh still launches raw qmd inline"
+fi
+ok "finalize and post delegate to shared helper (no inline raw pipeline)"
+
+echo "PASS: qmd-handoff-reindex ($ASSERTIONS assertions)"

--- a/core/scripts/tests/qmd-handoff-reindex.test.sh
+++ b/core/scripts/tests/qmd-handoff-reindex.test.sh
@@ -243,6 +243,84 @@ fi
 ok "raw qmd failure is non-blocking (exit 0)"
 
 # =============================================================================
+# 5b) failed flight does not stamp; immediate second call retries (M1)
+#     Dedupe must collapse successful finalize→post only — not blackout a
+#     failed first flight for DEDUPE_SEC.
+# =============================================================================
+reset_state
+set +e
+MANAGED_FAIL=1 QMD_HANDOFF_DEDUPE_SEC=90 HQ_QMD_INDEX_USER="$MANAGED" run_helper
+rc=$?
+set -e
+[[ "$rc" -eq 0 ]] || fail "managed failure should exit 0, got $rc"
+if [[ -f "$COMPLETE_STAMP" ]]; then
+  fail "failed managed flight must not write completion stamp (got $(cat "$COMPLETE_STAMP"))"
+fi
+managed_n=$(grep -c '^managed' "$MUTATION_LOG" || true)
+[[ "$managed_n" -eq 1 ]] || fail "first failed managed expected 1 invocation, got $managed_n"
+
+# Immediate second call within default dedupe window must still mutate.
+set +e
+MANAGED_FAIL=1 QMD_HANDOFF_DEDUPE_SEC=90 HQ_QMD_INDEX_USER="$MANAGED" run_helper
+rc=$?
+set -e
+[[ "$rc" -eq 0 ]] || fail "second managed failure should exit 0, got $rc"
+managed_n=$(grep -c '^managed' "$MUTATION_LOG" || true)
+[[ "$managed_n" -eq 2 ]] \
+  || fail "failed managed must allow immediate retry within dedupe window; managed=$managed_n"
+if [[ -f "$COMPLETE_STAMP" ]]; then
+  fail "second failed managed must still not stamp (got $(cat "$COMPLETE_STAMP"))"
+fi
+# Success after failures stamps and subsequent call dedupes.
+MANAGED_FAIL=0 QMD_HANDOFF_DEDUPE_SEC=90 HQ_QMD_INDEX_USER="$MANAGED" run_helper
+[[ -f "$COMPLETE_STAMP" ]] || fail "successful managed after fail should stamp"
+managed_n=$(grep -c '^managed' "$MUTATION_LOG" || true)
+[[ "$managed_n" -eq 3 ]] || fail "success after fails expected 3 managed total, got $managed_n"
+MANAGED_FAIL=0 QMD_HANDOFF_DEDUPE_SEC=90 HQ_QMD_INDEX_USER="$MANAGED" run_helper
+managed_n=$(grep -c '^managed' "$MUTATION_LOG" || true)
+[[ "$managed_n" -eq 3 ]] || fail "success stamp should dedupe next call; managed=$managed_n"
+ok "failed managed does not stamp; second call retries; success then dedupes"
+
+# Raw: update failure (embed skipped) must not stamp; immediate retry mutates.
+reset_state
+set +e
+QMD_FAIL_CMD=update QMD_FAIL_RC=7 QMD_HANDOFF_DEDUPE_SEC=90 \
+  HQ_QMD_INDEX_USER="$TMP/nope" run_helper
+rc=$?
+set -e
+[[ "$rc" -eq 0 ]] || fail "raw update failure should exit 0, got $rc"
+if [[ -f "$COMPLETE_STAMP" ]]; then
+  fail "failed raw update must not write completion stamp (got $(cat "$COMPLETE_STAMP"))"
+fi
+if grep -q '^qmd embed' "$MUTATION_LOG"; then
+  fail "embed must not run after failed update (stamp regression setup)"
+fi
+cleanup_n=$(grep -c '^qmd cleanup' "$MUTATION_LOG" || true)
+[[ "$cleanup_n" -eq 1 ]] || fail "first raw fail expected 1 cleanup, got $cleanup_n"
+
+QMD_FAIL_CMD=update QMD_FAIL_RC=7 QMD_HANDOFF_DEDUPE_SEC=90 \
+  HQ_QMD_INDEX_USER="$TMP/nope" run_helper
+cleanup_n=$(grep -c '^qmd cleanup' "$MUTATION_LOG" || true)
+update_n=$(grep -c '^qmd update' "$MUTATION_LOG" || true)
+[[ "$cleanup_n" -eq 2 && "$update_n" -eq 2 ]] \
+  || fail "failed raw update must allow immediate retry; c=$cleanup_n u=$update_n"
+if [[ -f "$COMPLETE_STAMP" ]]; then
+  fail "second failed raw update must still not stamp"
+fi
+# Successful raw after failure stamps (cleanup → update → embed).
+unset QMD_FAIL_CMD QMD_FAIL_RC
+QMD_HANDOFF_DEDUPE_SEC=90 HQ_QMD_INDEX_USER="$TMP/nope" run_helper
+[[ -f "$COMPLETE_STAMP" ]] || fail "successful raw after fail should stamp"
+cleanup_n=$(grep -c '^qmd cleanup' "$MUTATION_LOG" || true)
+embed_n=$(grep -c '^qmd embed' "$MUTATION_LOG" || true)
+[[ "$cleanup_n" -eq 3 && "$embed_n" -eq 1 ]] \
+  || fail "success raw after fails expected c=3 e=1, got c=$cleanup_n e=$embed_n"
+QMD_HANDOFF_DEDUPE_SEC=90 HQ_QMD_INDEX_USER="$TMP/nope" run_helper
+cleanup_n=$(grep -c '^qmd cleanup' "$MUTATION_LOG" || true)
+[[ "$cleanup_n" -eq 3 ]] || fail "raw success stamp should dedupe next call; c=$cleanup_n"
+ok "failed raw update does not stamp; second call retries; success then dedupes"
+
+# =============================================================================
 # 6) log behavior is bounded and deterministic (winner truncates once)
 # =============================================================================
 reset_state


### PR DESCRIPTION
## Summary

Route handoff finalize and post through one shared qmd reindex helper so agent
rituals and full `/handoff` cannot double-launch raw `qmd` or race the managed
user-half timer.

## Behavior

- New `core/scripts/qmd-handoff-reindex.sh`: portable user lock, managed
  user-half path (no `--embed`), developer raw fallback, log bounds, always exit 0.
- `handoff-finalize.sh` and `handoff-post.sh` delegate to that helper (no inline
  cleanup/update/embed).
- Recent-completion dedupe (default 90s) collapses sequential finalize→post
  **after a successful flight only**. Failed managed/raw-update flights do not
  stamp, so the second chance can still retry within the window.
- Live lock owners are never stolen; dead/stale (and owner-less past grace) reclaim
  via atomic rename.

## Tests

- `core/scripts/tests/qmd-handoff-reindex.test.sh` — **22 assertions** (managed/raw,
  concurrency, non-blocking failures, M1 no-stamp+retry+success-dedupe, lock reclaim,
  finalize/post routing, log cap).
- Wired into `.github/workflows/pr-checks.yml` (`autosave-failure-visibility`).
- Local: `git diff origin/main...HEAD --check` clean; `bash -n` clean;
  `lint-shell-portability` clean.
- CI on tip `0873c829`: pr-checks (incl. autosave-failure-visibility + shell-portability)
  green; PR Audit **Passed** with zero findings (2026-08-01T12:48:57Z).

## Paths

- `.claude/skills/handoff/SKILL.md`
- `.claude/audit/suppressions.yaml` (narrow pii suppression for test fixtures;
  reason free of email/phone-shaped literals)
- `.github/workflows/pr-checks.yml`
- `core/core.yaml` — hqVersion **15.0.73**
- `core/scripts/handoff-finalize.sh` / `handoff-post.sh`
- `core/scripts/qmd-handoff-reindex.sh` (new)
- `core/scripts/tests/qmd-handoff-reindex.test.sh` (new)

## Companion hq-pro (merged + production-proven)

| PR | Topic | Merge SHA | Production evidence |
|----|--------|-----------|---------------------|
| [#1751](https://github.com/indigoai-us/hq-pro/pull/1751) | qmd user-half single-flight lock + disable post-sync reindex | `455cf57204f44adb8e8063d8eb9d98250f906c69` | MERGED 2026-07-31T19:06:29Z — managed belt prerequisite for agent-box install |
| [#1769](https://github.com/indigoai-us/hq-pro/pull/1769) | Stale search health reconciliation | `ab9f74f76e7de5a770efcd38c02f5db98477adbc` | MERGED 2026-08-01T10:28:22Z — on main/deployed |
| [#1770](https://github.com/indigoai-us/hq-pro/pull/1770) | Phase B drain of stale failed flights | `bca3651e9d10efd67ed11b51abcbccd80fd90a5d` | MERGED 2026-08-01T09:42:00Z |
| [#1772](https://github.com/indigoai-us/hq-pro/pull/1772) | Phase B CodeBuild EventBridge ARN normalization | `73be81824588545b5da27f384ba95eb4a11655e8` | MERGED+DEPLOYED; decisive Phase B GITHUB canary CodeBuild #1301 auto-terminalized `BUILD#…c3ab4c91…` via full-ARN EventBridge (`terminalAppliedAt`/`terminalOutcome=succeeded`/`completionProcessedAt` 2026-08-01T13:02:31.541Z, no manual completion). Report: `/tmp/hq-land-pr1772-20260801.txt` **FINAL SHIP** |

## Risks / hard install dependency

**Do not install HQ Core 15.0.73 on agent boxes until a canary box runs the
#1751+ managed user-half belt** (`/usr/local/lib/hq-agent/qmd-index-user`
executable; user-half lock path; `HQ_QMD_REINDEX_ON_SYNC=0` on sync children).

Never ship HQ Core alone onto pre-#1751 root-only qmd lock images — raw fallback
would reintroduce races the dual-lock design closes. Developer machines (no
managed wrapper) may take 15.0.73 earlier (raw path under user lock only).

## Out of scope

- Draft audit PRs #146–#148 are remediation noise against intermediate heads —
  **do not merge**; close as superseded (audit now clean on tip `0873c829`).

## Commits

- `94072d99` Single-flight handoff qmd reindex
- `bb8caec9` Harden handoff qmd single-flight reindex
- `980e8807` Bump hqVersion to 15.0.73 for CI version gate
- `29a42233` Suppress false-positive PII hits in qmd-handoff-reindex test
- `e760fa5c` Rewrite qmd test PII suppression reason without email literal
- `076e0b23` Only stamp handoff qmd reindex after a successful flight
- `0873c829` Avoid phone-shaped literals in qmd test suppression
