### PR TITLE
feat(delegate): delegation bundle spec + builder (US-001)

### DIFF
--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,5 +1,5 @@
 version: 1
-hqVersion: "15.0.82"
+hqVersion: "15.0.83"
 agentSessionContractVersion: 1
 # Provider adapter contract version (US-500). Must match
 # HQ_ADAPTER_CONTRACT_VERSION in core/scripts/lib/provider-adapter-version.sh.

--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,5 +1,5 @@
 version: 1
-hqVersion: "15.0.81"
+hqVersion: "15.0.82"
 agentSessionContractVersion: 1
 # Provider adapter contract version (US-500). Must match
 # HQ_ADAPTER_CONTRACT_VERSION in core/scripts/lib/provider-adapter-version.sh.

--- a/core/knowledge/public/hq-core/delegation-bundle-spec.md
+++ b/core/knowledge/public/hq-core/delegation-bundle-spec.md
@@ -1,0 +1,100 @@
+# Delegation bundle — manifest.json v1 schema
+
+A **delegation bundle** is the portable, self-describing artifact `/delegate`
+builds when a project is handed from one principal to another. It lives at
+`workspace/delegations/<delegationId>/` and contains:
+
+- `manifest.json` — the machine-readable contract described here
+- `BRIEF.md` — full-prose orientation for a reader who has never seen the
+  project
+- `PICKUP-PROMPT.md` — generated later (US-007) from the manifest; the
+  self-sufficient prompt delivered by DM
+
+The manifest is the **single source of truth** for the whole delegation: the
+grant step, the verification probe, and the pickup prompt are all generated
+from it. Nothing downstream may invent a path, prefix, or secret name that is
+not in the manifest, and nothing in the manifest may be silently skipped.
+
+Builder: `core/scripts/hq-delegate-bundle.sh build --company <slug>
+--project <name> --to <principal> [--to-kind person|agent] [--to-name <name>]
+[--mode transfer|share]`. Prints the `delegationId` on stdout.
+
+## Top-level fields
+
+| Field | Type | Meaning |
+|---|---|---|
+| `schemaVersion` | number | Always `1` for this spec. |
+| `delegationId` | string | `dlg-<UTCstamp>-<project>` — also the bundle directory name. |
+| `createdAt` | string | ISO-8601 UTC creation time. |
+| `mode` | `"transfer"` \| `"share"` | `transfer` reassigns ownership (board, PRD, work mesh); `share` grants access but leaves ownership with the delegator. |
+| `from` | object | `{email, personUid}` of the delegator — resolved from `hq whoami` when available, else `null`s (filled before send). |
+| `to` | object | `{kind, principal, displayName}` — `kind` is `person` or `agent`; `principal` is a **confirmed** email, `prs_…`, or `agt_…` (resolved by `hq-delegate-resolve.sh`, never a guessed name). |
+| `company` | string | Company slug. Delegation never crosses a company boundary. |
+| `project` | object | `{name, prdPath, boardId}` — `prdPath` is HQ-root-relative; `boardId` is the `companies/<co>/board.json` project id or `null`. |
+| `vaultPrefixes` | array | What gets granted — see below. |
+| `repo` | object \| `null` | Code handover state — see below. `null` when the project has no `metadata.repoPath`. |
+| `secrets` | array | Secret **names** (never values) the recipient is granted — filled by the US-005 step; `[]` until then, `{skipped: true}` recorded when `--no-secrets`. |
+| `knowledge` | array | HQ-root-relative knowledge paths referenced by the PRD (for the brief and pickup prompt). |
+| `policies` | array | HQ-root-relative policy paths referenced by the PRD. |
+| `checksums` | object | `{<HQ-root-relative path>: <sha256>}` for every file in the project dossier at freeze time (capped at 200 files). Lets the recipient verify integrity after pulling. |
+| `status` | string | Delegation state machine — see below. |
+
+## `vaultPrefixes[]` entries
+
+```json
+{ "prefix": "projects/hq-delegate-command/", "permission": "write", "reason": "project dossier" }
+```
+
+- `prefix` — **bucket-relative** (never prefixed with `companies/<slug>/`) and
+  **always trailing-slash folder form**, per the hq-files prefix conventions. A
+  bare prefix would degrade to a single literal key and grant nothing useful;
+  the builder hard-fails rather than emit one.
+- `permission` — `write` on the project dossier, `read` on referenced
+  knowledge/policy folders. Individual knowledge *files* are mapped to their
+  containing folder.
+- `reason` — human-readable justification, surfaced in the confirmation step.
+
+After the grant step verifies a prefix via ACL read-back, it may annotate the
+entry with `verifiedAt` and the confirmed permission.
+
+## `repo` block
+
+```json
+{ "path": "repos/public/hq-core", "remote": "git@github.com:org/repo.git",
+  "branch": "feature/x", "baseBranch": "main", "headSha": "abc123…",
+  "dirtyFiles": [], "accessVerified": false }
+```
+
+The builder records `path`, `branch`, and `baseBranch` from the PRD; the
+US-004 handover step fills `remote` and `headSha`, lists uncommitted work in
+`dirtyFiles[]` (called out in the brief as **not transferred**), and sets
+`accessVerified` after a read-only `gh` access check. Repo paths never appear
+in `vaultPrefixes[]` and repo content is never pushed to the vault.
+
+## `status` state machine
+
+```
+building → granted → verified → sent
+```
+
+- `building` — bundle written, nothing granted yet.
+- `granted` — vault ACL grants written and read back successfully (US-003).
+- `verified` — every prefix probed reachable via `hq files browse` (US-008).
+- `sent` — DM delivered; manifest records the DM `eventId`.
+
+A failed step leaves the last successful status, so a re-run resumes instead
+of repeating grants. `--dry-run` never creates a bundle at all.
+
+## Hard safety rules
+
+Two rules apply to every artifact in the bundle and everything generated from
+it (policy `hq-delegate-never-inlines-secrets-or-share-urls`):
+
+1. **No secret value, ever.** Secrets appear by *name* only and are consumed
+   through `hq run` / `hq secrets exec`. The builder scans its own manifest and
+   brief against the shared secret patterns
+   (`core/scripts/lib/secret-patterns.sh`, mirroring
+   `.claude/hooks/detect-secrets.sh`) and fails closed on any match.
+2. **No share-session URLs.** Delegation uses direct ACL grants only. A
+   share-session URL is a live capability token and must never be minted or
+   embedded by any delegation step.

