### PR TITLE
feat(delegate): verified pickup probe + fully inert dry run (US-008)

### DIFF
--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,5 +1,5 @@
 version: 1
-hqVersion: "15.0.88"
+hqVersion: "15.0.89"
 agentSessionContractVersion: 1
 # Provider adapter contract version (US-500). Must match
 # HQ_ADAPTER_CONTRACT_VERSION in core/scripts/lib/provider-adapter-version.sh.

--- a/core/scripts/hq-delegate-bundle.sh
+++ b/core/scripts/hq-delegate-bundle.sh
@@ -6,7 +6,9 @@
 #   core/scripts/hq-delegate-bundle.sh build \
 #     --company <slug> --project <name> --to <principal> \
 #     [--to-kind person|agent] [--to-name <display name>] \
-#     [--mode transfer|share]
+#     [--mode transfer|share] [--dry-run]
+#
+# --dry-run prints the manifest JSON to stdout and writes nothing.
 #
 # Writes workspace/delegations/<delegationId>/{manifest.json,BRIEF.md} and
 # prints the delegationId on stdout. The manifest is the single source of
@@ -46,7 +48,7 @@ command -v jq >/dev/null 2>&1 || die "jq is required but not installed"
 [ "${1:-}" = "build" ] || { usage >&2; exit 1; }
 shift
 
-COMPANY="" PROJECT="" TO="" TO_KIND="person" TO_NAME="" MODE="transfer"
+COMPANY="" PROJECT="" TO="" TO_KIND="person" TO_NAME="" MODE="transfer" DRY_RUN=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --company) COMPANY="${2:-}"; shift 2 ;;
@@ -55,6 +57,7 @@ while [ $# -gt 0 ]; do
     --to-kind) TO_KIND="${2:-}"; shift 2 ;;
     --to-name) TO_NAME="${2:-}"; shift 2 ;;
     --mode)    MODE="${2:-}"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
     -h|--help) usage; exit 0 ;;
     *) die "unknown argument: $1" ;;
   esac
@@ -284,6 +287,16 @@ TRAPS="$(jq -r '[.metadata.securityNotes // empty, (.metadata.executionConventio
 
 if ! hq_scan_secrets "$STAGE/manifest.json" "$STAGE/BRIEF.md"; then
   die "generated bundle matched a secret-detection pattern — nothing written (see stderr above)"
+fi
+
+# --- dry run: print the manifest, write nothing ------------------------------
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  cat "$STAGE/manifest.json"
+  rm -rf "$STAGE"
+  trap - EXIT
+  echo "hq-delegate-bundle: dry run — nothing written" >&2
+  exit 0
 fi
 
 # --- move into place ---------------------------------------------------------

