### PR TITLE
feat(delegate): ownership transfer — board, PRD, work mesh, journal (US-006)

### DIFF
--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,5 +1,5 @@
 version: 1
-hqVersion: "15.0.86"
+hqVersion: "15.0.87"
 agentSessionContractVersion: 1
 # Provider adapter contract version (US-500). Must match
 # HQ_ADAPTER_CONTRACT_VERSION in core/scripts/lib/provider-adapter-version.sh.

--- a/core/scripts/hq-delegate-transfer.sh
+++ b/core/scripts/hq-delegate-transfer.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# hq-core: public
+# hq-delegate-transfer.sh — make a delegation real everywhere HQ tracks
+# ownership: board entry, PRD metadata, work mesh, and the project journal.
+#
+# Usage:
+#   core/scripts/hq-delegate-transfer.sh --manifest <path>
+#
+# Behavior (mode "transfer"; mode "share" skips every mutation):
+#   1. companies/<co>/board.json — the project's entry gets owner=<recipient>
+#      and a bumped updated_at; created (once) if absent
+#   2. prd.json metadata gains owner, delegatedFrom, delegatedAt
+#   3. work-mesh: `done` event closes the delegator's in-progress thread and
+#      broadcasts the reassignment; silently skipped when the helper is
+#      unavailable (local/offline installs) — the transfer still succeeds
+#   4. a dated "Delegated" stanza is appended to the project journal naming
+#      the recipient, delegation id, and transferred scope
+#
+# Idempotent: re-running updates owner/timestamps in place — never a
+# duplicate board entry, never a duplicated journal stanza.
+#
+# The delegator's own vault access is untouched (granting the recipient
+# write does not revoke anything).
+#
+# Env: HQ_ROOT — HQ root override (default: resolved from script location)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HQ_ROOT="${HQ_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+
+usage() { sed -n '3,25p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+die()   { echo "hq-delegate-transfer: $*" >&2; exit 1; }
+
+command -v jq >/dev/null 2>&1 || die "jq is required but not installed"
+
+MANIFEST=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --manifest) MANIFEST="${2:-}"; shift 2 ;;
+    -h|--help)  usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$MANIFEST" ] || die "--manifest is required"
+[ -f "$MANIFEST" ] || die "manifest not found: $MANIFEST"
+jq -e . "$MANIFEST" >/dev/null 2>&1 || die "manifest is not valid JSON: $MANIFEST"
+
+MODE="$(jq -r '.mode // "transfer"' "$MANIFEST")"
+COMPANY="$(jq -r '.company // empty' "$MANIFEST")"
+PROJECT="$(jq -r '.project.name // empty' "$MANIFEST")"
+PRINCIPAL="$(jq -r '.to.principal // empty' "$MANIFEST")"
+DISPLAY="$(jq -r '.to.displayName // .to.principal // empty' "$MANIFEST")"
+DELEGATION_ID="$(jq -r '.delegationId // empty' "$MANIFEST")"
+FROM="$(jq -r '.from.email // .from.personUid // "unknown"' "$MANIFEST")"
+[ -n "$COMPANY" ]   || die "manifest has no company"
+[ -n "$PROJECT" ]   || die "manifest has no project.name"
+[ -n "$PRINCIPAL" ] || die "manifest has no to.principal"
+
+if [ "$MODE" = "share" ]; then
+  echo "hq-delegate-transfer: mode is 'share' — ownership stays with the delegator, nothing mutated"
+  exit 0
+fi
+
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+TODAY="$(date -u +%Y-%m-%d)"
+PRD_PATH="companies/$COMPANY/projects/$PROJECT/prd.json"
+PRD_ABS="$HQ_ROOT/$PRD_PATH"
+PROJECT_DIR="$HQ_ROOT/companies/$COMPANY/projects/$PROJECT"
+BOARD="$HQ_ROOT/companies/$COMPANY/board.json"
+
+[ -f "$PRD_ABS" ] || die "prd not found: $PRD_PATH"
+
+# --- 1. board entry: update in place, create once if absent ------------------
+
+if [ -f "$BOARD" ]; then
+  jq -e . "$BOARD" >/dev/null 2>&1 || die "board.json is not valid JSON: $BOARD"
+else
+  echo '{"projects": []}' > "$BOARD"
+fi
+
+TITLE="$(jq -r '.name // empty' "$PRD_ABS")"
+DESC="$(jq -r '.description // ""' "$PRD_ABS" | head -c 300)"
+
+TMP_BOARD="$(mktemp)"
+jq \
+  --arg prd "$PRD_PATH" \
+  --arg owner "$PRINCIPAL" \
+  --arg now "$NOW" \
+  --arg title "$TITLE" \
+  --arg desc "$DESC" \
+  --arg project "$PROJECT" \
+  '
+  if ([.projects // [] | .[] | select(.prd_path == $prd)] | length) > 0 then
+    .projects = [.projects[] |
+      if .prd_path == $prd then .owner = $owner | .updated_at = $now else . end]
+  else
+    .projects = (.projects // []) + [{
+      id: ("proj-" + $project),
+      title: $title,
+      description: $desc,
+      status: "in_progress",
+      owner: $owner,
+      prd_path: $prd,
+      created_at: $now,
+      updated_at: $now
+    }]
+  end
+  | .updated_at = $now
+  ' "$BOARD" > "$TMP_BOARD" && mv "$TMP_BOARD" "$BOARD"
+
+# --- 2. prd metadata ----------------------------------------------------------
+
+TMP_PRD="$(mktemp)"
+jq \
+  --arg owner "$PRINCIPAL" \
+  --arg from "$FROM" \
+  --arg now "$NOW" \
+  '.metadata.owner = $owner
+   | .metadata.delegatedFrom = $from
+   | .metadata.delegatedAt = $now' \
+  "$PRD_ABS" > "$TMP_PRD" && mv "$TMP_PRD" "$PRD_ABS"
+
+# --- 3. work mesh: close the delegator's thread, broadcast reassignment ------
+# Silently tolerated when unavailable (local/offline installs no-op).
+
+WORK_MESH="$HQ_ROOT/core/scripts/work-mesh.sh"
+if [ -f "$WORK_MESH" ]; then
+  bash "$WORK_MESH" done --company "$COMPANY" --project "$PROJECT" \
+    --summary "Delegated to $DISPLAY ($PRINCIPAL) — delegation $DELEGATION_ID; ownership transferred" \
+    --silent >/dev/null 2>&1 || true
+fi
+
+# --- 4. journal: one dated stanza per delegation id --------------------------
+
+JOURNAL_DIR="$PROJECT_DIR/journal"
+JOURNAL_FILE="$JOURNAL_DIR/delegations.md"
+mkdir -p "$JOURNAL_DIR"
+if [ ! -f "$JOURNAL_FILE" ]; then
+  {
+    echo "# Delegation log — $PROJECT"
+    echo
+    echo "Ownership handoffs for this project, appended by /delegate."
+  } > "$JOURNAL_FILE"
+fi
+
+if ! grep -qF "$DELEGATION_ID" "$JOURNAL_FILE"; then
+  SCOPE="$(jq -r '[.vaultPrefixes // [] | .[] | .prefix] | join(", ")' "$MANIFEST")"
+  {
+    echo
+    echo "## $TODAY — Delegated to $DISPLAY"
+    echo
+    echo "- Delegation: \`$DELEGATION_ID\`"
+    echo "- From: $FROM"
+    echo "- To: $DISPLAY ($PRINCIPAL)"
+    echo "- Transferred scope: $SCOPE"
+    echo "- Board and work-mesh ownership reassigned; the delegator retains read access."
+  } >> "$JOURNAL_FILE"
+fi
+
+# --- record on the manifest ---------------------------------------------------
+
+TMP_MANIFEST="$(mktemp)"
+jq --arg now "$NOW" '.ownershipTransferredAt = $now' "$MANIFEST" > "$TMP_MANIFEST" \
+  && mv "$TMP_MANIFEST" "$MANIFEST"
+
+echo "hq-delegate-transfer: ownership of '$PROJECT' transferred to $DISPLAY ($PRINCIPAL) — board, PRD, work mesh, and journal updated"

--- a/core/scripts/tests/hq-delegate-transfer.test.sh
+++ b/core/scripts/tests/hq-delegate-transfer.test.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Regression: hq-delegate-transfer.sh must reassign ownership everywhere HQ
+# tracks it — board, PRD metadata, work mesh, journal — idempotently, with
+# --share mode mutating nothing and offline installs still succeeding.
+#
+# Guards:
+#   1. Project already on the board -> owner set, updated_at bumped, array
+#      length unchanged (update in place, no duplicate).
+#   2. Project absent from the board -> exactly one entry created with the
+#      correct prd_path.
+#   3. Run twice -> still one board entry, exactly one journal stanza for
+#      the delegation id.
+#   4. work-mesh.sh present -> invoked with done + company + project + a
+#      summary naming the recipient; absent -> transfer still exits 0 and
+#      the board/PRD mutations land.
+#   5. mode "share" -> board.json and prd.json byte-identical afterward.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+HELPER="$ROOT/core/scripts/hq-delegate-transfer.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$HELPER" ] || fail "missing helper: $HELPER"
+
+# --- fixture -----------------------------------------------------------------
+
+make_fixture() { # root  (fresh HQ root with project + board + fake work-mesh)
+  local fix="$1"
+  rm -rf "$fix"
+  mkdir -p "$fix/companies/acme/projects/widget" "$fix/core/scripts"
+  cat > "$fix/companies/acme/projects/widget/prd.json" <<'JSON'
+{"name": "widget", "description": "Build the widget.", "metadata": {"goal": "ship"}}
+JSON
+  cat > "$fix/companies/acme/board.json" <<'JSON'
+{"projects": [
+  {"id": "ac-proj-1", "title": "other", "prd_path": "companies/acme/projects/other/prd.json", "updated_at": "2026-01-01T00:00:00Z"},
+  {"id": "ac-proj-7", "title": "widget", "prd_path": "companies/acme/projects/widget/prd.json", "updated_at": "2026-01-01T00:00:00Z"}
+]}
+JSON
+  cat > "$fix/core/scripts/work-mesh.sh" <<'MESH'
+#!/usr/bin/env bash
+echo "$*" >> "$MESH_STUB_LOG"
+exit 0
+MESH
+  chmod +x "$fix/core/scripts/work-mesh.sh"
+}
+
+write_manifest() { # path mode
+  cat > "$1" <<JSON
+{
+  "schemaVersion": 1,
+  "delegationId": "dlg-20260807-widget",
+  "mode": "$2",
+  "company": "acme",
+  "from": {"email": "owner@acme.test", "personUid": "prs_owner1"},
+  "to": {"kind": "person", "principal": "alice@acme.test", "displayName": "Alice"},
+  "project": {"name": "widget", "prdPath": "companies/acme/projects/widget/prd.json", "boardId": "ac-proj-7"},
+  "vaultPrefixes": [{"prefix": "projects/widget/", "permission": "write", "reason": "project dossier"}],
+  "status": "granted"
+}
+JSON
+}
+
+FIX="$TMP/hqroot"
+M="$TMP/manifest.json"
+export MESH_STUB_LOG="$TMP/mesh.log"
+
+# --- 1+4. existing board entry: in-place update; work-mesh invoked -----------
+
+make_fixture "$FIX"
+write_manifest "$M" transfer
+: > "$MESH_STUB_LOG"
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$M" >/dev/null 2>&1 \
+  || fail "transfer exited non-zero"
+
+BOARD="$FIX/companies/acme/board.json"
+jq -e '(.projects | length) == 2' "$BOARD" >/dev/null \
+  || fail "board array length must be unchanged: $(jq '.projects | length' "$BOARD")"
+jq -e '.projects[] | select(.prd_path == "companies/acme/projects/widget/prd.json") | .owner == "alice@acme.test" and .updated_at != "2026-01-01T00:00:00Z"' \
+  "$BOARD" >/dev/null || fail "board entry must gain owner + bumped updated_at"
+
+PRD="$FIX/companies/acme/projects/widget/prd.json"
+jq -e '.metadata.owner == "alice@acme.test" and .metadata.delegatedFrom == "owner@acme.test" and .metadata.delegatedAt != null' \
+  "$PRD" >/dev/null || fail "prd metadata must record owner/delegatedFrom/delegatedAt"
+
+grep -q '^done --company acme --project widget' "$MESH_STUB_LOG" \
+  || fail "work-mesh must be invoked with done for the company/project: $(cat "$MESH_STUB_LOG")"
+grep -q 'alice@acme.test' "$MESH_STUB_LOG" \
+  || fail "work-mesh summary must name the recipient"
+
+JOURNAL="$FIX/companies/acme/projects/widget/journal/delegations.md"
+[ -f "$JOURNAL" ] || fail "journal delegation log must be created"
+grep -q 'dlg-20260807-widget' "$JOURNAL" || fail "journal must name the delegation id"
+grep -q 'Alice' "$JOURNAL" || fail "journal must name the recipient"
+grep -q 'projects/widget/' "$JOURNAL" || fail "journal must record the transferred scope"
+
+jq -e '.ownershipTransferredAt != null' "$M" >/dev/null \
+  || fail "manifest must record ownershipTransferredAt"
+
+# --- 3. idempotent second run ------------------------------------------------
+
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$M" >/dev/null 2>&1 \
+  || fail "second transfer run exited non-zero"
+jq -e '(.projects | length) == 2' "$BOARD" >/dev/null \
+  || fail "second run must not add a board entry"
+STANZAS="$(grep -c '^## ' "$JOURNAL")"
+[ "$STANZAS" -eq 1 ] || fail "second run must not duplicate the journal stanza (got $STANZAS)"
+
+# --- 2. project absent from board -> exactly one entry created ---------------
+
+make_fixture "$FIX"
+jq 'del(.projects[1])' "$FIX/companies/acme/board.json" > "$TMP/b" && mv "$TMP/b" "$FIX/companies/acme/board.json"
+write_manifest "$M" transfer
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$M" >/dev/null 2>&1 \
+  || fail "transfer (absent from board) exited non-zero"
+COUNT="$(jq '[.projects[] | select(.prd_path == "companies/acme/projects/widget/prd.json")] | length' "$FIX/companies/acme/board.json")"
+[ "$COUNT" -eq 1 ] || fail "exactly one board entry must be created, got $COUNT"
+jq -e '.projects[] | select(.prd_path == "companies/acme/projects/widget/prd.json") | .owner == "alice@acme.test"' \
+  "$FIX/companies/acme/board.json" >/dev/null || fail "created entry must carry the owner"
+
+# --- 4b. work-mesh unavailable -> still succeeds -----------------------------
+
+make_fixture "$FIX"
+rm "$FIX/core/scripts/work-mesh.sh"
+write_manifest "$M" transfer
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$M" >/dev/null 2>&1 \
+  || fail "transfer must exit 0 when work-mesh.sh is unavailable"
+jq -e '.projects[] | select(.prd_path == "companies/acme/projects/widget/prd.json") | .owner == "alice@acme.test"' \
+  "$FIX/companies/acme/board.json" >/dev/null \
+  || fail "board mutation must land even without work-mesh"
+
+# --- 5. share mode mutates nothing -------------------------------------------
+
+make_fixture "$FIX"
+write_manifest "$M" share
+BOARD_BEFORE="$(cat "$FIX/companies/acme/board.json")"
+PRD_BEFORE="$(cat "$FIX/companies/acme/projects/widget/prd.json")"
+: > "$MESH_STUB_LOG"
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$M" >/dev/null 2>&1 \
+  || fail "share mode must exit 0"
+[ "$(cat "$FIX/companies/acme/board.json")" = "$BOARD_BEFORE" ] \
+  || fail "share mode must leave board.json byte-identical"
+[ "$(cat "$FIX/companies/acme/projects/widget/prd.json")" = "$PRD_BEFORE" ] \
+  || fail "share mode must leave prd.json byte-identical"
+[ ! -s "$MESH_STUB_LOG" ] || fail "share mode must not touch the work mesh"
+[ ! -d "$FIX/companies/acme/projects/widget/journal" ] \
+  || fail "share mode must not write a journal stanza"
+
+echo "hq-delegate-transfer: ok (in-place board update, single created entry, idempotent journal, offline work-mesh tolerated, share mode inert)"


### PR DESCRIPTION
Sixth story of `/delegate` (project: `hq-delegate-command`, indigo). Reads the manifest contract from #160.

## What

`core/scripts/hq-delegate-transfer.sh --manifest <path>` — when the delegation mode is `transfer`:

1. **Board** — the project's `board.json` entry gets `owner` + bumped `updated_at`, updated in place; created exactly once if absent
2. **PRD** — metadata gains `owner`, `delegatedFrom`, `delegatedAt`
3. **Work mesh** — a `done` event closes the delegator's in-progress thread and broadcasts the reassignment; unavailable helper (local/offline installs) is silently tolerated and the transfer still succeeds
4. **Journal** — a dated "Delegated" stanza keyed on the delegation id (re-runs never duplicate it)

Mode `share` mutates nothing — board and PRD stay byte-identical. The delegator's own vault access is untouched.

## Tests

`bash core/scripts/tests/hq-delegate-transfer.test.sh` — fixture HQ root + stubbed work-mesh; covers in-place update, single-creation, double-run idempotency, offline tolerance, and share-mode inertness.

https://claude.ai/code/session_015YaqhyfE5w7L1NHnMiSnTp