--- a/core/scripts/hq-delegate-bundle.sh
+++ b/core/scripts/hq-delegate-bundle.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# hq-core: public
+# hq-delegate-bundle.sh — freeze a project into a portable delegation bundle.
+#
+# Usage:
+#   core/scripts/hq-delegate-bundle.sh build \
+#     --company <slug> --project <name> --to <principal> \
+#     [--to-kind person|agent] [--to-name <display name>] \
+#     [--mode transfer|share]
+#
+# Writes workspace/delegations/<delegationId>/{manifest.json,BRIEF.md} and
+# prints the delegationId on stdout. The manifest is the single source of
+# truth for every downstream delegation step (grants, verification, pickup
+# prompt) — schema documented in
+# core/knowledge/public/hq-core/delegation-bundle-spec.md.
+#
+# Fails closed (non-zero, nothing written) when:
+#   - required arguments are missing
+#   - the project directory or its prd.json does not exist / parses invalid
+#   - the generated manifest or BRIEF matches a secret-detection pattern
+#
+# Env:
+#   HQ_ROOT — HQ root override (default: resolved from this script's location)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HQ_ROOT="${HQ_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+
+# shellcheck source=lib/secret-patterns.sh
+. "$SCRIPT_DIR/lib/secret-patterns.sh"
+
+usage() {
+  sed -n '3,13p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+die() {
+  echo "hq-delegate-bundle: $*" >&2
+  exit 1
+}
+
+command -v jq >/dev/null 2>&1 || die "jq is required but not installed"
+
+# --- argument parsing --------------------------------------------------------
+
+[ "${1:-}" = "build" ] || { usage >&2; exit 1; }
+shift
+
+COMPANY="" PROJECT="" TO="" TO_KIND="person" TO_NAME="" MODE="transfer"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --company) COMPANY="${2:-}"; shift 2 ;;
+    --project) PROJECT="${2:-}"; shift 2 ;;
+    --to)      TO="${2:-}"; shift 2 ;;
+    --to-kind) TO_KIND="${2:-}"; shift 2 ;;
+    --to-name) TO_NAME="${2:-}"; shift 2 ;;
+    --mode)    MODE="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$COMPANY" ] || die "--company is required"
+[ -n "$PROJECT" ] || die "--project is required"
+[ -n "$TO" ]      || die "--to is required"
+case "$MODE" in transfer|share) ;; *) die "--mode must be transfer or share" ;; esac
+case "$TO_KIND" in person|agent) ;; *) die "--to-kind must be person or agent" ;; esac
+
+PROJECT_DIR="$HQ_ROOT/companies/$COMPANY/projects/$PROJECT"
+PRD="$PROJECT_DIR/prd.json"
+[ -d "$PROJECT_DIR" ] || die "project directory not found: companies/$COMPANY/projects/$PROJECT"
+[ -f "$PRD" ] || die "project has no prd.json: companies/$COMPANY/projects/$PROJECT/prd.json"
+jq -e . "$PRD" >/dev/null 2>&1 || die "prd.json is not valid JSON: $PRD"
+
+# --- identity ----------------------------------------------------------------
+
+CREATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+DELEGATION_ID="dlg-$(date -u +%Y%m%d-%H%M%S)-$PROJECT"
+FROM_EMAIL="" FROM_UID=""
+if command -v hq >/dev/null 2>&1; then
+  WHOAMI_JSON="$(hq whoami --json 2>/dev/null || true)"
+  if [ -n "$WHOAMI_JSON" ] && printf '%s' "$WHOAMI_JSON" | jq -e . >/dev/null 2>&1; then
+    FROM_EMAIL="$(printf '%s' "$WHOAMI_JSON" | jq -r '.email // empty')"
+    FROM_UID="$(printf '%s' "$WHOAMI_JSON" | jq -r '.personUid // .uid // empty')"
+  fi
+fi
+
+# --- checksum helper (macOS + Linux) -----------------------------------------
+
+file_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+# --- derive vault prefixes, knowledge, policies ------------------------------
+#
+# Vault prefixes are BUCKET-RELATIVE (never prefixed with companies/<slug>/)
+# and always in trailing-slash folder form — see hq-files "Prefix Conventions".
+
+PROJECT_PREFIX="projects/$PROJECT/"
+
+# knowledge entries from prd metadata: split into vault-grantable (under this
+# company), policies (under this company's policies/), and repo-based docs
+# (recorded for the brief, never granted as vault prefixes).
+KNOWLEDGE_JSON="$(jq -c '[.metadata.knowledge // [] | .[]]' "$PRD")"
+
+VAULT_READ_PREFIXES="$(printf '%s' "$KNOWLEDGE_JSON" | jq -r --arg co "$COMPANY" '
+  [ .[]
+    | select(startswith("companies/" + $co + "/"))
+    | sub("^companies/" + $co + "/"; "")
+    # a file path -> its containing folder; a dir path -> itself with slash
+    | if endswith("/") then . else (split("/")[:-1] | join("/") + "/") end
+  ] | unique | .[]')"
+
+MANIFEST_KNOWLEDGE="$(printf '%s' "$KNOWLEDGE_JSON" | jq -c --arg co "$COMPANY" '
+  [ .[] | select((startswith("companies/" + $co + "/policies/")) | not) ] | unique')"
+MANIFEST_POLICIES="$(printf '%s' "$KNOWLEDGE_JSON" | jq -c --arg co "$COMPANY" '
+  [ .[] | select(startswith("companies/" + $co + "/policies/")) ] | unique')"
+
+# vaultPrefixes[]: write on the project dossier, read on referenced knowledge.
+VAULT_PREFIXES_JSON="$(
+  {
+    jq -cn --arg p "$PROJECT_PREFIX" \
+      '{prefix: $p, permission: "write", reason: "project dossier"}'
+    if [ -n "$VAULT_READ_PREFIXES" ]; then
+      printf '%s\n' "$VAULT_READ_PREFIXES" | while IFS= read -r pfx; do
+        [ -n "$pfx" ] || continue
+        jq -cn --arg p "$pfx" \
+          '{prefix: $p, permission: "read", reason: "referenced knowledge/policies"}'
+      done
+    fi
+  } | jq -cs 'unique_by(.prefix)'
+)"
+
+# Guard: every prefix must be folder form and company-relative.
+printf '%s' "$VAULT_PREFIXES_JSON" | jq -e '
+  all(.[]; (.prefix | endswith("/")) and (.prefix | startswith("companies/") | not))
+' >/dev/null || die "internal error: derived a non-folder or company-anchored prefix"
+
+# --- repo block (recorded here; verified/pushed by the US-004 step) ----------
+
+REPO_PATH="$(jq -r '.metadata.repoPath // empty' "$PRD")"
+if [ -n "$REPO_PATH" ]; then
+  REPO_JSON="$(jq -cn \
+    --arg path "$REPO_PATH" \
+    --arg branch "$(jq -r '.branchName // empty' "$PRD")" \
+    --arg base "$(jq -r '.metadata.baseBranch // "main"' "$PRD")" \
+    '{path: $path, remote: null, branch: (if $branch == "" then null else $branch end),
+      baseBranch: $base, headSha: null, dirtyFiles: [], accessVerified: false}')"
+else
+  REPO_JSON="null"
+fi
+
+# --- board id ----------------------------------------------------------------
+
+BOARD_ID="null"
+BOARD_FILE="$HQ_ROOT/companies/$COMPANY/board.json"
+if [ -f "$BOARD_FILE" ]; then
+  BOARD_ID="$(jq --arg prd "companies/$COMPANY/projects/$PROJECT/prd.json" \
+    '[.projects // [] | .[] | select(.prd_path == $prd) | .id] | first // null' \
+    "$BOARD_FILE" 2>/dev/null || echo null)"
+fi
+
+# --- checksums of the project dossier ----------------------------------------
+
+CHECKSUMS_JSON="$(
+  cd "$HQ_ROOT" || exit 1
+  find "companies/$COMPANY/projects/$PROJECT" -type f ! -name '.DS_Store' | sort | head -200 | \
+  while IFS= read -r f; do
+    jq -cn --arg p "$f" --arg h "$(file_sha256 "$f")" '{key: $p, value: $h}'
+  done | jq -s 'from_entries'
+)"
+
+# --- build in a temp dir, scan, then move into place -------------------------
+
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+
+jq -n \
+  --arg id "$DELEGATION_ID" \
+  --arg createdAt "$CREATED_AT" \
+  --arg mode "$MODE" \
+  --arg fromEmail "$FROM_EMAIL" \
+  --arg fromUid "$FROM_UID" \
+  --arg toKind "$TO_KIND" \
+  --arg toPrincipal "$TO" \
+  --arg toName "$TO_NAME" \
+  --arg company "$COMPANY" \
+  --arg project "$PROJECT" \
+  --arg prdPath "companies/$COMPANY/projects/$PROJECT/prd.json" \
+  --argjson boardId "$BOARD_ID" \
+  --argjson vaultPrefixes "$VAULT_PREFIXES_JSON" \
+  --argjson repo "$REPO_JSON" \
+  --argjson knowledge "$MANIFEST_KNOWLEDGE" \
+  --argjson policies "$MANIFEST_POLICIES" \
+  --argjson checksums "$CHECKSUMS_JSON" \
+  '{
+    schemaVersion: 1,
+    delegationId: $id,
+    createdAt: $createdAt,
+    mode: $mode,
+    from: {email: (if $fromEmail == "" then null else $fromEmail end),
+           personUid: (if $fromUid == "" then null else $fromUid end)},
+    to: {kind: $toKind, principal: $toPrincipal,
+         displayName: (if $toName == "" then null else $toName end)},
+    company: $company,
+    project: {name: $project, prdPath: $prdPath, boardId: $boardId},
+    vaultPrefixes: $vaultPrefixes,
+    repo: $repo,
+    secrets: [],
+    knowledge: $knowledge,
+    policies: $policies,
+    checksums: $checksums,
+    status: "building"
+  }' > "$STAGE/manifest.json"
+
+# --- BRIEF.md — full prose for a reader who has never seen the project -------
+
+DESCRIPTION="$(jq -r '.description // "No description recorded."' "$PRD")"
+GOAL="$(jq -r '.metadata.goal // empty' "$PRD")"
+TOTAL_STORIES="$(jq -r '[.userStories // [] | .[]] | length' "$PRD")"
+DONE_STORIES="$(jq -r '[.userStories // [] | .[] | select(.passes == true)] | length' "$PRD")"
+DONE_LIST="$(jq -r '[.userStories // [] | .[] | select(.passes == true)] | .[] | "- \(.id): \(.title)"' "$PRD")"
+NEXT_STEPS="$(jq -r '[.userStories // [] | .[] | select(.passes != true)]
+  | sort_by(.priority) | .[:3] | .[]
+  | "### \(.id): \(.title)\n\n\(.description)\n"' "$PRD")"
+OPEN_QUESTIONS="$(jq -r '[.metadata.openQuestions // [] | .[]] | .[] | "- \(.)"' "$PRD")"
+TRAPS="$(jq -r '[.metadata.securityNotes // empty, (.metadata.executionConventions // [] | .[])]
+  | .[] | "- \(.)"' "$PRD")"
+
+{
+  echo "# Delegation brief — $PROJECT"
+  echo
+  echo "You are receiving ownership of the **$PROJECT** project in the **$COMPANY** company. This brief is written assuming you have never seen the project before. Everything referenced here is covered by the access you have already been granted — nothing below requires asking the delegator for permissions."
+  echo
+  echo "## What this project is"
+  echo
+  echo "$DESCRIPTION"
+  if [ -n "$GOAL" ]; then
+    echo
+    echo "## The goal"
+    echo
+    echo "$GOAL"
+  fi
+  echo
+  echo "## Where things stand"
+  echo
+  echo "$DONE_STORIES of $TOTAL_STORIES stories are complete."
+  if [ -n "$DONE_LIST" ]; then
+    echo
+    echo "Already done:"
+    echo
+    echo "$DONE_LIST"
+  fi
+  echo
+  echo "## The next three steps"
+  echo
+  if [ -n "$NEXT_STEPS" ]; then
+    echo "$NEXT_STEPS"
+  else
+    echo "All stories are complete. Remaining work, if any, is described in the project's post-implementation notes."
+  fi
+  if [ -n "$OPEN_QUESTIONS" ]; then
+    echo "## Open questions"
+    echo
+    echo "$OPEN_QUESTIONS"
+    echo
+  fi
+  if [ -n "$TRAPS" ]; then
+    echo "## Known traps and conventions"
+    echo
+    echo "$TRAPS"
+    echo
+  fi
+  echo "## Where everything lives"
+  echo
+  echo "The full PRD (every story, acceptance criteria, and decision history) is at \`companies/$COMPANY/projects/$PROJECT/prd.json\`. The pickup prompt that accompanied this brief pulls every file you need on demand — you do not need to run a full sync."
+} > "$STAGE/BRIEF.md"
+
+# --- fail-closed secret scan -------------------------------------------------
+
+if ! hq_scan_secrets "$STAGE/manifest.json" "$STAGE/BRIEF.md"; then
+  die "generated bundle matched a secret-detection pattern — nothing written (see stderr above)"
+fi
+
+# --- move into place ---------------------------------------------------------
+
+DEST="$HQ_ROOT/workspace/delegations/$DELEGATION_ID"
+mkdir -p "$(dirname "$DEST")"
+mv "$STAGE" "$DEST"
+trap - EXIT
+
+echo "$DELEGATION_ID"
+echo "hq-delegate-bundle: wrote workspace/delegations/$DELEGATION_ID/{manifest.json,BRIEF.md}" >&2

