### PR TITLE
feat(delegate): vault materialization + verified ACL grants (US-003)

### DIFF
--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,5 +1,5 @@
 version: 1
-hqVersion: "15.0.83"
+hqVersion: "15.0.84"
 agentSessionContractVersion: 1
 # Provider adapter contract version (US-500). Must match
 # HQ_ADAPTER_CONTRACT_VERSION in core/scripts/lib/provider-adapter-version.sh.

--- a/core/scripts/hq-delegate-grant.sh
+++ b/core/scripts/hq-delegate-grant.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# hq-core: public
+# hq-delegate-grant.sh — materialize a delegation's dossier in the vault and
+# write the ACL grants its manifest declares, verifying each one landed.
+#
+# Usage:
+#   core/scripts/hq-delegate-grant.sh --manifest <path> [--yes]
+#
+# Without --yes: prints the full grant plan (prefix, principal, permission —
+# the write grant is a privilege escalation and needs explicit confirmation)
+# and exits 2 without mutating anything. The caller (the /delegate skill)
+# confirms with the user, then re-invokes with --yes.
+#
+# With --yes:
+#   1. hq sync push the project directory so the vault prefix exists
+#   2. hq files share each manifest vaultPrefix to the recipient
+#   3. read each grant back with hq files acl and match grantee + permission
+#   4. advance manifest status building -> granted, stamping verifiedAt
+#
+# Direct ACL grants ONLY — this helper never mints a share-session URL
+# (policy hq-delegate-never-inlines-secrets-or-share-urls).
+#
+# Idempotent: a prefix whose grant already exists is reported, not an error.
+# A failed read-back exits non-zero and leaves manifest status unchanged.
+#
+# Env: HQ_ROOT — HQ root override (default: resolved from script location)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HQ_ROOT="${HQ_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+
+usage() { sed -n '3,25p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+die()   { echo "hq-delegate-grant: $*" >&2; exit 1; }
+
+command -v jq >/dev/null 2>&1 || die "jq is required but not installed"
+
+MANIFEST="" YES=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --manifest) MANIFEST="${2:-}"; shift 2 ;;
+    --yes)      YES=1; shift ;;
+    -h|--help)  usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$MANIFEST" ] || die "--manifest is required"
+[ -f "$MANIFEST" ] || die "manifest not found: $MANIFEST"
+jq -e . "$MANIFEST" >/dev/null 2>&1 || die "manifest is not valid JSON: $MANIFEST"
+
+COMPANY="$(jq -r '.company // empty' "$MANIFEST")"
+PROJECT="$(jq -r '.project.name // empty' "$MANIFEST")"
+PRINCIPAL="$(jq -r '.to.principal // empty' "$MANIFEST")"
+STATUS="$(jq -r '.status // empty' "$MANIFEST")"
+[ -n "$COMPANY" ]   || die "manifest has no company"
+[ -n "$PROJECT" ]   || die "manifest has no project.name"
+[ -n "$PRINCIPAL" ] || die "manifest has no to.principal"
+
+case "$STATUS" in
+  building|granted) ;;
+  *) die "manifest status is '$STATUS' — grants run from 'building' (or re-run from 'granted'), not from there" ;;
+esac
+
+PREFIX_COUNT="$(jq '.vaultPrefixes | length' "$MANIFEST")"
+[ "$PREFIX_COUNT" -gt 0 ] || die "manifest has no vaultPrefixes"
+
+# --- validate every prefix BEFORE touching anything --------------------------
+# Company-relative, trailing-slash folder form. A bare prefix would degrade to
+# a single literal key and grant nothing useful; company-anchored prefixes do
+# not exist in the bucket. Either is a hard error, never a silent grant.
+
+BAD="$(jq -r '.vaultPrefixes[] | .prefix
+  | select((endswith("/") | not) or startswith("companies/") or startswith("/"))' "$MANIFEST")"
+if [ -n "$BAD" ]; then
+  die "prefix violates the hq-files prefix conventions (must be company-relative folder form ending in '/'): $BAD"
+fi
+
+# --- plan (always printed; the only output without --yes) --------------------
+
+echo "Delegation grant plan — company '$COMPANY', recipient '$PRINCIPAL':"
+echo "  1. Push companies/$COMPANY/projects/$PROJECT/ to the vault (on-conflict keep)"
+jq -r '.vaultPrefixes[] | "  2. Grant \(.permission) on \(.prefix) — \(.reason // "")"' "$MANIFEST"
+WRITE_PREFIXES="$(jq -r '.vaultPrefixes[] | select(.permission == "write") | .prefix' "$MANIFEST")"
+if [ -n "$WRITE_PREFIXES" ]; then
+  echo
+  echo "NOTE: granting 'write' is a privilege escalation. The recipient will be able"
+  echo "to upload, overwrite, and delete under: $(printf '%s ' "$WRITE_PREFIXES")"
+fi
+
+if [ "$YES" -ne 1 ]; then
+  echo
+  echo "hq-delegate-grant: confirmation required — re-run with --yes after the user approves" >&2
+  exit 2
+fi
+
+# --- 1. materialize the dossier in the vault ---------------------------------
+
+hq sync push "companies/$COMPANY/projects/$PROJECT/" --company "$COMPANY" --on-conflict keep \
+  || die "vault push failed for companies/$COMPANY/projects/$PROJECT/"
+
+# --- 2+3. grant each prefix, then verify via ACL read-back -------------------
+
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+i=0
+while [ "$i" -lt "$PREFIX_COUNT" ]; do
+  PFX="$(jq -r ".vaultPrefixes[$i].prefix" "$MANIFEST")"
+  PERM="$(jq -r ".vaultPrefixes[$i].permission" "$MANIFEST")"
+
+  if ! hq files share "$PFX" --with "$PRINCIPAL" --permission "$PERM" --company "$COMPANY"; then
+    # The share may fail because an identical grant already exists — the
+    # read-back below is the arbiter either way.
+    echo "hq-delegate-grant: share reported an error on $PFX — checking whether the grant already exists" >&2
+  fi
+
+  ACL_OUT="$(hq files acl "$PFX" --company "$COMPANY" 2>/dev/null || true)"
+  MATCH="$(printf '%s\n' "$ACL_OUT" | grep -F "$PRINCIPAL" | grep -c "$PERM" || true)"
+  if [ "${MATCH:-0}" -eq 0 ]; then
+    die "grant did not land: '$PRINCIPAL' with '$PERM' not visible in ACL for '$PFX' — manifest status left unchanged"
+  fi
+  echo "hq-delegate-grant: verified $PERM on $PFX for $PRINCIPAL"
+  i=$((i + 1))
+done
+
+# --- 4. advance manifest status ----------------------------------------------
+
+TMP_MANIFEST="$(mktemp)"
+jq --arg now "$NOW" '
+  .status = "granted"
+  | .vaultPrefixes = [.vaultPrefixes[] | . + {verifiedAt: $now}]
+' "$MANIFEST" > "$TMP_MANIFEST" && mv "$TMP_MANIFEST" "$MANIFEST"
+
+echo "hq-delegate-grant: all $PREFIX_COUNT grants verified — manifest status advanced to 'granted'"

