### PR TITLE
feat(delegate): secret access handover — granted by name, never by value (US-005)

### DIFF
--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,5 +1,5 @@
 version: 1
-hqVersion: "15.0.85"
+hqVersion: "15.0.86"
 agentSessionContractVersion: 1
 # Provider adapter contract version (US-500). Must match
 # HQ_ADAPTER_CONTRACT_VERSION in core/scripts/lib/provider-adapter-version.sh.

--- a/core/scripts/hq-delegate-secrets.sh
+++ b/core/scripts/hq-delegate-secrets.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# hq-core: public
+# hq-delegate-secrets.sh — grant a delegation recipient access to the secrets
+# a project needs, BY NAME ONLY. No command in this helper ever reads,
+# prints, logs, or interpolates a secret value.
+#
+# Usage:
+#   core/scripts/hq-delegate-secrets.sh --manifest <path> [--yes] [--no-secrets]
+#     [--env-schema <path>]
+#
+# Behavior:
+#   - derives required secret NAMES from the project's / repo's .env.schema
+#     (--env-schema overrides discovery); no schema -> records secrets: []
+#     and says so plainly rather than guessing at credentials
+#   - without --yes: prints a full-prose confirmation listing every name and
+#     the principal, then exits 2 granting nothing — this step is a privilege
+#     handover and gets its own confirmation, separate from the file grants
+#   - with --yes: hq secrets share <NAME> --with <principal> --permission read
+#     per name, then records the names (and only the names) in the manifest
+#   - --no-secrets: skips everything, records {secrets: [], secretsSkipped: true}
+#
+# Consumption on the recipient's side is via `hq run` / `hq secrets exec` —
+# documented in the brief; values never appear in any delegation artifact
+# (policy hq-delegate-never-inlines-secrets-or-share-urls).
+#
+# Env: HQ_ROOT — HQ root override (default: resolved from script location)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HQ_ROOT="${HQ_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+
+usage() { sed -n '3,24p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+die()   { echo "hq-delegate-secrets: $*" >&2; exit 1; }
+
+command -v jq >/dev/null 2>&1 || die "jq is required but not installed"
+
+MANIFEST="" YES=0 NO_SECRETS=0 ENV_SCHEMA=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --manifest)   MANIFEST="${2:-}"; shift 2 ;;
+    --yes)        YES=1; shift ;;
+    --no-secrets) NO_SECRETS=1; shift ;;
+    --env-schema) ENV_SCHEMA="${2:-}"; shift 2 ;;
+    -h|--help)    usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$MANIFEST" ] || die "--manifest is required"
+[ -f "$MANIFEST" ] || die "manifest not found: $MANIFEST"
+jq -e . "$MANIFEST" >/dev/null 2>&1 || die "manifest is not valid JSON: $MANIFEST"
+
+COMPANY="$(jq -r '.company // empty' "$MANIFEST")"
+PRINCIPAL="$(jq -r '.to.principal // empty' "$MANIFEST")"
+PROJECT="$(jq -r '.project.name // empty' "$MANIFEST")"
+[ -n "$COMPANY" ]   || die "manifest has no company"
+[ -n "$PRINCIPAL" ] || die "manifest has no to.principal"
+
+update_manifest() { # jq-filter
+  local tmp
+  tmp="$(mktemp)"
+  jq "$1" "$MANIFEST" > "$tmp" && mv "$tmp" "$MANIFEST"
+}
+
+# --- explicit skip ------------------------------------------------------------
+
+if [ "$NO_SECRETS" -eq 1 ]; then
+  update_manifest '.secrets = [] | .secretsSkipped = true'
+  echo "hq-delegate-secrets: skipped (--no-secrets) — no credential access granted"
+  exit 0
+fi
+
+# --- discover the env schema --------------------------------------------------
+
+if [ -z "$ENV_SCHEMA" ]; then
+  REPO_REL="$(jq -r '.repo.path // empty' "$MANIFEST")"
+  for candidate in \
+    "$HQ_ROOT/companies/$COMPANY/projects/$PROJECT/.env.schema" \
+    "${REPO_REL:+$HQ_ROOT/$REPO_REL/.env.schema}"; do
+    [ -n "$candidate" ] && [ -f "$candidate" ] && { ENV_SCHEMA="$candidate"; break; }
+  done
+fi
+
+if [ -z "$ENV_SCHEMA" ] || [ ! -f "$ENV_SCHEMA" ]; then
+  update_manifest '.secrets = [] | .secretsSkipped = false'
+  echo "hq-delegate-secrets: no .env.schema found for this project or its repo — no secret names to grant. If the project needs credentials, add an .env.schema and re-run, or grant them manually with 'hq secrets share'."
+  exit 0
+fi
+
+# --- parse names (KEY= lines; comments and blanks ignored) --------------------
+
+NAMES="$(grep -E '^[A-Za-z_][A-Za-z0-9_]*=' "$ENV_SCHEMA" | cut -d= -f1 | sort -u)"
+if [ -z "$NAMES" ]; then
+  update_manifest '.secrets = [] | .secretsSkipped = false'
+  echo "hq-delegate-secrets: $ENV_SCHEMA declares no secret names — nothing to grant"
+  exit 0
+fi
+NAME_COUNT="$(printf '%s\n' "$NAMES" | wc -l | tr -d ' ')"
+
+# --- confirmation gate (full prose; separate from the file-grant confirm) ----
+
+echo "Secret access handover — this grants the recipient the ability to use these credentials."
+echo
+echo "The following $NAME_COUNT secret name(s), declared by $(basename "$ENV_SCHEMA") for project '$PROJECT', will be shared with read permission to '$PRINCIPAL' in company '$COMPANY':"
+echo
+printf '%s\n' "$NAMES" | sed 's/^/  - /'
+echo
+echo "Only the names are granted and recorded; no secret value is read, printed, or transmitted by this step. The recipient consumes them through 'hq run' / 'hq secrets exec'."
+
+if [ "$YES" -ne 1 ]; then
+  echo
+  echo "hq-delegate-secrets: confirmation required — re-run with --yes after the user approves (or --no-secrets to skip)" >&2
+  exit 2
+fi
+
+# --- grant each name (names only — never a value read) ------------------------
+
+printf '%s\n' "$NAMES" | while IFS= read -r name; do
+  hq secrets share "$name" --with "$PRINCIPAL" --permission read --company "$COMPANY" \
+    || die "failed to grant '$name' to '$PRINCIPAL' — aborting; manifest not updated"
+  echo "hq-delegate-secrets: granted read on '$name' to '$PRINCIPAL'"
+done
+
+NAMES_JSON="$(printf '%s\n' "$NAMES" | jq -R . | jq -cs .)"
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+update_manifest ".secrets = $NAMES_JSON | .secretsSkipped = false | .secretsGrantedAt = \"$NOW\""
+
+echo "hq-delegate-secrets: $NAME_COUNT secret name(s) granted and recorded (names only)"

