### PR TITLE
fix(handoff): agent skip qmd reindex (thrash WS3b)

### DIFF
--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,10 +1,10 @@
 version: 1
-hqVersion: "15.0.72"
+hqVersion: "15.0.73"
 agentSessionContractVersion: 1
 # Provider adapter contract version (US-500). Must match
 # HQ_ADAPTER_CONTRACT_VERSION in core/scripts/lib/provider-adapter-version.sh.
 adapterContractVersion: "1.0.0"
-updatedAt: "2026-07-31T11:19:15Z"
+updatedAt: "2026-08-01T23:05:00Z"
 # hq-core is the minimal scaffold seed. Rich add-ons ship as `@indigoai-us/hq-pack-*`
 # npm packages installed into `core/packages/` via `hq install`. See `core/packages/README.md`.
 rules:

--- a/core/scripts/handoff-finalize.sh
+++ b/core/scripts/handoff-finalize.sh
@@ -478,10 +478,23 @@ if [[ $STAGE_FAILURE_COUNT -gt 0 && "$HQ_COMMIT_STATUS" != "failed" ]]; then
 fi
 COMMIT_AFTER=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
-# -------- qmd reindex fire-and-forget --------
+# -------- qmd reindex fire-and-forget (agent: skip; laptop: single-flight) --------
+# Agent boxes: managed timer owns indexing — handoff never kicks qmd.
+# Laptop: qmd-reindex-bg single-flight reindex. See qmd-reindex-bg.sh.
 QMD_PID=""
-if command -v qmd >/dev/null 2>&1; then
-  nohup bash -c 'qmd cleanup 2>/dev/null; qmd update 2>/dev/null && qmd embed 2>/dev/null' \
+_QMD_BG="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/qmd-reindex-bg.sh"
+# Prefer PATH toolset helper on agent boxes (survives vault overwrite of core/).
+if [[ -x /usr/local/bin/hq-agent-qmd-reindex-bg ]]; then
+  _QMD_BG=/usr/local/bin/hq-agent-qmd-reindex-bg
+fi
+if [[ -x "$_QMD_BG" ]]; then
+  QMD_PID="$("$_QMD_BG" --log /tmp/qmd-handoff.log 2>/dev/null || true)"
+elif [[ -d /var/lib/hq-agent ]]; then
+  # Agent box without helper yet: still do not raw-embed.
+  QMD_PID="skipped-agent"
+elif command -v qmd >/dev/null 2>&1; then
+  # Laptop fallback if helper missing: single-flight via flock.
+  nohup bash -c 'exec 9>"${HOME:-/tmp}/.hq-agent/qmd-index.lock" 2>/dev/null || exec 9>/tmp/hq-qmd-index.lock; flock -n 9 || exit 0; nice -n 19 qmd cleanup 2>/dev/null; nice -n 19 qmd update 2>/dev/null; nice -n 19 qmd embed 2>/dev/null' \
     > /tmp/qmd-handoff.log 2>&1 &
   QMD_PID=$!
 fi

--- a/core/scripts/handoff-post.sh
+++ b/core/scripts/handoff-post.sh
@@ -5,7 +5,7 @@
 # that used to burn foreground-session tokens:
 #   1. Archive old threads (60d), then regen thread INDEX.md + recent.md (bash)
 #   2. Regen orchestrator INDEX.md (bash)
-#   3. Background qmd cleanup + update + embed
+#   3. qmd reindex via qmd-reindex-bg.sh (single-flight; agent boxes skip)
 #
 # Model work is intentionally not launched from this detached shell. /learn and
 # /document-release follow-ups run from the handoff skill itself, so auth
@@ -111,11 +111,22 @@ elif [[ -n "$THREAD_PATH" && -f "$THREAD_PATH" ]]; then
   log "workspace-sync: skipped (hq CLI unavailable)"
 fi
 
-# --- 4. qmd reindex (background, fire-and-forget) ---
-if command -v qmd >/dev/null 2>&1; then
-  nohup bash -c 'qmd cleanup 2>/dev/null; qmd update 2>/dev/null && qmd embed 2>/dev/null' \
+# --- 4. qmd reindex (agent: skip; laptop: single-flight) ---
+# handoff-finalize may already have run the helper; agent boxes no-op
+# (skipped-agent). Never dual-nohup raw cleanup+update+embed on agents.
+_QMD_BG="$HQ_ROOT/core/scripts/qmd-reindex-bg.sh"
+if [[ -x /usr/local/bin/hq-agent-qmd-reindex-bg ]]; then
+  _QMD_BG=/usr/local/bin/hq-agent-qmd-reindex-bg
+fi
+if [[ -x "$_QMD_BG" ]]; then
+  _qmd_out="$("$_QMD_BG" --log "$LOG_QMD" 2>/dev/null || true)"
+  log "qmd: reindex-bg → ${_qmd_out:-ok}"
+elif [[ -d /var/lib/hq-agent ]]; then
+  log "qmd: skipped-agent (no helper; indexer owns freshness)"
+elif command -v qmd >/dev/null 2>&1; then
+  nohup bash -c 'exec 9>"${HOME:-/tmp}/.hq-agent/qmd-index.lock" 2>/dev/null || exec 9>/tmp/hq-qmd-index.lock; flock -n 9 || exit 0; nice -n 19 qmd cleanup 2>/dev/null; nice -n 19 qmd update 2>/dev/null; nice -n 19 qmd embed 2>/dev/null' \
     > "$LOG_QMD" 2>&1 &