--- a/core/scripts/hq-delegate-resolve.sh
+++ b/core/scripts/hq-delegate-resolve.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# hq-core: public
+# hq-delegate-resolve.sh — resolve a delegation recipient to a confirmed
+# principal (person email / prs_ uid, or fleet-agent agt_ uid). Read-only.
+#
+# Usage:
+#   core/scripts/hq-delegate-resolve.sh --company <slug> --to <token>
+#
+# Output (stdout, JSON): {kind, principal, displayName, source}
+#   kind      — "person" | "agent"
+#   principal — confirmed email, prs_… or agt_… uid
+#   source    — "verbatim" | "people-resolve" | "agents-list"
+#
+# Exit codes:
+#   0 — resolved
+#   1 — usage error (missing/invalid arguments)
+#   3 — ambiguous: candidate list printed to stdout as JSON
+#       {status:"ambiguous", matches:[…]} — caller must present a picker
+#   4 — not found (or found with no email): plain message on stderr
+#
+# Tenancy: every lookup is scoped with an explicit --company. This helper
+# never enumerates or falls back across companies — single-company by
+# construction, matching the /dm skill's resolution contract.
+#
+# Fast path: a token containing "@" or starting with prs_ / agt_ passes
+# through verbatim with NO lookup, preserving existing invocations exactly.
+
+set -euo pipefail
+
+usage() {
+  sed -n '3,26p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+die_usage() {
+  echo "hq-delegate-resolve: $*" >&2
+  usage >&2
+  exit 1
+}
+
+command -v jq >/dev/null 2>&1 || { echo "hq-delegate-resolve: jq is required" >&2; exit 1; }
+
+COMPANY="" TOKEN=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --company) COMPANY="${2:-}"; shift 2 ;;
+    --to)      TOKEN="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) die_usage "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$COMPANY" ] || die_usage "--company is required (single-company lookups only; never a multi-company scan)"
+[ -n "$TOKEN" ]   || die_usage "--to is required"
+
+emit() { # kind principal displayName source
+  jq -cn --arg kind "$1" --arg principal "$2" --arg name "$3" --arg source "$4" \
+    '{kind: $kind, principal: $principal,
+      displayName: (if $name == "" then null else $name end), source: $source}'
+}
+
+# Strip CLI noise (version warnings, session-refresh notices) before the JSON
+# payload: keep everything from the first line that starts a JSON value.
+json_only() {
+  awk 'started {print; next} /^[[:space:]]*[{[]/ {started=1; print}'
+}
+
+# --- fast path: already a principal — pass through verbatim, no lookup -------
+
+case "$TOKEN" in
+  agt_*)
+    emit agent "$TOKEN" "" verbatim
+    exit 0
+    ;;
+  prs_*|*@*)
+    emit person "$TOKEN" "" verbatim
+    exit 0
+    ;;
+esac
+
+# --- name → people roster (single-company, read-only) ------------------------
+
+PEOPLE_RAW="$(hq people resolve "$TOKEN" --json --company "$COMPANY" 2>/dev/null | json_only || true)"
+PEOPLE_STATUS=""
+if [ -n "$PEOPLE_RAW" ] && printf '%s' "$PEOPLE_RAW" | jq -e . >/dev/null 2>&1; then
+  PEOPLE_STATUS="$(printf '%s' "$PEOPLE_RAW" | jq -r '.status // empty')"
+fi
+
+case "$PEOPLE_STATUS" in
+  found)
+    EMAIL="$(printf '%s' "$PEOPLE_RAW" | jq -r '.email // empty')"
+    NAME="$(printf '%s' "$PEOPLE_RAW" | jq -r '.name // .displayName // empty')"
+    [ -n "$EMAIL" ] || { echo "hq-delegate-resolve: resolver returned found but no email for '$TOKEN'" >&2; exit 4; }
+    emit person "$EMAIL" "$NAME" people-resolve
+    exit 0
+    ;;
+  ambiguous)
+    printf '%s' "$PEOPLE_RAW" | jq -c '{status: "ambiguous", matches: (.matches // [])}'
+    exit 3
+    ;;
+  no_email)
+    echo "hq-delegate-resolve: '$TOKEN' was found in company '$COMPANY' but has no email on record — pass their exact email or personUid instead" >&2
+    exit 4
+    ;;
+  not_found|"")
+    : # fall through to the fleet-agent roster
+    ;;
+  *)
+    echo "hq-delegate-resolve: unexpected resolver status '$PEOPLE_STATUS' for '$TOKEN'" >&2
+    exit 4
+    ;;
+esac
+
+# --- name → fleet-agent roster (same company, read-only) ---------------------
+
+AGENTS_RAW="$(hq agents list --company "$COMPANY" --json 2>/dev/null | json_only || true)"
+if [ -z "$AGENTS_RAW" ] || ! printf '%s' "$AGENTS_RAW" | jq -e . >/dev/null 2>&1; then
+  AGENTS_RAW="[]"
+fi
+
+MATCHES="$(printf '%s' "$AGENTS_RAW" | jq -c --arg t "$TOKEN" '
+  [ .[]
+    | select((.name // .displayName // "") | ascii_downcase == ($t | ascii_downcase))
+    | {agentUid: (.agentUid // .uid // empty), name: (.name // .displayName // "")}
+    | select(.agentUid != "")
+  ]')"
+MATCH_COUNT="$(printf '%s' "$MATCHES" | jq 'length')"
+
+if [ "$MATCH_COUNT" -eq 1 ]; then
+  emit agent \
+    "$(printf '%s' "$MATCHES" | jq -r '.[0].agentUid')" \
+    "$(printf '%s' "$MATCHES" | jq -r '.[0].name')" \
+    agents-list
+  exit 0
+elif [ "$MATCH_COUNT" -gt 1 ]; then
+  printf '%s' "$MATCHES" | jq -c '{status: "ambiguous", matches: .}'
+  exit 3
+fi
+
+echo "hq-delegate-resolve: no teammate or fleet agent named '$TOKEN' found in company '$COMPANY' — pass the exact email, personUid (prs_…), or agentUid (agt_…) instead" >&2
+exit 4

--- a/core/scripts/lib/secret-patterns.sh
+++ b/core/scripts/lib/secret-patterns.sh
@@ -1,0 +1,49 @@
+# shellcheck shell=bash
+# hq-core: public
+# secret-patterns.sh — shared secret-detection patterns for hq-core shell scripts.
+#
+# SOURCED, never executed:  . "$ROOT/core/scripts/lib/secret-patterns.sh"
+# bash 3.2 safe; no associative arrays.
+#
+# Single source of truth for the secret-shaped patterns that generated
+# artifacts (delegation manifests, briefs, pickup prompts, DM payloads) are
+# scanned against before they are written to disk or transmitted. Mirrors the
+# runtime PreToolUse hook at .claude/hooks/detect-secrets.sh — a regression
+# test (core/scripts/tests/hq-delegate-bundle.test.sh) asserts this list stays
+# a superset of the hook's, so the two cannot silently drift.
+#
+# Entries are "<extended-regex>:<human name>". The regex part may not contain
+# a colon; the name may.
+
+SECRET_PATTERNS=(
+  "sk-[a-zA-Z0-9._-]{20,}:OpenAI/Stripe key"
+  "ghp_[a-zA-Z0-9]{36,}:GitHub PAT"
+  "AKIA[0-9A-Z]{16}:AWS access key"
+  "xox[bpsa]-[a-zA-Z0-9-]+:Slack token"
+  "Bearer [a-zA-Z0-9._-]{20,}:Bearer token"
+  "-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----:Private key"
+  "glpat-[a-zA-Z0-9_-]{20,}:GitLab PAT"
+  "gho_[a-zA-Z0-9]{36,}:GitHub OAuth token"
+  "github_pat_[a-zA-Z0-9_]{22,}:Fine-grained GitHub PAT"
+  "eyJ[a-zA-Z0-9_-]{20,}\.[a-zA-Z0-9_-]{20,}\.[a-zA-Z0-9_-]{10,}:JWT"
+)
+
+# hq_scan_secrets <file>...
+#   Scan files for secret-shaped content. Prints "pattern: <name> in <file>"
+#   to stderr for every hit (never the matched value itself) and returns 1 if
+#   anything matched, 0 when all files are clean. Missing files are skipped.
+hq_scan_secrets() {
+  local hit=0 f entry pattern name
+  for f in "$@"; do
+    [ -f "$f" ] || continue
+    for entry in "${SECRET_PATTERNS[@]}"; do
+      pattern="${entry%%:*}"
+      name="${entry#*:}"
+      if grep -Eq "$pattern" "$f" 2>/dev/null; then
+        echo "secret-scan: pattern '$name' matched in $f" >&2
+        hit=1
+      fi
+    done
+  done
+  return "$hit"
+}

--- a/core/scripts/tests/hq-delegate-bundle.test.sh
+++ b/core/scripts/tests/hq-delegate-bundle.test.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Regression: hq-delegate-bundle.sh must freeze a project into a valid v1
+# delegation bundle, fail closed on missing inputs, and fail closed (writing
+# nothing) when its own output matches a secret-detection pattern.
+#
+# Guards:
+#   1. A fixture project with a prd.json builds a manifest that validates
+#      against the documented v1 schema, plus a non-empty prose BRIEF.md, and
+#      the delegationId is printed on stdout.
+#   2. Vault prefixes are bucket-relative folder form: every prefix ends in
+#      "/" and none starts with "companies/".
+#   3. Missing prd.json → non-zero exit, nothing written.
+#   4. Secret-shaped content in the prd → non-zero exit, no new directory
+#      under workspace/delegations/.
+#   5. The shared secret-pattern lib stays a superset of the runtime hook's
+#      patterns (.claude/hooks/detect-secrets.sh) so the two cannot drift.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+BUILDER="$ROOT/core/scripts/hq-delegate-bundle.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$BUILDER" ] || fail "missing builder: $BUILDER"
+
+# --- fixture HQ root ---------------------------------------------------------
+
+FIX="$TMP/hqroot"
+PROJ="$FIX/companies/acme/projects/widget"
+mkdir -p "$PROJ" "$FIX/workspace" "$FIX/companies/acme/knowledge/insights"
+echo "insight body" > "$FIX/companies/acme/knowledge/insights/widget-notes.md"
+
+cat > "$PROJ/prd.json" <<'JSON'
+{
+  "name": "widget",
+  "description": "Build the widget.",
+  "branchName": "feature/widget",
+  "metadata": {
+    "goal": "Widgets ship.",
+    "repoPath": "repos/public/widget-repo",
+    "baseBranch": "main",
+    "knowledge": [
+      "companies/acme/knowledge/insights/widget-notes.md",
+      "companies/acme/policies/widget-policy.md",
+      "repos/public/widget-repo/docs/widget.md"
+    ],
+    "openQuestions": ["Should widgets spin?"],
+    "executionConventions": ["Branch from origin/main"]
+  },
+  "userStories": [
+    {"id": "US-001", "title": "Frame", "description": "Build the frame.", "priority": 1, "passes": true},
+    {"id": "US-002", "title": "Spin", "description": "Make it spin.", "priority": 1, "passes": false},
+    {"id": "US-003", "title": "Paint", "description": "Paint it.", "priority": 2, "passes": false}
+  ]
+}
+JSON
+
+cat > "$FIX/companies/acme/board.json" <<'JSON'
+{"projects": [{"id": "ac-proj-7", "prd_path": "companies/acme/projects/widget/prd.json"}]}
+JSON
+
+# Stub hq CLI so `hq whoami --json` works offline.
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/hq" <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "whoami" ]; then
+  echo '{"email": "owner@acme.test", "personUid": "prs_owner1"}'
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "$TMP/bin/hq"
+export PATH="$TMP/bin:$PATH"
+
+# --- 1+2. happy path ---------------------------------------------------------
+
+OUT="$(HQ_ROOT="$FIX" bash "$BUILDER" build --company acme --project widget \
+  --to alice@acme.test --to-name "Alice" 2>"$TMP/stderr.log")" \
+  || fail "builder exited non-zero on valid fixture: $(cat "$TMP/stderr.log")"
+
+DID="$(printf '%s' "$OUT" | head -1)"
+case "$DID" in dlg-*-widget) ;; *) fail "stdout is not a delegationId: '$OUT'" ;; esac
+
+BUNDLE="$FIX/workspace/delegations/$DID"
+MANIFEST="$BUNDLE/manifest.json"
+BRIEF="$BUNDLE/BRIEF.md"
+[ -f "$MANIFEST" ] || fail "manifest not written: $MANIFEST"
+[ -f "$BRIEF" ] || fail "BRIEF not written: $BRIEF"
+
+# Schema validation — required fields, correct values.
+jq -e '
+  .schemaVersion == 1 and
+  .delegationId != null and
+  .createdAt != null and
+  .mode == "transfer" and
+  .from.email == "owner@acme.test" and
+  .to.kind == "person" and
+  .to.principal == "alice@acme.test" and
+  .to.displayName == "Alice" and
+  .company == "acme" and
+  .project.name == "widget" and
+  .project.prdPath == "companies/acme/projects/widget/prd.json" and
+  .project.boardId == "ac-proj-7" and
+  (.vaultPrefixes | type) == "array" and (.vaultPrefixes | length) >= 2 and
+  .repo.path == "repos/public/widget-repo" and
+  .repo.branch == "feature/widget" and
+  .repo.baseBranch == "main" and
+  .secrets == [] and
+  (.checksums | type) == "object" and (.checksums | length) >= 1 and
+  .status == "building"
+' "$MANIFEST" >/dev/null || fail "manifest does not validate against the v1 schema: $(cat "$MANIFEST")"
+
+# Write on the project dossier, read on referenced knowledge.
+jq -e '.vaultPrefixes[] | select(.prefix == "projects/widget/" and .permission == "write")' \
+  "$MANIFEST" >/dev/null || fail "missing write grant on projects/widget/"
+jq -e '.vaultPrefixes[] | select(.prefix == "knowledge/insights/" and .permission == "read")' \
+  "$MANIFEST" >/dev/null || fail "missing read grant on knowledge/insights/"
+jq -e '.vaultPrefixes[] | select(.prefix == "policies/" and .permission == "read")' \
+  "$MANIFEST" >/dev/null || fail "missing read grant on policies/"
+
+# Prefix conventions: folder form, bucket-relative, no repo paths.
+jq -e 'all(.vaultPrefixes[]; (.prefix | endswith("/")) and (.prefix | startswith("companies/") | not) and (.prefix | startswith("repos/") | not))' \
+  "$MANIFEST" >/dev/null || fail "a vault prefix violates conventions (folder form, bucket-relative, no repos/)"
+
+# Repo docs recorded as knowledge but never granted.
+jq -e '.knowledge | index("repos/public/widget-repo/docs/widget.md")' "$MANIFEST" >/dev/null \
+  || fail "repo-based doc missing from knowledge[]"
+jq -e '.policies == ["companies/acme/policies/widget-policy.md"]' "$MANIFEST" >/dev/null \
+  || fail "policy path not routed into policies[]"
+
+# BRIEF is non-empty prose covering the required sections.
+[ -s "$BRIEF" ] || fail "BRIEF.md is empty"
+for section in "What this project is" "Where things stand" "The next three steps" "Open questions" "Known traps"; do
+  grep -q "$section" "$BRIEF" || fail "BRIEF missing section: $section"
+done
+grep -q "US-002" "$BRIEF" || fail "BRIEF next steps must name the top incomplete story"
+grep -q "1 of 3 stories" "$BRIEF" || fail "BRIEF must state where things stand (1 of 3)"
+
+# --- 3. missing prd.json → non-zero, nothing written -------------------------
+
+mkdir -p "$FIX/companies/acme/projects/empty"
+if HQ_ROOT="$FIX" bash "$BUILDER" build --company acme --project empty \
+  --to alice@acme.test >/dev/null 2>&1; then
+  fail "builder must exit non-zero when the project has no prd.json"
+fi
+[ -z "$(find "$FIX/workspace/delegations" -maxdepth 1 -name '*empty*' 2>/dev/null)" ] \
+  || fail "builder wrote a bundle for a project with no prd.json"
+
+# Missing --company is a usage error.
+if HQ_ROOT="$FIX" bash "$BUILDER" build --project widget --to a@b.c >/dev/null 2>&1; then
+  fail "builder must exit non-zero when --company is missing"
+fi
+
+# --- 4. secret-shaped prd → fail closed, no bundle ---------------------------
+
+SECRET_PROJ="$FIX/companies/acme/projects/leaky"
+mkdir -p "$SECRET_PROJ"
+jq '.name = "leaky" | .description = "key is AKIA" + "ABCDEFGHIJKLMNOP"' \
+  "$PROJ/prd.json" > "$SECRET_PROJ/prd.json"
+
+BEFORE_COUNT="$(find "$FIX/workspace/delegations" -maxdepth 1 -mindepth 1 -type d | wc -l | tr -d ' ')"
+if HQ_ROOT="$FIX" bash "$BUILDER" build --company acme --project leaky \
+  --to alice@acme.test >/dev/null 2>&1; then
+  fail "builder must fail closed when output matches a secret pattern"
+fi
+AFTER_COUNT="$(find "$FIX/workspace/delegations" -maxdepth 1 -mindepth 1 -type d | wc -l | tr -d ' ')"
+[ "$BEFORE_COUNT" = "$AFTER_COUNT" ] \
+  || fail "builder wrote a bundle despite a secret-pattern match"
+
+# --- 5. shared pattern lib is a superset of the runtime hook -----------------
+
+HOOK="$ROOT/.claude/hooks/detect-secrets.sh"
+LIB="$ROOT/core/scripts/lib/secret-patterns.sh"
+[ -f "$LIB" ] || fail "missing shared secret-pattern lib: $LIB"
+if [ -f "$HOOK" ]; then
+  # Extract each pattern literal from the hook's PATTERNS array and require it
+  # verbatim in the lib.
+  grep -oE '^  "[^"]+"' "$HOOK" | sed 's/^  //' | while IFS= read -r entry; do
+    grep -qF "$entry" "$LIB" \
+      || fail "secret-patterns.sh drifted: hook pattern $entry missing from lib"
+  done
+fi
+
+echo "hq-delegate-bundle: ok (schema valid; prefixes folder-form + bucket-relative; fail-closed on missing prd and secret match; pattern lib superset of hook)"

--- a/core/scripts/tests/hq-delegate-resolve.test.sh
+++ b/core/scripts/tests/hq-delegate-resolve.test.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Regression: hq-delegate-resolve.sh must resolve delegation recipients
+# safely — verbatim fast path, confirmed people lookups, fleet-agent
+# fallback — while staying read-only and strictly single-company.
+#
+# Guards:
+#   1. Fast path: email / prs_ / agt_ tokens pass through verbatim with NO
+#      lookup invoked.
+#   2. A bare name resolving to exactly one person exits 0 with that email.
+#   3. An ambiguous name exits 3 and prints the candidate list.
+#   4. A name matching only a fleet agent exits 0 with kind=agent.
+#   5. Every stubbed hq invocation carries --company <slug>; none names
+#      another company; nothing is invoked without it (tenancy).
+#   6. Missing --company is a usage error before any lookup.
+#   7. not-found in both rosters exits 4 with a plain message.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+RESOLVE="$ROOT/core/scripts/hq-delegate-resolve.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$RESOLVE" ] || fail "missing resolver: $RESOLVE"
+
+# --- stub hq CLI -------------------------------------------------------------
+# Records every invocation; behavior driven by env:
+#   HQ_STUB_PEOPLE_JSON — response for `hq people resolve`
+#   HQ_STUB_AGENTS_JSON — response for `hq agents list`
+INVOKE_LOG="$TMP/invocations.log"
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/hq" <<'STUB'
+#!/usr/bin/env bash
+echo "$*" >> "$HQ_STUB_LOG"
+people_resp="${HQ_STUB_PEOPLE_JSON:-}"
+[ -n "$people_resp" ] || people_resp='{"status":"not_found"}'
+agents_resp="${HQ_STUB_AGENTS_JSON:-}"
+[ -n "$agents_resp" ] || agents_resp='[]'
+case "$1 $2" in
+  "people resolve")
+    echo "warning: noise line the parser must skip"
+    printf '%s\n' "$people_resp"
+    ;;
+  "agents list")
+    printf '%s\n' "$agents_resp"
+    ;;
+esac
+exit 0
+STUB
+chmod +x "$TMP/bin/hq"
+export PATH="$TMP/bin:$PATH"
+export HQ_STUB_LOG="$INVOKE_LOG"
+
+run() { # token [env overrides via pre-set vars]
+  : > "$INVOKE_LOG"
+  bash "$RESOLVE" --company acme --to "$1"
+}
+
+# --- 1. fast path: verbatim, zero lookups ------------------------------------
+
+OUT="$(run "alice@acme.test")" || fail "email fast path exited non-zero"
+printf '%s' "$OUT" | jq -e '.kind == "person" and .principal == "alice@acme.test" and .source == "verbatim"' >/dev/null \
+  || fail "email fast path wrong output: $OUT"
+[ ! -s "$INVOKE_LOG" ] || fail "email fast path must invoke NO lookup, got: $(cat "$INVOKE_LOG")"
+
+OUT="$(run "prs_abc123")" || fail "prs_ fast path exited non-zero"
+printf '%s' "$OUT" | jq -e '.kind == "person" and .principal == "prs_abc123"' >/dev/null \
+  || fail "prs_ fast path wrong output: $OUT"
+[ ! -s "$INVOKE_LOG" ] || fail "prs_ fast path must invoke no lookup"
+
+OUT="$(run "agt_xyz789")" || fail "agt_ fast path exited non-zero"
+printf '%s' "$OUT" | jq -e '.kind == "agent" and .principal == "agt_xyz789"' >/dev/null \
+  || fail "agt_ fast path wrong output: $OUT"
+[ ! -s "$INVOKE_LOG" ] || fail "agt_ fast path must invoke no lookup"
+
+# --- 2. unique person match --------------------------------------------------
+
+export HQ_STUB_PEOPLE_JSON='{"status":"found","email":"stefan@acme.test","name":"Stefan Walsh"}'
+OUT="$(run "stefan")" || fail "unique person match exited non-zero"
+printf '%s' "$OUT" | jq -e '.kind == "person" and .principal == "stefan@acme.test" and .displayName == "Stefan Walsh" and .source == "people-resolve"' >/dev/null \
+  || fail "unique person match wrong output: $OUT"
+
+# --- 3. ambiguous person -> exit 3 + candidates ------------------------------
+
+export HQ_STUB_PEOPLE_JSON='{"status":"ambiguous","matches":[{"name":"Sam A","email":"sama@acme.test"},{"name":"Sam B","email":"samb@acme.test"}]}'
+set +e
+OUT="$(run "sam")"
+RC=$?
+set -e
+[ "$RC" -eq 3 ] || fail "ambiguous person must exit 3, got $RC"
+printf '%s' "$OUT" | jq -e '.status == "ambiguous" and (.matches | length) == 2' >/dev/null \
+  || fail "ambiguous person must print both candidates: $OUT"
+
+# --- 4. agent fallback -------------------------------------------------------
+
+export HQ_STUB_PEOPLE_JSON='{"status":"not_found"}'
+export HQ_STUB_AGENTS_JSON='[{"agentUid":"agt_01DEACON","name":"Deacon"},{"agentUid":"agt_01OTHER","name":"Scout"}]'
+OUT="$(run "deacon")" || fail "agent fallback exited non-zero"
+printf '%s' "$OUT" | jq -e '.kind == "agent" and .principal == "agt_01DEACON" and .displayName == "Deacon" and .source == "agents-list"' >/dev/null \
+  || fail "agent fallback wrong output: $OUT"
+
+# --- 5. tenancy: every lookup carries --company acme, no other company -------
+
+grep -q 'people resolve' "$INVOKE_LOG" || fail "expected a people lookup in the agent-fallback run"
+while IFS= read -r line; do
+  case "$line" in
+    *"--company acme"*) ;;
+    *) fail "lookup invoked without --company acme: '$line'" ;;
+  esac
+done < "$INVOKE_LOG"
+! grep -vq 'acme' "$INVOKE_LOG" >/dev/null 2>&1 || true # every line already checked above
+
+# --- 6. missing --company = usage error, zero lookups ------------------------
+
+: > "$INVOKE_LOG"
+set +e
+bash "$RESOLVE" --to "somebody" >/dev/null 2>&1
+RC=$?
+set -e
+[ "$RC" -eq 1 ] || fail "missing --company must exit 1 (usage), got $RC"
+[ ! -s "$INVOKE_LOG" ] || fail "missing --company must invoke no lookup"
+
+# --- 7. not found anywhere -> exit 4, plain message --------------------------
+
+export HQ_STUB_PEOPLE_JSON='{"status":"not_found"}'
+export HQ_STUB_AGENTS_JSON='[]'
+set +e
+ERR="$(run "nobody" 2>&1 >/dev/null)"
+RC=$?
+set -e
+[ "$RC" -eq 4 ] || fail "not-found must exit 4, got $RC"
+case "$ERR" in
+  *nobody*acme*) ;;
+  *) fail "not-found message must name the token and company: '$ERR'" ;;
+esac
+
+# no_email also stops with exit 4
+export HQ_STUB_PEOPLE_JSON='{"status":"no_email"}'
+set +e
+run "ghost" >/dev/null 2>&1
+RC=$?
+set -e
+[ "$RC" -eq 4 ] || fail "no_email must exit 4, got $RC"
+
+echo "hq-delegate-resolve: ok (verbatim fast path, person/agent resolution, ambiguous=3, not-found=4, single-company enforced)"