--- a/core/scripts/tests/hq-delegate-grant.test.sh
+++ b/core/scripts/tests/hq-delegate-grant.test.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Regression: hq-delegate-grant.sh must materialize the dossier, write the
+# manifest's grants via DIRECT ACL grants, verify each via read-back, and
+# fail closed on convention violations or unverified grants.
+#
+# Guards:
+#   1. Happy path: one sync push + one share per prefix, expected permission
+#      per prefix, every shared prefix ends in "/", manifest advances to
+#      'granted' with verifiedAt stamps.
+#   2. ACL read-back missing the grantee -> non-zero, status stays 'building'.
+#   3. A companies/<slug>/-anchored prefix -> non-zero naming the convention,
+#      nothing invoked.
+#   4. Without --yes -> exit 2, plan printed, zero mutating invocations.
+#   5. No share-session URL path: every share call carries --with (direct
+#      grant), never the bare browser-flow form.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+GRANT="$ROOT/core/scripts/hq-delegate-grant.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$GRANT" ] || fail "missing grant helper: $GRANT"
+
+# --- stub hq CLI -------------------------------------------------------------
+INVOKE_LOG="$TMP/invocations.log"
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/hq" <<'STUB'
+#!/usr/bin/env bash
+echo "$*" >> "$HQ_STUB_LOG"
+case "$1 $2" in
+  "sync push") exit 0 ;;
+  "files share") exit 0 ;;
+  "files acl")
+    resp="${HQ_STUB_ACL_RESPONSE:-}"
+    [ -n "$resp" ] || resp="grantee: alice@acme.test  permission: MATCHPERM"
+    # The stub echoes a per-permission line so grantee+permission matching is real.
+    printf '%s\n' "$resp"
+    exit 0
+    ;;
+esac
+exit 0
+STUB
+chmod +x "$TMP/bin/hq"
+export PATH="$TMP/bin:$PATH"
+export HQ_STUB_LOG="$INVOKE_LOG"
+
+write_manifest() { # path status
+  cat > "$1" <<JSON
+{
+  "schemaVersion": 1,
+  "delegationId": "dlg-test-widget",
+  "company": "acme",
+  "mode": "transfer",
+  "to": {"kind": "person", "principal": "alice@acme.test", "displayName": "Alice"},
+  "project": {"name": "widget", "prdPath": "companies/acme/projects/widget/prd.json", "boardId": null},
+  "vaultPrefixes": [
+    {"prefix": "projects/widget/", "permission": "write", "reason": "project dossier"},
+    {"prefix": "knowledge/insights/", "permission": "read", "reason": "referenced knowledge"},
+    {"prefix": "policies/", "permission": "read", "reason": "referenced policies"}
+  ],
+  "secrets": [],
+  "status": "$2"
+}
+JSON
+}
+
+# --- 4. without --yes: plan only, exit 2, zero mutations ---------------------
+
+M="$TMP/manifest.json"
+write_manifest "$M" building
+: > "$INVOKE_LOG"
+set +e
+PLAN="$(bash "$GRANT" --manifest "$M" 2>/dev/null)"
+RC=$?
+set -e
+[ "$RC" -eq 2 ] || fail "without --yes must exit 2, got $RC"
+[ ! -s "$INVOKE_LOG" ] || fail "without --yes nothing may be invoked, got: $(cat "$INVOKE_LOG")"
+printf '%s' "$PLAN" | grep -q "projects/widget/" || fail "plan must name the project prefix"
+printf '%s' "$PLAN" | grep -q "alice@acme.test" || fail "plan must name the principal"
+printf '%s' "$PLAN" | grep -qi "privilege escalation" || fail "plan must flag the write grant as a privilege escalation"
+jq -e '.status == "building"' "$M" >/dev/null || fail "plan-only run must not advance status"
+
+# --- 1. happy path -----------------------------------------------------------
+
+: > "$INVOKE_LOG"
+export HQ_STUB_ACL_RESPONSE="grantee: alice@acme.test permission: write
+grantee: alice@acme.test permission: read"
+bash "$GRANT" --manifest "$M" --yes >/dev/null 2>&1 || fail "happy path exited non-zero"
+
+grep -q "^sync push companies/acme/projects/widget/ --company acme --on-conflict keep" "$INVOKE_LOG" \
+  || fail "must push the project dir to the vault first: $(cat "$INVOKE_LOG")"
+
+SHARE_COUNT="$(grep -c '^files share' "$INVOKE_LOG")"
+[ "$SHARE_COUNT" -eq 3 ] || fail "expected exactly 3 share calls, got $SHARE_COUNT"
+grep -q '^files share projects/widget/ --with alice@acme.test --permission write --company acme$' "$INVOKE_LOG" \
+  || fail "missing write share on projects/widget/"
+grep -q '^files share knowledge/insights/ --with alice@acme.test --permission read --company acme$' "$INVOKE_LOG" \
+  || fail "missing read share on knowledge/insights/"
+grep -q '^files share policies/ --with alice@acme.test --permission read --company acme$' "$INVOKE_LOG" \
+  || fail "missing read share on policies/"
+
+# 5. direct grants only — every share carries --with (no browser/share-session flow)
+if grep '^files share' "$INVOKE_LOG" | grep -vq -- '--with'; then
+  fail "a share call omitted --with (browser/share-session flow is forbidden here)"
+fi
+
+# every shared prefix is folder form
+grep '^files share' "$INVOKE_LOG" | awk '{print $3}' | while IFS= read -r p; do
+  case "$p" in
+    */) ;;
+    *) fail "shared prefix not folder form: $p" ;;
+  esac
+done
+
+jq -e '.status == "granted"' "$M" >/dev/null || fail "manifest must advance to granted"
+jq -e 'all(.vaultPrefixes[]; .verifiedAt != null)' "$M" >/dev/null \
+  || fail "every vaultPrefix must be stamped verifiedAt"
+
+# --- 2. read-back missing grantee -> fail, status unchanged ------------------
+
+write_manifest "$M" building
+: > "$INVOKE_LOG"
+export HQ_STUB_ACL_RESPONSE="grantee: someone-else@acme.test permission: write"
+set +e
+bash "$GRANT" --manifest "$M" --yes >/dev/null 2>&1
+RC=$?
+set -e
+[ "$RC" -ne 0 ] || fail "unverified grant must exit non-zero"
+jq -e '.status == "building"' "$M" >/dev/null \
+  || fail "failed read-back must leave manifest status unchanged"
+unset HQ_STUB_ACL_RESPONSE
+
+# --- 3. company-anchored prefix -> hard error, nothing invoked ---------------
+
+write_manifest "$M" building
+TMP_M="$(mktemp)"
+jq '.vaultPrefixes[0].prefix = "companies/acme/projects/widget/"' "$M" > "$TMP_M" && mv "$TMP_M" "$M"
+: > "$INVOKE_LOG"
+set +e
+ERR="$(bash "$GRANT" --manifest "$M" --yes 2>&1 >/dev/null)"
+RC=$?
+set -e
+[ "$RC" -ne 0 ] || fail "company-anchored prefix must be a hard error"
+printf '%s' "$ERR" | grep -qi "convention" || fail "error must name the prefix-convention rule: $ERR"
+[ ! -s "$INVOKE_LOG" ] || fail "convention violation must invoke nothing: $(cat "$INVOKE_LOG")"
+
+# bare (non-folder) prefix is equally hard an error
+write_manifest "$M" building
+TMP_M="$(mktemp)"
+jq '.vaultPrefixes[1].prefix = "knowledge/insights"' "$M" > "$TMP_M" && mv "$TMP_M" "$M"
+: > "$INVOKE_LOG"
+set +e
+bash "$GRANT" --manifest "$M" --yes >/dev/null 2>&1
+RC=$?
+set -e
+[ "$RC" -ne 0 ] || fail "bare non-folder prefix must be a hard error"
+[ ! -s "$INVOKE_LOG" ] || fail "bare-prefix violation must invoke nothing"
+
+echo "hq-delegate-grant: ok (plan/confirm gate, push+share+readback, folder-form enforced, fail-closed on unverified grant, direct grants only)"


