### PR TITLE
feat(delegate): the /delegate skill — wired end to end (US-009)

### DIFF
--- a/.claude/skills/delegate/SKILL.md
+++ b/.claude/skills/delegate/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: delegate
+description: Hand a project to a named person or fleet agent in one command — freezes state, grants vault access, hands over the branch and secrets, transfers ownership, and sends a self-sufficient pickup DM. The recipient pastes one prompt and has everything; no /hq-sync run, no follow-up questions.
+allowed-tools: Read, AskUserQuestion, Skill, Bash(hq:*), Bash(bash core/scripts/hq-session.sh:*), Bash(bash core/scripts/hq-delegate-resolve.sh:*), Bash(bash core/scripts/hq-delegate-bundle.sh:*), Bash(bash core/scripts/hq-delegate-grant.sh:*), Bash(bash core/scripts/hq-delegate-repo.sh:*), Bash(bash core/scripts/hq-delegate-secrets.sh:*), Bash(bash core/scripts/hq-delegate-transfer.sh:*), Bash(bash core/scripts/hq-delegate-verify.sh:*), Bash(bash core/scripts/hq-delegate-send.sh:*), Bash(rm:*)
+---
+
+# /delegate — one-command project handoff
+
+Transfer a project to a teammate or fleet agent so completely that they never
+have to ask for anything: the dossier lands in the vault with verified access,
+the branch is on the remote, the secrets they need are granted by name, the
+board and work mesh point at them, and their DM carries a pickup prompt that
+pulls every file on demand.
+
+## Usage
+
+```
+/delegate <recipient> [project] [--share] [--no-secrets] [--dry-run] [--company <slug>]
+```
+
+- `<recipient>` — a teammate's name, email, `prs_…` personUid, or a fleet
+  agent's name or `agt_…` agentUid. Required.
+- `[project]` — the project slug under `companies/<co>/projects/`. Defaults to
+  the session's active project (`bash core/scripts/hq-session.sh get project`).
+- `--share` — grant access and send the brief but keep ownership (board, PRD,
+  work mesh untouched). Default is a full transfer.
+- `--no-secrets` — skip the credential handover entirely.
+- `--dry-run` — print the full plan and change nothing.
+- `--company <slug>` — defaults to the session's bound company
+  (`bash core/scripts/hq-session.sh get company_slug`).
+
+The heavy lifting lives in eight tested helpers; this skill orchestrates them
+and owns the user-facing confirmation. Do not reimplement their logic inline.
+
+## Process
+
+### 1. Resolve context
+
+Company from `--company` or `bash core/scripts/hq-session.sh get company_slug`;
+project from the argument or `bash core/scripts/hq-session.sh get project`.
+If either is still unknown, ask — one structured question, not a guess. Verify
+`companies/<co>/projects/<project>/prd.json` exists; if not, stop and say so
+plainly (a delegation needs a PRD to describe what is being handed over).
+
+### 2. Resolve the recipient — confirm before anything else
+
+```bash
+bash core/scripts/hq-delegate-resolve.sh --company <co> --to "<recipient>"
+```
+
+- **Exit 0** — JSON `{kind, principal, displayName}`. Continue.
+- **Exit 3 (ambiguous)** — the output carries `matches[]`. Present the
+  candidates as a single structured picker (AskUserQuestion; decision-queue
+  pattern, one question). Never guess, never send blind. Re-run nothing —
+  use the chosen principal directly.
+- **Exit 4 (not found / no email)** — STOP. Relay the helper's message: no
+  teammate or fleet agent by that name in this company; the user can pass an
+  exact email, `prs_…`, or `agt_…` instead.
+
+Resolution is single-company and tenancy-safe; never look across companies.
+
+### 3. Dry run (when `--dry-run`)
+
+```bash
+bash core/scripts/hq-delegate-verify.sh --dry-run --company <co> --project <project> --to <principal> [--mode share]
+```
+
+Print the plan verbatim and stop. Nothing is pushed, granted, transferred, or
+sent, and nothing lands under `workspace/delegations/`.
+
+### 4. Freeze session state
+
+Before building the bundle, checkpoint the session so nothing in flight is
+lost to the handoff:
+
+```bash
+hq core checkpoint --summary "Delegating <project> to <displayName>" || true
+```
+
+If checkpointing is unavailable in this runtime, note it and continue — the
+delegation itself does not depend on it.
+
+### 5. Build the bundle
+
+```bash
+bash core/scripts/hq-delegate-bundle.sh build --company <co> --project <project> \
+  --to <principal> --to-kind <kind> --to-name "<displayName>" [--mode share]
+```
+
+Prints the `delegationId`; the manifest is
+`workspace/delegations/<delegationId>/manifest.json`. The builder fails closed
+if its own output matches a secret pattern — if it does, stop and report,
+never work around it.
+
+### 6. Collect the plan (no mutations yet)
+
+Run the three gated helpers WITHOUT `--yes`. Each prints its plan and exits 2;
+none of them touches anything:
+
+```bash
+bash core/scripts/hq-delegate-grant.sh --manifest <manifest>          # vault grants incl. write escalation
+bash core/scripts/hq-delegate-repo.sh --manifest <manifest>           # exit 2 only when a local-only branch needs pushing
+bash core/scripts/hq-delegate-secrets.sh --manifest <manifest>        # secret NAMES that would be granted (skip when --no-secrets)
+```
+
+### 7. The one confirmation
+
+Present exactly one structured confirmation (AskUserQuestion) before any
+mutation, in full prose — no shorthand here. It must name:
+
+- the recipient as resolved: display name + principal, and whether they are a
+  person or a fleet agent
+- the mode: full ownership transfer, or share (ownership stays)
+- every vault prefix with its permission — stating plainly that **write** lets
+  the recipient upload, overwrite, and delete under the project prefix, and
+  that access persists until manually revoked
+- every secret name that will be granted (read) — values never move, the
+  recipient consumes them via `hq run` / `hq secrets exec`
+- the repo and branch, including "the branch exists only locally and will be
+  pushed" when the repo helper said so
+- that a DM will be sent to the recipient when everything verifies
+
+Offer **Proceed** / **Proceed without secrets** / **Cancel**. On cancel:
+delete `workspace/delegations/<delegationId>/`, confirm nothing was granted,
+transferred, or sent, and stop. This single gate carries the write-grant and
+secret-handover confirmations — the helpers are then invoked with `--yes`.
+
+### 8. Execute, in order, stopping at the first failure
+
+```bash
+bash core/scripts/hq-delegate-grant.sh --manifest <manifest> --yes
+bash core/scripts/hq-delegate-repo.sh --manifest <manifest> --yes        # when the project has a repo
+bash core/scripts/hq-delegate-secrets.sh --manifest <manifest> --yes     # or --no-secrets
+bash core/scripts/hq-delegate-transfer.sh --manifest <manifest>          # skipped automatically in share mode
+bash core/scripts/hq-delegate-verify.sh --manifest <manifest>            # reachability probe — gates the send
+```
+
+If any step fails: report **which step** in plain language with the specific
+fix from its stderr, send nothing, and never claim partial success. The
+manifest keeps its last successful status, so re-running `/delegate` for the
+same project resumes instead of re-granting.
+
+### 9. Send
+
+Draft the DM headline, then run the channel-aware humanize pass on it per
+`core/knowledge/public/hq-core/humanize-before-send.md` (channel `dm`,
+intensity `light`) — plain and factual, no hype. Never rewrite the generated
+command lines, recipients, or flags. Then:
+
+```bash
+bash core/scripts/hq-delegate-send.sh --manifest <manifest> --send --headline "<humanized headline>"
+```
+
+One DM, prompt and brief attached from files. The helper refuses to send
+unless the probe passed.
+
+### 10. Report
+
+One plain sentence naming the recipient and what they now have — no step log,
+no jargon. Example:
+
+> Done — Alice owns the widget project now. Her DM has the brief and a prompt
+> that pulls everything she needs; nothing for her to ask for.
+
+## Rules
+
+1. **Never mint or embed a share-session URL.** Delegation uses direct ACL
+   grants only (policy `hq-delegate-never-inlines-secrets-or-share-urls`).
+   If a step suggests the browser share flow, that is the wrong path.
+2. **Never let a secret value into any artifact, DM, or output.** Names only;
+   the helpers fail closed on secret-shaped content — respect the failure,
+   never work around it.
+3. **Confirm before granting, once.** Exactly one structured confirmation
+   covers write grants, secret names, branch push, and the DM. Decline means
+   nothing mutates.
+4. **Never send blind.** The recipient must come from
+   `hq-delegate-resolve.sh` output or be an exact principal the user typed.
+   On ambiguity, use the picker; on not-found, stop.
+5. **A failed probe means no DM.** A delegation that cannot be picked up
+   fails in front of the delegator — that is the feature working, not a step
+   to skip.
+6. **Tenancy.** Everything is scoped to one company. Cross-company delegation
+   is out of scope and must be refused plainly.
+
+## See also
+
+- `/handoff` — session-state freeze without an ownership change
+- `/dm` — the delivery channel this skill sends through
+- `/hq-share` — one-off vault path shares (link or single grant)
+- `/new-agent` — provisioning a fleet agent (the verified-probe pattern this
+  skill's verification step follows)
+- `core/knowledge/public/hq-core/delegation-bundle-spec.md` — the manifest
+  contract every helper reads

--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,5 +1,5 @@
 version: 1
-hqVersion: "15.0.89"
+hqVersion: "15.0.90"
 agentSessionContractVersion: 1
 # Provider adapter contract version (US-500). Must match
 # HQ_ADAPTER_CONTRACT_VERSION in core/scripts/lib/provider-adapter-version.sh.

--- a/core/scripts/tests/hq-delegate-skill.test.sh
+++ b/core/scripts/tests/hq-delegate-skill.test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Regression: the /delegate skill must wire the eight tested helpers into a
+# single confirmed flow — structural contract on SKILL.md, plus the shipped
+# helper scripts it references must exist and be runnable.
+#
+# Guards:
+#   1. Skill exists with scoped frontmatter (name, description,
+#      allowed-tools including AskUserQuestion for the confirm/picker).
+#   2. Every hq-delegate-*.sh helper is referenced AND exists on disk.
+#   3. Ambiguous resolution (exit 3) is handled with a structured picker;
+#      not-found stops; never sends blind.
+#   4. Exactly-one-confirmation contract: the gated helpers are first run
+#      WITHOUT --yes (plan mode), and the confirmation section precedes
+#      execution with --yes.
+#   5. Decline path: cancel deletes the bundle and mutates nothing.
+#   6. Failure path: report the failing step, never claim partial success;
+#      probe failure means no DM.
+#   7. Dry-run documented as fully inert.
+#   8. Humanize pass wired for the DM headline; success report is one plain
+#      sentence.
+#   9. Both hard policies are stated: no share-session URLs, no secret
+#      values.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SKILL="$ROOT/.claude/skills/delegate/SKILL.md"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$SKILL" ] || fail "missing delegate skill: $SKILL"
+
+# 1. frontmatter
+grep -q '^name: delegate$' "$SKILL" || fail "frontmatter must declare name: delegate"
+grep -q '^description: ' "$SKILL" || fail "frontmatter must carry a description"
+grep -q '^allowed-tools: .*AskUserQuestion' "$SKILL" \
+  || fail "allowed-tools must include AskUserQuestion (picker + confirmation)"
+
+# 2. every helper referenced and shipped
+for helper in hq-delegate-resolve hq-delegate-bundle hq-delegate-grant \
+  hq-delegate-repo hq-delegate-secrets hq-delegate-transfer \
+  hq-delegate-verify hq-delegate-send; do
+  grep -q "core/scripts/$helper.sh" "$SKILL" \
+    || fail "skill must reference core/scripts/$helper.sh"
+  [ -f "$ROOT/core/scripts/$helper.sh" ] \
+    || fail "referenced helper missing from tree: core/scripts/$helper.sh"
+  bash -n "$ROOT/core/scripts/$helper.sh" \
+    || fail "helper does not parse: core/scripts/$helper.sh"
+done
+
+# 3. resolution outcomes
+grep -q 'Exit 3' "$SKILL" || fail "skill must handle the ambiguous (exit 3) outcome"
+grep -q 'Exit 4' "$SKILL" || fail "skill must handle the not-found (exit 4) outcome"
+grep -qi 'never send blind' "$SKILL" || fail "skill must state it never sends blind"
+grep -qi 'single-company' "$SKILL" || fail "skill must state resolution is single-company"
+
+# 4. one-confirmation contract: plan (no --yes) before the gate, --yes after
+grep -q 'WITHOUT `--yes`' "$SKILL" || fail "plan collection must run helpers without --yes"
+grep -qi 'exactly one structured confirmation\|one structured confirmation (AskUserQuestion) before any mutation' "$SKILL" \
+  || fail "skill must promise exactly one confirmation before mutation"
+# ordering: the "collect the plan" section must appear before "--yes" execution
+PLAN_LINE="$(grep -n 'Collect the plan' "$SKILL" | head -1 | cut -d: -f1)"
+EXEC_LINE="$(grep -n -- '--manifest <manifest> --yes' "$SKILL" | head -1 | cut -d: -f1)"
+[ -n "$PLAN_LINE" ] && [ -n "$EXEC_LINE" ] && [ "$PLAN_LINE" -lt "$EXEC_LINE" ] \
+  || fail "plan collection must precede --yes execution"
+
+# 5. decline path
+grep -qi 'On cancel' "$SKILL" || fail "skill must document the cancel path"
+grep -q 'delete `workspace/delegations/' "$SKILL" \
+  || fail "cancel must delete the bundle"
+grep -qi 'confirm nothing was granted' "$SKILL" \
+  || fail "cancel must confirm nothing mutated"
+
+# 6. failure semantics
+grep -qi 'never claim partial success' "$SKILL" || fail "skill must never claim partial success"
+grep -qi 'failed probe means no DM' "$SKILL" || fail "probe failure must block the DM"
+grep -qi 'resumes instead of re-granting' "$SKILL" || fail "re-run must resume, not re-grant"
+
+# 7. dry run inert
+grep -q -- '--dry-run' "$SKILL" || fail "skill must document --dry-run"
+grep -qi 'Nothing is pushed, granted' "$SKILL" \
+  || fail "dry run must be documented as fully inert"
+
+# 8. humanize + plain report
+grep -q 'humanize-before-send.md' "$SKILL" || fail "DM headline must go through the humanize pass"
+grep -qi 'One plain sentence' "$SKILL" || fail "success report must be one plain sentence"
+
+# 9. hard policies
+grep -q 'share-session' "$SKILL" || fail "skill must forbid share-session URLs"
+grep -q 'hq-delegate-never-inlines-secrets-or-share-urls' "$SKILL" \
+  || fail "skill must cite the delegation policy"
+grep -qi 'Names only' "$SKILL" || fail "skill must state secret values never move"
+
+echo "hq-delegate-skill: ok (frontmatter scoped, all 8 helpers shipped+referenced, picker/stop resolution, single confirm gate, inert dry-run, fail-closed semantics)"


### PR DESCRIPTION
Ninth story of `/delegate` (project: `hq-delegate-command`, indigo). **Integration branch**: stacked on #170 and merges the sibling helpers (#161, #163, #164, #165, #167) so the skill and every gate run against the complete set. Diff shrinks to just the skill as siblings land.

## What

`.claude/skills/delegate/SKILL.md` — `/delegate <recipient> [project] [--share] [--no-secrets] [--dry-run] [--company <slug>]`

The flow: resolve recipient (structured picker on ambiguity, hard stop on not-found) → checkpoint session state → build bundle → collect every gated helper's plan **without** `--yes` → **exactly one structured confirmation** (recipient, mode, every prefix+permission with the write escalation spelled out, secret names, branch push, the DM) → execute grant → repo → secrets → transfer → verify probe → send, stopping at the first failure.

## Contracts held

- Narrow per-command `allowed-tools` — passes the permission validator's concrete-command coverage (bare `Bash` is rejected by it)
- Cancel deletes the bundle and confirms nothing was granted, transferred, or sent
- Failed probe = no DM; re-runs resume from the manifest's last successful status
- Success report is one plain sentence

## Gates (all green)

- `core/scripts/tests/hq-delegate-skill.test.sh` (new, structural)
- `agent-runtime-permissions.test.sh` · `agent-runtime-skill-metadata.test.sh` · `skill-script-refs.test.sh`

https://claude.ai/code/session_015YaqhyfE5w7L1NHnMiSnTp