### PR DESCRIPTION
First story of the `/delegate` command (project: `hq-delegate-command`, indigo).

## What

Freezes a project into a portable **delegation bundle** at `workspace/delegations/<delegationId>/`:

- `manifest.json` — v1 schema (documented in `core/knowledge/public/hq-core/delegation-bundle-spec.md`), the single source of truth every later delegation step (grants, verification probe, pickup prompt) is generated from
- `BRIEF.md` — full-prose orientation for a recipient who has never seen the project

## Safety

- Vault prefixes are always bucket-relative, trailing-slash folder form; the builder hard-fails rather than emit a bare prefix that would degrade to a literal key
- Repo paths are recorded for the brief but never granted as vault prefixes
- Fail-closed secret scan: the builder scans its own manifest + BRIEF against a new shared pattern lib (`core/scripts/lib/secret-patterns.sh`) and writes nothing on a match
- Regression test asserts the shared lib stays a superset of `.claude/hooks/detect-secrets.sh` so the two can't drift

## Tests

`bash core/scripts/tests/hq-delegate-bundle.test.sh` — offline, stubbed `hq` CLI. Covers: happy-path schema validation, prefix conventions, missing-prd fail, secret-match fail-closed (nothing written), pattern-lib superset guard.

https://claude.ai/code/session_015YaqhyfE5w7L1NHnMiSnTp