### PR TITLE
feat(delegate): recipient resolution — person or fleet agent, tenancy-safe (US-002)

### DIFF
--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,5 +1,5 @@
 version: 1
-hqVersion: "15.0.82"
+hqVersion: "15.0.83"
 agentSessionContractVersion: 1
 # Provider adapter contract version (US-500). Must match
 # HQ_ADAPTER_CONTRACT_VERSION in core/scripts/lib/provider-adapter-version.sh.

--- a/core/scripts/hq-delegate-resolve.sh
+++ b/core/scripts/hq-delegate-resolve.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# hq-core: public
+# hq-delegate-resolve.sh — resolve a delegation recipient to a confirmed
+# principal (person email / prs_ uid, or fleet-agent agt_ uid). Read-only.
+#
+# Usage:
+#   core/scripts/hq-delegate-resolve.sh --company <slug> --to <token>
+#
+# Output (stdout, JSON): {kind, principal, displayName, source}
+#   kind      — "person" | "agent"
+#   principal — confirmed email, prs_… or agt_… uid
+#   source    — "verbatim" | "people-resolve" | "agents-list"
+#
+# Exit codes:
+#   0 — resolved
+#   1 — usage error (missing/invalid arguments)
+#   3 — ambiguous: candidate list printed to stdout as JSON
+#       {status:"ambiguous", matches:[…]} — caller must present a picker
+#   4 — not found (or found with no email): plain message on stderr
+#
+# Tenancy: every lookup is scoped with an explicit --company. This helper
+# never enumerates or falls back across companies — single-company by
+# construction, matching the /dm skill's resolution contract.
+#
+# Fast path: a token containing "@" or starting with prs_ / agt_ passes
+# through verbatim with NO lookup, preserving existing invocations exactly.
+
+set -euo pipefail
+
+usage() {
+  sed -n '3,26p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+die_usage() {
+  echo "hq-delegate-resolve: $*" >&2
+  usage >&2
+  exit 1
+}
+
+command -v jq >/dev/null 2>&1 || { echo "hq-delegate-resolve: jq is required" >&2; exit 1; }
+
+COMPANY="" TOKEN=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --company) COMPANY="${2:-}"; shift 2 ;;
+    --to)      TOKEN="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) die_usage "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$COMPANY" ] || die_usage "--company is required (single-company lookups only; never a multi-company scan)"
+[ -n "$TOKEN" ]   || die_usage "--to is required"
+
+emit() { # kind principal displayName source
+  jq -cn --arg kind "$1" --arg principal "$2" --arg name "$3" --arg source "$4" \
+    '{kind: $kind, principal: $principal,
+      displayName: (if $name == "" then null else $name end), source: $source}'
+}
+
+# Strip CLI noise (version warnings, session-refresh notices) before the JSON
+# payload: keep everything from the first line that starts a JSON value.
+json_only() {
+  awk 'started {print; next} /^[[:space:]]*[{[]/ {started=1; print}'
+}
+
+# --- fast path: already a principal — pass through verbatim, no lookup -------
+
+case "$TOKEN" in
+  agt_*)
+    emit agent "$TOKEN" "" verbatim
+    exit 0
+    ;;
+  prs_*|*@*)
+    emit person "$TOKEN" "" verbatim
+    exit 0
+    ;;
+esac
+
+# --- name → people roster (single-company, read-only) ------------------------
+
+PEOPLE_RAW="$(hq people resolve "$TOKEN" --json --company "$COMPANY" 2>/dev/null | json_only || true)"
+PEOPLE_STATUS=""
+if [ -n "$PEOPLE_RAW" ] && printf '%s' "$PEOPLE_RAW" | jq -e . >/dev/null 2>&1; then
+  PEOPLE_STATUS="$(printf '%s' "$PEOPLE_RAW" | jq -r '.status // empty')"
+fi
+
+case "$PEOPLE_STATUS" in
+  found)
+    EMAIL="$(printf '%s' "$PEOPLE_RAW" | jq -r '.email // empty')"
+    NAME="$(printf '%s' "$PEOPLE_RAW" | jq -r '.name // .displayName // empty')"
+    [ -n "$EMAIL" ] || { echo "hq-delegate-resolve: resolver returned found but no email for '$TOKEN'" >&2; exit 4; }
+    emit person "$EMAIL" "$NAME" people-resolve
+    exit 0
+    ;;
+  ambiguous)
+    printf '%s' "$PEOPLE_RAW" | jq -c '{status: "ambiguous", matches: (.matches // [])}'
+    exit 3
+    ;;
+  no_email)
+    echo "hq-delegate-resolve: '$TOKEN' was found in company '$COMPANY' but has no email on record — pass their exact email or personUid instead" >&2
+    exit 4
+    ;;
+  not_found|"")
+    : # fall through to the fleet-agent roster
+    ;;
+  *)
+    echo "hq-delegate-resolve: unexpected resolver status '$PEOPLE_STATUS' for '$TOKEN'" >&2
+    exit 4
+    ;;
+esac
+
+# --- name → fleet-agent roster (same company, read-only) ---------------------
+
+AGENTS_RAW="$(hq agents list --company "$COMPANY" --json 2>/dev/null | json_only || true)"
+if [ -z "$AGENTS_RAW" ] || ! printf '%s' "$AGENTS_RAW" | jq -e . >/dev/null 2>&1; then
+  AGENTS_RAW="[]"
+fi
+
+MATCHES="$(printf '%s' "$AGENTS_RAW" | jq -c --arg t "$TOKEN" '
+  [ .[]
+    | select((.name // .displayName // "") | ascii_downcase == ($t | ascii_downcase))
+    | {agentUid: (.agentUid // .uid // empty), name: (.name // .displayName // "")}
+    | select(.agentUid != "")
+  ]')"
+MATCH_COUNT="$(printf '%s' "$MATCHES" | jq 'length')"
+
+if [ "$MATCH_COUNT" -eq 1 ]; then
+  emit agent \
+    "$(printf '%s' "$MATCHES" | jq -r '.[0].agentUid')" \
+    "$(printf '%s' "$MATCHES" | jq -r '.[0].name')" \
+    agents-list
+  exit 0
+elif [ "$MATCH_COUNT" -gt 1 ]; then
+  printf '%s' "$MATCHES" | jq -c '{status: "ambiguous", matches: .}'
+  exit 3
+fi
+
+echo "hq-delegate-resolve: no teammate or fleet agent named '$TOKEN' found in company '$COMPANY' — pass the exact email, personUid (prs_…), or agentUid (agt_…) instead" >&2
+exit 4

--- a/core/scripts/tests/hq-delegate-resolve.test.sh
+++ b/core/scripts/tests/hq-delegate-resolve.test.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Regression: hq-delegate-resolve.sh must resolve delegation recipients
+# safely — verbatim fast path, confirmed people lookups, fleet-agent
+# fallback — while staying read-only and strictly single-company.
+#
+# Guards:
+#   1. Fast path: email / prs_ / agt_ tokens pass through verbatim with NO
+#      lookup invoked.
+#   2. A bare name resolving to exactly one person exits 0 with that email.
+#   3. An ambiguous name exits 3 and prints the candidate list.
+#   4. A name matching only a fleet agent exits 0 with kind=agent.
+#   5. Every stubbed hq invocation carries --company <slug>; none names
+#      another company; nothing is invoked without it (tenancy).
+#   6. Missing --company is a usage error before any lookup.
+#   7. not-found in both rosters exits 4 with a plain message.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+RESOLVE="$ROOT/core/scripts/hq-delegate-resolve.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$RESOLVE" ] || fail "missing resolver: $RESOLVE"
+
+# --- stub hq CLI -------------------------------------------------------------
+# Records every invocation; behavior driven by env:
+#   HQ_STUB_PEOPLE_JSON — response for `hq people resolve`
+#   HQ_STUB_AGENTS_JSON — response for `hq agents list`
+INVOKE_LOG="$TMP/invocations.log"
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/hq" <<'STUB'
+#!/usr/bin/env bash
+echo "$*" >> "$HQ_STUB_LOG"
+people_resp="${HQ_STUB_PEOPLE_JSON:-}"
+[ -n "$people_resp" ] || people_resp='{"status":"not_found"}'
+agents_resp="${HQ_STUB_AGENTS_JSON:-}"
+[ -n "$agents_resp" ] || agents_resp='[]'
+case "$1 $2" in
+  "people resolve")
+    echo "warning: noise line the parser must skip"
+    printf '%s\n' "$people_resp"
+    ;;
+  "agents list")
+    printf '%s\n' "$agents_resp"
+    ;;
+esac
+exit 0
+STUB
+chmod +x "$TMP/bin/hq"
+export PATH="$TMP/bin:$PATH"
+export HQ_STUB_LOG="$INVOKE_LOG"
+
+run() { # token [env overrides via pre-set vars]
+  : > "$INVOKE_LOG"
+  bash "$RESOLVE" --company acme --to "$1"
+}
+
+# --- 1. fast path: verbatim, zero lookups ------------------------------------
+
+OUT="$(run "alice@acme.test")" || fail "email fast path exited non-zero"
+printf '%s' "$OUT" | jq -e '.kind == "person" and .principal == "alice@acme.test" and .source == "verbatim"' >/dev/null \
+  || fail "email fast path wrong output: $OUT"
+[ ! -s "$INVOKE_LOG" ] || fail "email fast path must invoke NO lookup, got: $(cat "$INVOKE_LOG")"
+
+OUT="$(run "prs_abc123")" || fail "prs_ fast path exited non-zero"
+printf '%s' "$OUT" | jq -e '.kind == "person" and .principal == "prs_abc123"' >/dev/null \
+  || fail "prs_ fast path wrong output: $OUT"
+[ ! -s "$INVOKE_LOG" ] || fail "prs_ fast path must invoke no lookup"
+
+OUT="$(run "agt_xyz789")" || fail "agt_ fast path exited non-zero"
+printf '%s' "$OUT" | jq -e '.kind == "agent" and .principal == "agt_xyz789"' >/dev/null \
+  || fail "agt_ fast path wrong output: $OUT"
+[ ! -s "$INVOKE_LOG" ] || fail "agt_ fast path must invoke no lookup"
+
+# --- 2. unique person match --------------------------------------------------
+
+export HQ_STUB_PEOPLE_JSON='{"status":"found","email":"stefan@acme.test","name":"Stefan Walsh"}'
+OUT="$(run "stefan")" || fail "unique person match exited non-zero"
+printf '%s' "$OUT" | jq -e '.kind == "person" and .principal == "stefan@acme.test" and .displayName == "Stefan Walsh" and .source == "people-resolve"' >/dev/null \
+  || fail "unique person match wrong output: $OUT"
+
+# --- 3. ambiguous person -> exit 3 + candidates ------------------------------
+
+export HQ_STUB_PEOPLE_JSON='{"status":"ambiguous","matches":[{"name":"Sam A","email":"sama@acme.test"},{"name":"Sam B","email":"samb@acme.test"}]}'
+set +e
+OUT="$(run "sam")"
+RC=$?
+set -e
+[ "$RC" -eq 3 ] || fail "ambiguous person must exit 3, got $RC"
+printf '%s' "$OUT" | jq -e '.status == "ambiguous" and (.matches | length) == 2' >/dev/null \
+  || fail "ambiguous person must print both candidates: $OUT"
+
+# --- 4. agent fallback -------------------------------------------------------
+
+export HQ_STUB_PEOPLE_JSON='{"status":"not_found"}'
+export HQ_STUB_AGENTS_JSON='[{"agentUid":"agt_01DEACON","name":"Deacon"},{"agentUid":"agt_01OTHER","name":"Scout"}]'
+OUT="$(run "deacon")" || fail "agent fallback exited non-zero"
+printf '%s' "$OUT" | jq -e '.kind == "agent" and .principal == "agt_01DEACON" and .displayName == "Deacon" and .source == "agents-list"' >/dev/null \
+  || fail "agent fallback wrong output: $OUT"
+
+# --- 5. tenancy: every lookup carries --company acme, no other company -------
+
+grep -q 'people resolve' "$INVOKE_LOG" || fail "expected a people lookup in the agent-fallback run"
+while IFS= read -r line; do
+  case "$line" in
+    *"--company acme"*) ;;
+    *) fail "lookup invoked without --company acme: '$line'" ;;
+  esac
+done < "$INVOKE_LOG"
+! grep -vq 'acme' "$INVOKE_LOG" >/dev/null 2>&1 || true # every line already checked above
+
+# --- 6. missing --company = usage error, zero lookups ------------------------
+
+: > "$INVOKE_LOG"
+set +e
+bash "$RESOLVE" --to "somebody" >/dev/null 2>&1
+RC=$?
+set -e
+[ "$RC" -eq 1 ] || fail "missing --company must exit 1 (usage), got $RC"
+[ ! -s "$INVOKE_LOG" ] || fail "missing --company must invoke no lookup"
+
+# --- 7. not found anywhere -> exit 4, plain message --------------------------
+
+export HQ_STUB_PEOPLE_JSON='{"status":"not_found"}'
+export HQ_STUB_AGENTS_JSON='[]'
+set +e
+ERR="$(run "nobody" 2>&1 >/dev/null)"
+RC=$?
+set -e
+[ "$RC" -eq 4 ] || fail "not-found must exit 4, got $RC"
+case "$ERR" in
+  *nobody*acme*) ;;
+  *) fail "not-found message must name the token and company: '$ERR'" ;;
+esac
+
+# no_email also stops with exit 4
+export HQ_STUB_PEOPLE_JSON='{"status":"no_email"}'
+set +e
+run "ghost" >/dev/null 2>&1
+RC=$?
+set -e
+[ "$RC" -eq 4 ] || fail "no_email must exit 4, got $RC"
+
+echo "hq-delegate-resolve: ok (verbatim fast path, person/agent resolution, ambiguous=3, not-found=4, single-company enforced)"


### PR DESCRIPTION
Second story of `/delegate` (project: `hq-delegate-command`, indigo). Independent of #160.

## What

`core/scripts/hq-delegate-resolve.sh --company <slug> --to <token>` resolves a recipient token to a confirmed principal:

- **Fast path**: email / `prs_…` / `agt_…` pass through verbatim — zero lookups, existing invocation shapes preserved
- **Names**: `hq people resolve` (same contract as the /dm skill) → fleet-agent roster (`hq agents list`) as fallback
- **Exit codes**: 0 resolved · 3 ambiguous (candidates printed as JSON for a picker) · 4 not-found/no-email · 1 usage

## Tenancy

Every lookup carries an explicit `--company`; the helper never enumerates or falls back across companies. The test asserts no stubbed invocation omits it. Read-only throughout.

## Tests

`bash core/scripts/tests/hq-delegate-resolve.test.sh` — offline, stubbed `hq` CLI covering all seven guards (fast path, unique match, ambiguous, agent fallback, tenancy, usage error, not-found).

https://claude.ai/code/session_015YaqhyfE5w7L1NHnMiSnTp