--- a/core/scripts/hq-delegate-verify.sh
+++ b/core/scripts/hq-delegate-verify.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# hq-core: public
+# hq-delegate-verify.sh — prove a delegation can actually be picked up
+# before anyone is told it is theirs, or print the full plan without
+# touching anything.
+#
+# Usage (probe mode — after grants, before the DM):
+#   core/scripts/hq-delegate-verify.sh --manifest <path>
+#
+# Probes every manifest vaultPrefix with `hq files browse` and requires it
+# reachable AND non-empty. All pass -> manifest advances granted -> verified
+# (send is gated on this). Any failure -> non-zero, the failing prefix and
+# likely cause named, status left at its last successful value so a re-run
+# resumes without re-granting.
+#
+# Usage (dry-run mode — full plan, zero mutation):
+#   core/scripts/hq-delegate-verify.sh --dry-run \
+#     --company <slug> --project <name> --to <principal> [--mode transfer|share]
+#
+# Prints recipient, mode, every prefix with its permission, the secret
+# names an .env.schema would grant, repo + branch, and the DM headline that
+# would be sent. Exits 0. Creates nothing under workspace/delegations/ and
+# invokes no mutating command.
+#
+# Env: HQ_ROOT — HQ root override (default: resolved from script location)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HQ_ROOT="${HQ_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+
+usage() { sed -n '3,25p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+die()   { echo "hq-delegate-verify: $*" >&2; exit 1; }
+
+command -v jq >/dev/null 2>&1 || die "jq is required but not installed"
+
+MANIFEST="" DRY_RUN=0 COMPANY="" PROJECT="" TO="" MODE="transfer"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --manifest) MANIFEST="${2:-}"; shift 2 ;;
+    --dry-run)  DRY_RUN=1; shift ;;
+    --company)  COMPANY="${2:-}"; shift 2 ;;
+    --project)  PROJECT="${2:-}"; shift 2 ;;
+    --to)       TO="${2:-}"; shift 2 ;;
+    --mode)     MODE="${2:-}"; shift 2 ;;
+    -h|--help)  usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+# =============================================================================
+# Dry-run mode: full plan from the builder's own derivation, zero mutation
+# =============================================================================
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  [ -n "$COMPANY" ] || die "--dry-run requires --company"
+  [ -n "$PROJECT" ] || die "--dry-run requires --project"
+  [ -n "$TO" ]      || die "--dry-run requires --to"
+
+  # The builder's --dry-run prints the manifest it WOULD write — single
+  # derivation source, nothing lands on disk.
+  PLAN_JSON="$(HQ_ROOT="$HQ_ROOT" bash "$SCRIPT_DIR/hq-delegate-bundle.sh" build \
+    --company "$COMPANY" --project "$PROJECT" --to "$TO" --mode "$MODE" --dry-run)" \
+    || die "could not derive the delegation plan (see builder error above)"
+
+  # Secret names the US-005 step would grant (same .env.schema derivation).
+  REPO_REL="$(printf '%s' "$PLAN_JSON" | jq -r '.repo.path // empty')"
+  SCHEMA=""
+  for candidate in \
+    "$HQ_ROOT/companies/$COMPANY/projects/$PROJECT/.env.schema" \
+    "${REPO_REL:+$HQ_ROOT/$REPO_REL/.env.schema}"; do
+    [ -n "$candidate" ] && [ -f "$candidate" ] && { SCHEMA="$candidate"; break; }
+  done
+  SECRET_NAMES="(none — no .env.schema found)"
+  if [ -n "$SCHEMA" ]; then
+    SECRET_NAMES="$(grep -E '^[A-Za-z_][A-Za-z0-9_]*=' "$SCHEMA" | cut -d= -f1 | sort -u | tr '\n' ' ')"
+    [ -n "$SECRET_NAMES" ] || SECRET_NAMES="(none declared)"
+  fi
+
+  echo "Delegation dry run — nothing will be pushed, granted, transferred, or sent."
+  echo
+  echo "  Recipient:  $TO"
+  echo "  Mode:       $MODE"
+  echo "  Company:    $COMPANY"
+  echo "  Project:    $PROJECT"
+  echo
+  echo "  Vault grants that would be written:"
+  printf '%s' "$PLAN_JSON" | jq -r '.vaultPrefixes[] | "    \(.permission)\ton \(.prefix)\t(\(.reason // ""))"'
+  echo
+  echo "  Secret names that would be granted (read): $SECRET_NAMES"
+  echo
+  if printf '%s' "$PLAN_JSON" | jq -e '.repo != null' >/dev/null; then
+    printf '%s' "$PLAN_JSON" | jq -r '"  Repo handover: \(.repo.path) — branch \(.repo.branch // "(none)") (base \(.repo.baseBranch))"'
+  else
+    echo "  Repo handover: none (project has no repoPath)"
+  fi
+  echo
+  echo "  DM that would be sent to $TO:"
+  echo "    \"Project handoff: $PROJECT is yours now — open details for the brief, paste the prompt into your agent to pick it up\""
+  echo "    (prompt: generated pickup prompt; details: the delegation brief)"
+  exit 0
+fi
+
+# =============================================================================
+# Probe mode: reachability of every granted prefix
+# =============================================================================
+
+[ -n "$MANIFEST" ] || die "--manifest is required (or --dry-run with --company/--project/--to)"
+[ -f "$MANIFEST" ] || die "manifest not found: $MANIFEST"
+jq -e . "$MANIFEST" >/dev/null 2>&1 || die "manifest is not valid JSON: $MANIFEST"
+
+COMPANY="$(jq -r '.company // empty' "$MANIFEST")"
+STATUS="$(jq -r '.status // empty' "$MANIFEST")"
+[ -n "$COMPANY" ] || die "manifest has no company"
+
+case "$STATUS" in
+  granted|verified) ;;
+  building) die "manifest status is 'building' — run hq-delegate-grant.sh first (probe verifies grants, it cannot create them)" ;;
+  *) die "manifest status is '$STATUS' — probe runs from 'granted' (or re-runs from 'verified')" ;;
+esac
+
+PREFIX_COUNT="$(jq '.vaultPrefixes | length' "$MANIFEST")"
+[ "$PREFIX_COUNT" -gt 0 ] || die "manifest has no vaultPrefixes to probe"
+
+echo "hq-delegate-verify: probing $PREFIX_COUNT prefix(es) in company '$COMPANY'"
+FAILED=0
+i=0
+while [ "$i" -lt "$PREFIX_COUNT" ]; do
+  PFX="$(jq -r ".vaultPrefixes[$i].prefix" "$MANIFEST")"
+  BROWSE_OUT="$(hq files browse "$PFX" --company "$COMPANY" 2>&1)" && BROWSE_RC=0 || BROWSE_RC=$?
+  if [ "$BROWSE_RC" -ne 0 ]; then
+    echo "  FAIL  $PFX — browse errored (likely cause: the grant did not land, or the caller's session expired — re-run /hq-login and hq-delegate-grant.sh)"
+    FAILED=1
+  elif [ -z "$(printf '%s' "$BROWSE_OUT" | tr -d '[:space:]')" ]; then
+    echo "  FAIL  $PFX — reachable but EMPTY (likely cause: the dossier was never pushed to the vault — hq sync push companies/$COMPANY/... and re-run)"
+    FAILED=1
+  else
+    echo "  pass  $PFX"
+  fi
+  i=$((i + 1))
+done
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "hq-delegate-verify: probe FAILED — the DM must not be sent; fix the failing prefix(es) above and re-run (manifest status left at '$STATUS')" >&2
+  exit 1
+fi
+
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+TMP_MANIFEST="$(mktemp)"
+jq --arg now "$NOW" '.status = "verified" | .verifiedAt = $now' \
+  "$MANIFEST" > "$TMP_MANIFEST" && mv "$TMP_MANIFEST" "$MANIFEST"
+
+echo "hq-delegate-verify: all $PREFIX_COUNT prefix(es) reachable — manifest status advanced to 'verified'"

