### PR TITLE
feat(delegate): code/branch handover with anchored push + read-only access check (US-004)

### DIFF
--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,5 +1,5 @@
 version: 1
-hqVersion: "15.0.84"
+hqVersion: "15.0.85"
 agentSessionContractVersion: 1
 # Provider adapter contract version (US-500). Must match
 # HQ_ADAPTER_CONTRACT_VERSION in core/scripts/lib/provider-adapter-version.sh.

--- a/core/scripts/hq-delegate-repo.sh
+++ b/core/scripts/hq-delegate-repo.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# hq-core: public
+# hq-delegate-repo.sh — code/branch handover for a delegation: make sure the
+# project's branch exists on the remote, record uncommitted work as NOT
+# transferred, and verify the recipient's repository access read-only.
+#
+# Usage:
+#   core/scripts/hq-delegate-repo.sh --manifest <path> [--yes] [--github-user <login>]
+#
+# Behavior (driven by the manifest's repo{} block; no-op when repo is null):
+#   - records remote URL and the branch's headSha into the manifest
+#   - a branch that exists only locally requires confirmation: without --yes
+#     the helper prints the plan and exits 2; with --yes it pushes via an
+#     explicitly anchored `git -C <abs path> push -u origin <branch>`
+#   - dirty/untracked files are captured into repo.dirtyFiles[] and appended
+#     to BRIEF.md as work NOT transferred — never silently dropped
+#   - recipient access is checked read-only via gh when --github-user is
+#     given; otherwise (or on a gh failure) repo.accessVerified stays false
+#     and the brief says so plainly — the helper never claims unverified access
+#   - never touches vaultPrefixes[] and never pushes repo content to the vault
+#
+# Env: HQ_ROOT — HQ root override (default: resolved from script location)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HQ_ROOT="${HQ_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+
+usage() { sed -n '3,22p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+die()   { echo "hq-delegate-repo: $*" >&2; exit 1; }
+
+command -v jq >/dev/null 2>&1 || die "jq is required but not installed"
+
+MANIFEST="" YES=0 GH_USER=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --manifest)    MANIFEST="${2:-}"; shift 2 ;;
+    --yes)         YES=1; shift ;;
+    --github-user) GH_USER="${2:-}"; shift 2 ;;
+    -h|--help)     usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$MANIFEST" ] || die "--manifest is required"
+[ -f "$MANIFEST" ] || die "manifest not found: $MANIFEST"
+jq -e . "$MANIFEST" >/dev/null 2>&1 || die "manifest is not valid JSON: $MANIFEST"
+
+BUNDLE_DIR="$(cd "$(dirname "$MANIFEST")" && pwd)"
+BRIEF="$BUNDLE_DIR/BRIEF.md"
+
+# --- no-repo projects skip cleanly -------------------------------------------
+
+if jq -e '.repo == null' "$MANIFEST" >/dev/null; then
+  echo "hq-delegate-repo: project has no repoPath — nothing to hand over"
+  exit 0
+fi
+
+REPO_REL="$(jq -r '.repo.path // empty' "$MANIFEST")"
+BRANCH="$(jq -r '.repo.branch // empty' "$MANIFEST")"
+[ -n "$REPO_REL" ] || die "manifest repo block has no path"
+
+REPO_DIR="$HQ_ROOT/$REPO_REL"
+[ -d "$REPO_DIR/.git" ] || git -C "$REPO_DIR" rev-parse --git-dir >/dev/null 2>&1 \
+  || die "not a git repository: $REPO_DIR"
+
+REMOTE_URL="$(git -C "$REPO_DIR" remote get-url origin 2>/dev/null || true)"
+
+# --- dirty / untracked work is recorded, never dropped -----------------------
+
+DIRTY_JSON="$(git -C "$REPO_DIR" status --porcelain | sed 's/^...//' | jq -R . | jq -cs .)"
+
+# --- branch state -------------------------------------------------------------
+
+BRANCH_PUSHED=false HEAD_SHA=""
+if [ -n "$BRANCH" ]; then
+  LOCAL_SHA="$(git -C "$REPO_DIR" rev-parse --verify --quiet "refs/heads/$BRANCH" || true)"
+  REMOTE_SHA="$(git -C "$REPO_DIR" rev-parse --verify --quiet "refs/remotes/origin/$BRANCH" || true)"
+
+  if [ -n "$REMOTE_SHA" ]; then
+    BRANCH_PUSHED=true
+    HEAD_SHA="$REMOTE_SHA"
+  elif [ -n "$LOCAL_SHA" ]; then
+    echo "Branch handover plan — repo '$REPO_REL':"
+    echo "  branch '$BRANCH' exists only locally ($LOCAL_SHA)"
+    echo "  action: git -C $REPO_DIR push -u origin $BRANCH"
+    if [ "$YES" -ne 1 ]; then
+      echo
+      echo "hq-delegate-repo: confirmation required — re-run with --yes to push the branch" >&2
+      exit 2
+    fi
+    git -C "$REPO_DIR" push -u origin "$BRANCH" \
+      || die "failed to push branch '$BRANCH' to origin"
+    BRANCH_PUSHED=true
+    HEAD_SHA="$LOCAL_SHA"
+  else
+    echo "hq-delegate-repo: branch '$BRANCH' does not exist yet (declared in the PRD, not started) — recording as unpushed"
+  fi
+fi
+
+# --- read-only recipient access check ----------------------------------------
+
+ACCESS_VERIFIED=false ACCESS_NOTE=""
+if [ -n "$GH_USER" ] && [ -n "$REMOTE_URL" ] && command -v gh >/dev/null 2>&1; then
+  # owner/repo from ssh or https remote forms
+  OWNER_REPO="$(printf '%s' "$REMOTE_URL" | sed -E 's#^(git@[^:]+:|https?://[^/]+/)##; s#\.git$##')"
+  if gh api "repos/$OWNER_REPO/collaborators/$GH_USER" >/dev/null 2>&1; then
+    ACCESS_VERIFIED=true
+    ACCESS_NOTE="verified: $GH_USER is a collaborator on $OWNER_REPO"
+  else
+    ACCESS_NOTE="UNVERIFIED: could not confirm $GH_USER has access to $OWNER_REPO — the recipient may need to be invited before they can pull the branch"
+  fi
+else
+  ACCESS_NOTE="UNVERIFIED: recipient repository access was not checked (no GitHub login supplied) — confirm they can reach the repo before assuming so"
+fi
+
+# --- manifest update (repo block only — vaultPrefixes are never touched) -----
+
+TMP_MANIFEST="$(mktemp)"
+jq \
+  --arg remote "$REMOTE_URL" \
+  --arg headSha "$HEAD_SHA" \
+  --argjson dirty "$DIRTY_JSON" \
+  --argjson pushed "$BRANCH_PUSHED" \
+  --argjson access "$ACCESS_VERIFIED" \
+  --arg accessNote "$ACCESS_NOTE" \
+  '.repo.remote = (if $remote == "" then null else $remote end)
+   | .repo.headSha = (if $headSha == "" then null else $headSha end)
+   | .repo.dirtyFiles = $dirty
+   | .repo.branchPushed = $pushed
+   | .repo.accessVerified = $access
+   | .repo.accessNote = $accessNote' \
+  "$MANIFEST" > "$TMP_MANIFEST" && mv "$TMP_MANIFEST" "$MANIFEST"
+
+# --- brief: call out untransferred work and unverified access ----------------
+
+if [ -f "$BRIEF" ]; then
+  DIRTY_COUNT="$(printf '%s' "$DIRTY_JSON" | jq 'length')"
+  if [ "$DIRTY_COUNT" -gt 0 ] || [ "$ACCESS_VERIFIED" != "true" ]; then
+    {
+      echo
+      echo "## Code handover notes"
+      echo
+      if [ "$DIRTY_COUNT" -gt 0 ]; then
+        echo "The delegator's working tree had uncommitted changes that are **not transferred** with this delegation. If something seems missing, these files are why — ask the delegator to commit and push them:"
+        echo
+        printf '%s' "$DIRTY_JSON" | jq -r '.[] | "- `\(.)`"'
+        echo
+      fi
+      if [ "$ACCESS_VERIFIED" != "true" ]; then
+        echo "$ACCESS_NOTE"
+      fi
+    } >> "$BRIEF"
+  fi
+fi
+
+echo "hq-delegate-repo: recorded branch state (pushed=$BRANCH_PUSHED, dirty=$(printf '%s' "$DIRTY_JSON" | jq 'length') files, accessVerified=$ACCESS_VERIFIED)"