--- a/core/scripts/tests/hq-delegate-secrets.test.sh
+++ b/core/scripts/tests/hq-delegate-secrets.test.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Regression: hq-delegate-secrets.sh must grant secret access BY NAME ONLY —
+# no command may ever read, print, or transmit a secret value — behind its
+# own explicit confirmation, with --no-secrets and no-schema paths that
+# grant nothing.
+#
+# Guards:
+#   1. Schema with 3 names + --yes -> exactly those 3 names shared with
+#      --permission read; the stub's value-read commands (get/env/exec/
+#      --reveal) are NEVER invoked; manifest records names only.
+#   2. --no-secrets -> zero invocations, {secrets: [], secretsSkipped: true}.
+#   3. Without --yes -> exit 2, zero invocations, prose lists names +
+#      principal.
+#   4. No .env.schema -> secrets: [], plain report, exit 0, zero grants.
+#   5. A sentinel secret VALUE planted in the stub store never appears in
+#      the manifest or anywhere in the bundle.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+HELPER="$ROOT/core/scripts/hq-delegate-secrets.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$HELPER" ] || fail "missing helper: $HELPER"
+
+# --- stub hq CLI with a sentinel value that must never surface ---------------
+SENTINEL="sentinel-value-Zx9Qw7-never-leaks"
+INVOKE_LOG="$TMP/invocations.log"
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/hq" <<STUB
+#!/usr/bin/env bash
+echo "\$*" >> "\$HQ_STUB_LOG"
+case "\$1 \$2" in
+  "secrets share") exit 0 ;;
+  "secrets get"|"secrets env"|"secrets exec")
+    echo "$SENTINEL"
+    exit 0
+    ;;
+esac
+exit 0
+STUB
+chmod +x "$TMP/bin/hq"
+export PATH="$TMP/bin:$PATH"
+export HQ_STUB_LOG="$INVOKE_LOG"
+
+# --- fixture: HQ root, project with .env.schema, bundle ----------------------
+
+FIX="$TMP/hqroot"
+PROJ="$FIX/companies/acme/projects/widget"
+mkdir -p "$PROJ"
+cat > "$PROJ/.env.schema" <<'SCHEMA'
+# Widget runtime credentials
+DATABASE_URL=
+WIDGET_API_KEY=
+STRIPE_WEBHOOK_SECRET=
+SCHEMA
+
+BUNDLE="$FIX/workspace/delegations/dlg-test-widget"
+mkdir -p "$BUNDLE"
+MANIFEST="$BUNDLE/manifest.json"
+write_manifest() {
+  cat > "$MANIFEST" <<'JSON'
+{
+  "schemaVersion": 1,
+  "delegationId": "dlg-test-widget",
+  "company": "acme",
+  "to": {"kind": "person", "principal": "alice@acme.test"},
+  "project": {"name": "widget"},
+  "repo": null,
+  "secrets": [],
+  "status": "building"
+}
+JSON
+}
+write_manifest
+echo "# Delegation brief — widget" > "$BUNDLE/BRIEF.md"
+
+# --- 3. without --yes: exit 2, prose plan, zero invocations ------------------
+
+: > "$INVOKE_LOG"
+set +e
+PLAN="$(HQ_ROOT="$FIX" bash "$HELPER" --manifest "$MANIFEST" 2>/dev/null)"
+RC=$?
+set -e
+[ "$RC" -eq 2 ] || fail "without --yes must exit 2, got $RC"
+[ ! -s "$INVOKE_LOG" ] || fail "without --yes nothing may be invoked: $(cat "$INVOKE_LOG")"
+printf '%s' "$PLAN" | grep -q "WIDGET_API_KEY" || fail "confirmation prose must list the names"
+printf '%s' "$PLAN" | grep -q "alice@acme.test" || fail "confirmation prose must name the principal"
+jq -e '.secrets == []' "$MANIFEST" >/dev/null || fail "declined run must not record names"
+
+# --- 1. with --yes: names granted, values never read -------------------------
+
+: > "$INVOKE_LOG"
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$MANIFEST" --yes >/dev/null 2>&1 \
+  || fail "grant run exited non-zero"
+
+SHARE_COUNT="$(grep -c '^secrets share' "$INVOKE_LOG")"
+[ "$SHARE_COUNT" -eq 3 ] || fail "expected exactly 3 share calls, got $SHARE_COUNT: $(cat "$INVOKE_LOG")"
+for name in DATABASE_URL WIDGET_API_KEY STRIPE_WEBHOOK_SECRET; do
+  grep -q "^secrets share $name --with alice@acme.test --permission read --company acme$" "$INVOKE_LOG" \
+    || fail "missing read share for $name"
+done
+
+# value-read commands must never run
+if grep -Eq '^secrets (get|env|exec)|--reveal' "$INVOKE_LOG"; then
+  fail "a value-reading command was invoked: $(cat "$INVOKE_LOG")"
+fi
+
+jq -e '.secrets == ["DATABASE_URL","STRIPE_WEBHOOK_SECRET","WIDGET_API_KEY"] and .secretsSkipped == false and .secretsGrantedAt != null' \
+  "$MANIFEST" >/dev/null || fail "manifest must record exactly the granted names: $(jq -c '.secrets' "$MANIFEST")"
+
+# --- 5. the sentinel value appears nowhere in the bundle ---------------------
+
+if grep -r "$SENTINEL" "$BUNDLE" >/dev/null 2>&1; then
+  fail "a secret VALUE leaked into the bundle"
+fi
+
+# --- 2. --no-secrets: zero invocations, skipped recorded ---------------------
+
+write_manifest
+: > "$INVOKE_LOG"
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$MANIFEST" --no-secrets >/dev/null 2>&1 \
+  || fail "--no-secrets run exited non-zero"
+[ ! -s "$INVOKE_LOG" ] || fail "--no-secrets must invoke nothing"
+jq -e '.secrets == [] and .secretsSkipped == true' "$MANIFEST" >/dev/null \
+  || fail "--no-secrets must record secrets: [] with skipped: true"
+
+# --- 4. no .env.schema: plain report, zero grants, exit 0 --------------------
+
+write_manifest
+rm "$PROJ/.env.schema"
+: > "$INVOKE_LOG"
+OUT="$(HQ_ROOT="$FIX" bash "$HELPER" --manifest "$MANIFEST" --yes 2>&1)" \
+  || fail "no-schema run must exit 0"
+[ ! -s "$INVOKE_LOG" ] || fail "no-schema run must grant nothing"
+printf '%s' "$OUT" | grep -qi "no .env.schema" || fail "no-schema run must say so plainly: $OUT"
+jq -e '.secrets == [] and .secretsSkipped == false' "$MANIFEST" >/dev/null \
+  || fail "no-schema run must record empty secrets without the skipped flag"
+
+echo "hq-delegate-secrets: ok (names only, own confirm gate, --no-secrets and no-schema paths, sentinel value never surfaced)"


### PR DESCRIPTION
Fifth story of `/delegate` (project: `hq-delegate-command`, indigo). Reads the manifest contract from #160.

## What

`core/scripts/hq-delegate-secrets.sh --manifest <path> [--yes] [--no-secrets] [--env-schema <path>]`

- Derives required secret **names** from the project's / repo's `.env.schema`
- Grants each with `hq secrets share <name> --with <principal> --permission read --company <slug>`
- Records the names (and only the names) in the manifest; recipient consumes via `hq run` / `hq secrets exec`

## Safety

- **No value ever moves**: no command in this helper reads, prints, logs, or interpolates a secret value. The test plants a sentinel value in the stub store and asserts it never appears anywhere in the bundle.
- **Own confirmation gate** (exit 2 without `--yes`), separate from the file-grant confirm — full prose listing every name and the principal
- `--no-secrets` skips entirely (`secretsSkipped: true`); a missing schema grants nothing and says so plainly instead of guessing

## Tests

`bash core/scripts/tests/hq-delegate-secrets.test.sh` — offline, stubbed `hq` CLI; five guards including the sentinel-value no-leak assertion.

https://claude.ai/code/session_015YaqhyfE5w7L1NHnMiSnTp