--- a/core/scripts/tests/hq-delegate-verify.test.sh
+++ b/core/scripts/tests/hq-delegate-verify.test.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Regression: hq-delegate-verify.sh must prove every granted prefix is
+# reachable before any DM, resume without re-granting, and offer a
+# zero-mutation dry run of the whole delegation plan.
+#
+# Guards:
+#   1. One prefix's browse fails -> exit non-zero, that prefix named with a
+#      likely cause, status stays 'granted', and no dm was ever invoked.
+#   2. All prefixes reachable -> status becomes 'verified' (send gates on
+#      this) with verifiedAt stamped.
+#   3. Re-run after a failed probe issues no `files share` (no re-grant).
+#   4. Empty-but-reachable prefix is a failure (dossier never pushed).
+#   5. --dry-run: prints recipient, mode, prefixes+permissions, secret
+#      names, repo+branch, and the DM headline; invokes no mutating
+#      command; leaves workspace/delegations/ untouched; exits 0.
+#   6. Probe from status 'building' refuses (grants must exist first).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+HELPER="$ROOT/core/scripts/hq-delegate-verify.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$HELPER" ] || fail "missing helper: $HELPER"
+
+# --- stub hq CLI -------------------------------------------------------------
+# HQ_STUB_BROWSE_FAIL: prefix whose browse errors
+# HQ_STUB_BROWSE_EMPTY: prefix whose browse succeeds with empty output
+INVOKE_LOG="$TMP/invocations.log"
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/hq" <<'STUB'
+#!/usr/bin/env bash
+echo "$*" >> "$HQ_STUB_LOG"
+case "$1 $2" in
+  "files browse")
+    if [ "$3" = "${HQ_STUB_BROWSE_FAIL:-}" ]; then
+      echo "403 Forbidden" >&2
+      exit 1
+    fi
+    if [ "$3" = "${HQ_STUB_BROWSE_EMPTY:-}" ]; then
+      exit 0
+    fi
+    echo "prd.json  1.2KB  shared-with-you"
+    exit 0
+    ;;
+  "whoami "*|"whoami ")
+    echo '{"email":"owner@acme.test"}'
+    exit 0
+    ;;
+esac
+exit 0
+STUB
+chmod +x "$TMP/bin/hq"
+export PATH="$TMP/bin:$PATH"
+export HQ_STUB_LOG="$INVOKE_LOG"
+
+# --- fixture -----------------------------------------------------------------
+
+FIX="$TMP/hqroot"
+PROJ="$FIX/companies/acme/projects/widget"
+mkdir -p "$PROJ" "$FIX/workspace/delegations"
+cat > "$PROJ/prd.json" <<'JSON'
+{
+  "name": "widget", "description": "Build the widget.", "branchName": "feature/widget",
+  "metadata": {"goal": "ship", "repoPath": "repos/public/widget-repo", "baseBranch": "main",
+    "knowledge": ["companies/acme/knowledge/insights/notes.md"]},
+  "userStories": [{"id": "US-001", "title": "Frame", "description": "d", "priority": 1, "passes": false}]
+}
+JSON
+cat > "$PROJ/.env.schema" <<'SCHEMA'
+WIDGET_API_KEY=
+SCHEMA
+
+M="$TMP/manifest.json"
+write_manifest() { # status
+  cat > "$M" <<JSON
+{
+  "schemaVersion": 1, "delegationId": "dlg-test-widget", "mode": "transfer",
+  "company": "acme",
+  "to": {"kind": "person", "principal": "alice@acme.test"},
+  "project": {"name": "widget", "prdPath": "companies/acme/projects/widget/prd.json"},
+  "vaultPrefixes": [
+    {"prefix": "projects/widget/", "permission": "write"},
+    {"prefix": "knowledge/insights/", "permission": "read"}
+  ],
+  "status": "$1"
+}
+JSON
+}
+
+# --- 1+3. failing browse: named prefix, no dm, no re-grant, status kept ------
+
+write_manifest granted
+: > "$INVOKE_LOG"
+export HQ_STUB_BROWSE_FAIL="knowledge/insights/"
+set +e
+OUT="$(HQ_ROOT="$FIX" bash "$HELPER" --manifest "$M" 2>&1)"
+RC=$?
+set -e
+[ "$RC" -ne 0 ] || fail "failed probe must exit non-zero"
+printf '%s' "$OUT" | grep -q "FAIL  knowledge/insights/" || fail "output must name the failing prefix: $OUT"
+printf '%s' "$OUT" | grep -qi "likely cause" || fail "output must state a likely cause"
+jq -e '.status == "granted"' "$M" >/dev/null || fail "failed probe must leave status at granted"
+if grep -Eq '^(dm|files share|sync push)' "$INVOKE_LOG"; then
+  fail "probe must never send a dm, share, or push: $(cat "$INVOKE_LOG")"
+fi
+
+# re-run (still failing): still no share/dm — resume never re-grants
+set +e
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$M" >/dev/null 2>&1
+set -e
+if grep -Eq '^(dm|files share)' "$INVOKE_LOG"; then
+  fail "re-run must not issue shares or dms"
+fi
+unset HQ_STUB_BROWSE_FAIL
+
+# --- 4. reachable-but-empty prefix fails -------------------------------------
+
+write_manifest granted
+export HQ_STUB_BROWSE_EMPTY="projects/widget/"
+set +e
+OUT="$(HQ_ROOT="$FIX" bash "$HELPER" --manifest "$M" 2>&1)"
+RC=$?
+set -e
+[ "$RC" -ne 0 ] || fail "empty prefix must fail the probe"
+printf '%s' "$OUT" | grep -q "EMPTY" || fail "empty prefix failure must say so: $OUT"
+unset HQ_STUB_BROWSE_EMPTY
+
+# --- 2. all reachable -> verified --------------------------------------------
+
+write_manifest granted
+: > "$INVOKE_LOG"
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$M" >/dev/null 2>&1 \
+  || fail "healthy probe exited non-zero"
+jq -e '.status == "verified" and .verifiedAt != null' "$M" >/dev/null \
+  || fail "healthy probe must advance status to verified"
+BROWSE_COUNT="$(grep -c '^files browse' "$INVOKE_LOG")"
+[ "$BROWSE_COUNT" -eq 2 ] || fail "expected one browse per prefix (2), got $BROWSE_COUNT"
+
+# --- 6. probe from 'building' refuses ----------------------------------------
+
+write_manifest building
+set +e
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$M" >/dev/null 2>&1
+RC=$?
+set -e
+[ "$RC" -ne 0 ] || fail "probe from 'building' must refuse (grants first)"
+
+# --- 5. dry run: full plan, zero mutation ------------------------------------
+
+: > "$INVOKE_LOG"
+BEFORE="$(find "$FIX/workspace/delegations" -mindepth 1 | sort)"
+OUT="$(HQ_ROOT="$FIX" bash "$HELPER" --dry-run --company acme --project widget --to alice@acme.test 2>/dev/null)" \
+  || fail "dry run must exit 0"
+AFTER="$(find "$FIX/workspace/delegations" -mindepth 1 | sort)"
+[ "$BEFORE" = "$AFTER" ] || fail "dry run must leave workspace/delegations/ untouched"
+if grep -Eq '^(dm|files share|sync push|secrets share)' "$INVOKE_LOG"; then
+  fail "dry run invoked a mutating command: $(cat "$INVOKE_LOG")"
+fi
+for needle in "alice@acme.test" "transfer" "projects/widget/" "knowledge/insights/" \
+  "WIDGET_API_KEY" "feature/widget" "DM that would be sent"; do
+  printf '%s' "$OUT" | grep -qF "$needle" || fail "dry-run plan missing: $needle"
+done
+printf '%s' "$OUT" | grep -q "write" || fail "dry-run plan must show permissions"
+
+echo "hq-delegate-verify: ok (probe gates the DM, named failures with causes, resume without re-grant, empty=fail, dry run fully inert)"