--- a/core/scripts/tests/hq-delegate-repo.test.sh
+++ b/core/scripts/tests/hq-delegate-repo.test.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Regression: hq-delegate-repo.sh must hand over the code branch with an
+# explicit repo anchor, record dirty work as NOT transferred, verify access
+# read-only, and never leak repo paths into vault prefixes.
+#
+# Guards (uses a REAL git fixture — local clone + bare origin):
+#   1. Local-only branch + --yes -> pushed with `git -C ... push -u origin`,
+#      visible in the bare origin, headSha recorded, branchPushed=true.
+#   2. Local-only branch without --yes -> exit 2, branch NOT pushed.
+#   3. Dirty/untracked files -> recorded in repo.dirtyFiles[] AND called out
+#      in BRIEF.md as not transferred.
+#   4. gh access check failure -> accessVerified=false, note says UNVERIFIED;
+#      no step claims access exists.
+#   5. vaultPrefixes[] untouched and free of repos/ paths.
+#   6. repo: null -> clean exit 0, nothing changed.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+HELPER="$ROOT/core/scripts/hq-delegate-repo.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$HELPER" ] || fail "missing helper: $HELPER"
+
+# --- real git fixture: bare origin + working clone under a fake HQ root ------
+
+FIX="$TMP/hqroot"
+mkdir -p "$FIX/repos/public" "$TMP/origin"
+git init --bare --quiet --initial-branch=main "$TMP/origin/widget-repo.git"
+git -C "$FIX/repos/public" clone --quiet "$TMP/origin/widget-repo.git" widget-repo 2>/dev/null
+REPO="$FIX/repos/public/widget-repo"
+git -C "$REPO" config user.email test@test.local
+git -C "$REPO" config user.name Test
+echo "hello" > "$REPO/README.md"
+git -C "$REPO" add README.md
+git -C "$REPO" commit --quiet -m "init"
+git -C "$REPO" push --quiet -u origin main 2>/dev/null
+git -C "$REPO" switch --quiet -c feature/widget
+echo "wip" > "$REPO/feature.txt"
+git -C "$REPO" add feature.txt
+git -C "$REPO" commit --quiet -m "feature work"
+# leave dirty + untracked work behind
+echo "uncommitted" >> "$REPO/README.md"
+echo "scratch" > "$REPO/notes.tmp"
+
+# stub gh: always 404s the collaborator check
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+echo "$*" >> "$GH_STUB_LOG"
+exit 1
+STUB
+chmod +x "$TMP/bin/gh"
+export PATH="$TMP/bin:$PATH"
+export GH_STUB_LOG="$TMP/gh.log"
+
+# --- bundle fixture ----------------------------------------------------------
+
+BUNDLE="$TMP/bundle"
+mkdir -p "$BUNDLE"
+MANIFEST="$BUNDLE/manifest.json"
+cat > "$MANIFEST" <<'JSON'
+{
+  "schemaVersion": 1,
+  "delegationId": "dlg-test-widget",
+  "company": "acme",
+  "to": {"kind": "person", "principal": "alice@acme.test"},
+  "project": {"name": "widget"},
+  "vaultPrefixes": [
+    {"prefix": "projects/widget/", "permission": "write", "reason": "project dossier"}
+  ],
+  "repo": {"path": "repos/public/widget-repo", "remote": null, "branch": "feature/widget",
+           "baseBranch": "main", "headSha": null, "dirtyFiles": [], "accessVerified": false},
+  "status": "building"
+}
+JSON
+echo "# Delegation brief — widget" > "$BUNDLE/BRIEF.md"
+PREFIXES_BEFORE="$(jq -c '.vaultPrefixes' "$MANIFEST")"
+
+# --- 2. without --yes: exit 2, branch not pushed -----------------------------
+
+set +e
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$MANIFEST" >/dev/null 2>&1
+RC=$?
+set -e
+[ "$RC" -eq 2 ] || fail "local-only branch without --yes must exit 2, got $RC"
+git -C "$TMP/origin/widget-repo.git" rev-parse --verify --quiet refs/heads/feature/widget >/dev/null \
+  && fail "branch must NOT be pushed without --yes"
+
+# --- 1+3+4. with --yes: push, record dirty, unverified access ----------------
+
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$MANIFEST" --yes --github-user alicehub >/dev/null 2>&1 \
+  || fail "handover with --yes exited non-zero"
+
+# 1. branch landed in the bare origin; manifest records it
+git -C "$TMP/origin/widget-repo.git" rev-parse --verify --quiet refs/heads/feature/widget >/dev/null \
+  || fail "branch was not pushed to origin"
+LOCAL_SHA="$(git -C "$REPO" rev-parse refs/heads/feature/widget)"
+jq -e --arg sha "$LOCAL_SHA" '.repo.headSha == $sha and .repo.branchPushed == true' "$MANIFEST" >/dev/null \
+  || fail "manifest must record the pushed headSha: $(jq -c '.repo' "$MANIFEST")"
+
+# 3. dirty + untracked recorded and surfaced in the brief
+jq -e '.repo.dirtyFiles | index("README.md") and index("notes.tmp")' "$MANIFEST" >/dev/null \
+  || fail "dirty and untracked files must land in repo.dirtyFiles: $(jq -c '.repo.dirtyFiles' "$MANIFEST")"
+grep -q "not transferred" "$BUNDLE/BRIEF.md" || fail "BRIEF must call out untransferred work"
+grep -q "README.md" "$BUNDLE/BRIEF.md" || fail "BRIEF must name the dirty files"
+
+# 4. gh 404 -> unverified, stated plainly, never claimed
+grep -q "collaborators/alicehub" "$GH_STUB_LOG" || fail "gh collaborator check was not invoked"
+jq -e '.repo.accessVerified == false' "$MANIFEST" >/dev/null \
+  || fail "failed gh check must leave accessVerified=false"
+jq -e '.repo.accessNote | test("UNVERIFIED")' "$MANIFEST" >/dev/null \
+  || fail "manifest accessNote must say UNVERIFIED"
+grep -q "UNVERIFIED" "$BUNDLE/BRIEF.md" || fail "BRIEF must state access is unverified"
+
+# --- 5. vaultPrefixes untouched, no repos/ paths -----------------------------
+
+[ "$(jq -c '.vaultPrefixes' "$MANIFEST")" = "$PREFIXES_BEFORE" ] \
+  || fail "handover must not touch vaultPrefixes"
+jq -e 'all(.vaultPrefixes[]; .prefix | startswith("repos/") | not)' "$MANIFEST" >/dev/null \
+  || fail "vaultPrefixes must contain no repos/ path"
+
+# --- 6. repo: null skips cleanly ---------------------------------------------
+
+NULL_MANIFEST="$TMP/null-manifest.json"
+jq '.repo = null' "$MANIFEST" > "$NULL_MANIFEST"
+BEFORE="$(cat "$NULL_MANIFEST")"
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$NULL_MANIFEST" >/dev/null 2>&1 \
+  || fail "repo:null project must skip cleanly with exit 0"
+[ "$(cat "$NULL_MANIFEST")" = "$BEFORE" ] || fail "repo:null run must change nothing"
+
+echo "hq-delegate-repo: ok (anchored push behind --yes, dirty work surfaced, access unverified stated plainly, vaultPrefixes untouched, null skip)"


### PR DESCRIPTION
Fourth story of `/delegate` (project: `hq-delegate-command`, indigo). Reads the manifest contract from #160.

## What

`core/scripts/hq-delegate-repo.sh --manifest <path> [--yes] [--github-user <login>]`:

- Records remote, headSha, and branch state into the manifest's `repo{}` block
- A branch that exists only locally requires confirmation (exit 2 without `--yes`); pushed with an explicitly anchored `git -C <abs> push -u origin <branch>`
- Dirty/untracked files are captured into `repo.dirtyFiles[]` **and** appended to BRIEF.md as work not transferred
- Recipient access checked read-only via `gh api .../collaborators/<login>`; on failure the manifest and brief say **UNVERIFIED** plainly — nothing ever claims access that wasn't confirmed
- `vaultPrefixes[]` never touched; repo content never pushed to the vault; `repo: null` projects skip cleanly

## Tests

`bash core/scripts/tests/hq-delegate-repo.test.sh` — real git fixture (bare origin + working clone), stubbed `gh`. Covers confirm-gated push, dirty-work surfacing, unverified access, vault-prefix invariance, and the null skip.

https://claude.ai/code/session_015YaqhyfE5w7L1NHnMiSnTp