-  log "qmd: launched PID $!"
+  log "qmd: launched PID $! (fallback flock)"
 else
   log "qmd: skipped (CLI unavailable)"
 fi

--- a/core/scripts/qmd-reindex-bg.sh
+++ b/core/scripts/qmd-reindex-bg.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# qmd-reindex-bg.sh — single-flight background search reindex for handoff/sync.
+#
+# Ownership (agent handoff+qmd plan):
+#   - Hosted agent boxes: NEVER mutate qmd from handoff. Managed timer/indexer
+#     owns all update/embed. Print "skipped-agent" so callers can record it.
+#   - Laptop / non-agent HQ: one flock-guarded nohup of cleanup → update → embed.
+#
+# Seatbelt: PATH /usr/local/bin/qmd shim still flock-serializes any stray raw
+# embed on agent boxes (toolset). This helper simply refuses to start work.
+#
+# Usage (fire-and-forget; prints token/PID on stdout):
+#   core/scripts/qmd-reindex-bg.sh
+#   core/scripts/qmd-reindex-bg.sh --log /tmp/qmd-handoff.log
+#
+# Exit 0 always for callers that must not fail handoff.
+
+set -u
+
+LOG="${QMD_REINDEX_LOG:-/tmp/qmd-handoff.log}"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --log) LOG="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,22p' "$0"
+      exit 0
+      ;;
+    *) shift ;;
+  esac
+done
+
+# Explicit skip (ritual/toolset can force this even on laptop for tests).
+if [ "${HQ_QMD_REINDEX_MODE:-}" = "skip-agent" ] || [ "${HQ_QMD_REINDEX_MODE:-}" = "skip" ]; then
+  echo "skipped-agent" >>"$LOG" 2>/dev/null || true
+  echo "skipped-agent"
+  exit 0
+fi
+
+if ! command -v qmd >/dev/null 2>&1; then
+  echo "skipped"
+  exit 0
+fi
+
+# ---- Hosted agent box: indexer owns mutation; handoff does not kick ----
+_agent_box=0
+if [ -n "${HQ_AGENT_BOX:-}" ] && [ "${HQ_AGENT_BOX}" != "0" ]; then
+  _agent_box=1
+fi
+if [ -x /usr/local/bin/hq-agent-qmd-index ] \
+  || [ -x /usr/local/lib/hq-agent/qmd-index-user ] \
+  || [ -f /etc/systemd/system/hq-agent-qmd-index.timer ] \
+  || [ -f /etc/systemd/system/hq-agent-qmd-index.service ] \
+  || systemctl is-enabled hq-agent-qmd-index.timer >/dev/null 2>&1; then
+  _agent_box=1
+fi
+if [ -d /var/lib/hq-agent ] && { [ -d /home/ec2-user/hq-agent ] || [ -d "${AGENT_WORKDIR:-}" ]; }; then
+  _agent_box=1
+fi
+
+if [ "$_agent_box" -eq 1 ]; then
+  # Freshness: timer (15m lexical) + post-sync qmd-need-lexical flag (indexer).
+  # Handoff must not systemctl-start the full oneshot (can arm embed under load).
+  echo "skipped-agent" >>"$LOG" 2>/dev/null || true
+  echo "skipped-agent"
+  exit 0
+fi
+
+# ---- Laptop / non-agent: single-flight raw reindex ----
+LOCK_DIR="${HOME:-/tmp}/.hq-agent"
+mkdir -p "$LOCK_DIR" 2>/dev/null || LOCK_DIR="/tmp"
+LOCK_FILE="${LOCK_DIR}/qmd-index.lock"
+
+nohup bash -c "
+  exec 9>\"${LOCK_FILE}\" || exit 0
+  flock -n 9 || exit 0
+  {
+    echo \"[qmd-reindex-bg] start \$(date -Iseconds)\"
+    nice -n 19 ionice -c 3 qmd cleanup 2>/dev/null || true
+    nice -n 19 ionice -c 3 qmd update 2>/dev/null || true
+    nice -n 19 ionice -c 3 qmd embed 2>/dev/null || true
+    echo \"[qmd-reindex-bg] done \$(date -Iseconds)\"
+  } >>\"${LOG}\" 2>&1
+" >/dev/null 2>&1 &
+echo $!
+exit 0


### PR DESCRIPTION
## Summary
- Replace dual `nohup qmd cleanup; update; embed` in `handoff-finalize` / `handoff-post` with `qmd-reindex-bg` (agent hard-skip, laptop single-flight flock).
- Add `core/scripts/qmd-reindex-bg.sh` so rescue/kit installs stop reintroducing thrash scripts on fleet boxes.

## Context
hq-pro #1790 delivers toolset ownership; kit still shipped thrash-prone handoff scripts that `hq rescue` re-seeds into agent workdirs. This is plan WS3b.

## Test plan
- [x] No raw `nohup bash -c 'qmd cleanup...'` left in handoff scripts
- [x] Agent detect paths print `skipped-agent`
- [ ] After release/tag: agent rescue no longer reintroduces dual-embed handoff