### PR DESCRIPTION
Eighth story of `/delegate` (project: `hq-delegate-command`, indigo). **Stacked on #169 → #160**; base auto-retargets as the stack merges.

## What

`core/scripts/hq-delegate-verify.sh`:

**Probe mode** (`--manifest <path>`) — after grants, before the DM:
- `hq files browse` per manifest prefix; must be reachable **and** non-empty (empty = the dossier was never pushed — that's a failed handoff, not a pass)
- Any failure: non-zero, the failing prefix + likely cause named, DM never sent, status left at its last successful value so re-runs resume without re-granting
- All pass: `granted → verified` — `hq-delegate-send --send` gates on exactly this

**Dry-run mode** (`--dry-run --company --project --to`) — the full plan with zero mutation: recipient, mode, every prefix + permission, secret names, repo + branch, and the DM that would go out. Derivation comes from the bundle builder itself via a new `--dry-run` flag on it (single source — the plan can't drift from what a real run would do). Creates nothing under `workspace/delegations/`.

## Why it matters

This is the story that makes a broken handoff fail in front of the **delegator** instead of silently stranding the recipient — modeled on the verified-probe standard in `/new-agent`.

## Tests

`bash core/scripts/tests/hq-delegate-verify.test.sh` — six guards; stacked-branch regressions (`hq-delegate-bundle`, `hq-delegate-send`) re-run green.

https://claude.ai/code/session_015YaqhyfE5w7L1NHnMiSnTp