### PR DESCRIPTION
Third story of `/delegate` (project: `hq-delegate-command`, indigo). Reads the manifest contract from #160; composes with #161.

## What

`core/scripts/hq-delegate-grant.sh --manifest <path> [--yes]`:

1. `hq sync push` the project dossier so the vault prefix exists before granting
2. `hq files share --with <principal> --permission <level>` per manifest prefix — **direct grants only**, the share-session/browser flow is never used
3. Read-back via `hq files acl`, matched on grantee **and** permission — an unverified grant fails the run and leaves manifest status unchanged
4. Manifest advances `building → granted` with per-prefix `verifiedAt` stamps

## Safety

- Without `--yes`: prints the plan (flagging write as a privilege escalation), exits 2, mutates nothing — the /delegate skill owns the user confirmation
- Prefixes validated company-relative + trailing-slash folder form before anything runs; a bare or `companies/`-anchored prefix is a hard error
- Idempotent re-runs: existing grants reported, not duplicated

## Tests

`bash core/scripts/tests/hq-delegate-grant.test.sh` — offline, stubbed `hq` CLI; covers the confirm gate, push+share+read-back sequencing, folder-form enforcement, unverified-grant fail-closed, and direct-grant-only.

https://claude.ai/code/session_015YaqhyfE5w7L1NHnMiSnTp