### PR TITLE
feat(delegate): /delegate — one-command project handoff (US-001..US-010, v15.0.91)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -28,6 +28,9 @@ scaffolds, supervises, and syncs work across repos and companies.
 - Provision teammates and agents: `/new-hire` for people, `/new-agent` for
   fleet agents (identity → membership → vault → grants → verified probe).
 - Direct messages and reminders: `/dm` or `hq dm`.
+- Hand a project to a person or fleet agent: `/delegate` (verified vault
+  grants, branch + secrets handover, ownership transfer, self-pulling
+  pickup DM — never hand-roll this flow from share/dm primitives).
 - Identity: `/hq-login`, `/hq-logout`, `/hq-whoami`.
 - Bugs and feature requests: `/hq-bug`.
 - Coordinate active project work: `bash core/scripts/work-mesh.sh check|start|progress|blocked|done --company {co} --project {project}`. On cloud-connected HQ installs this writes through the hq-pro Work Mesh API and fans out over MQTT/IoT; on local/offline installs it silently no-ops. Local HQ instances that need live awareness can run `bash core/scripts/work-mesh.sh watch` to subscribe to authorized MQTT topics and maintain `workspace/work-mesh/live-cache.json`; thread writes still go through the helper's project verbs, not direct MQTT publish.

--- a/.claude/skills/delegate/SKILL.md
+++ b/.claude/skills/delegate/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: delegate
+description: Hand a project to a named person or fleet agent in one command — freezes state, grants vault access, hands over the branch and secrets, transfers ownership, and sends a self-sufficient pickup DM. The recipient pastes one prompt and has everything; no /hq-sync run, no follow-up questions.
+allowed-tools: Read, AskUserQuestion, Skill, Bash(hq:*), Bash(bash core/scripts/hq-session.sh:*), Bash(bash core/scripts/hq-delegate-resolve.sh:*), Bash(bash core/scripts/hq-delegate-bundle.sh:*), Bash(bash core/scripts/hq-delegate-grant.sh:*), Bash(bash core/scripts/hq-delegate-repo.sh:*), Bash(bash core/scripts/hq-delegate-secrets.sh:*), Bash(bash core/scripts/hq-delegate-transfer.sh:*), Bash(bash core/scripts/hq-delegate-verify.sh:*), Bash(bash core/scripts/hq-delegate-send.sh:*), Bash(rm:*)
+---
+
+# /delegate — one-command project handoff
+
+Transfer a project to a teammate or fleet agent so completely that they never
+have to ask for anything: the dossier lands in the vault with verified access,
+the branch is on the remote, the secrets they need are granted by name, the
+board and work mesh point at them, and their DM carries a pickup prompt that
+pulls every file on demand.
+
+## Usage
+
+```
+/delegate <recipient> [project] [--share] [--no-secrets] [--dry-run] [--company <slug>]
+```
+
+- `<recipient>` — a teammate's name, email, `prs_…` personUid, or a fleet
+  agent's name or `agt_…` agentUid. Required.
+- `[project]` — the project slug under `companies/<co>/projects/`. Defaults to
+  the session's active project (`bash core/scripts/hq-session.sh get project`).
+- `--share` — grant access and send the brief but keep ownership (board, PRD,
+  work mesh untouched). Default is a full transfer.
+- `--no-secrets` — skip the credential handover entirely.
+- `--dry-run` — print the full plan and change nothing.
+- `--company <slug>` — defaults to the session's bound company
+  (`bash core/scripts/hq-session.sh get company_slug`).
+
+The heavy lifting lives in eight tested helpers; this skill orchestrates them
+and owns the user-facing confirmation. Do not reimplement their logic inline.
+
+## Process
+
+### 1. Resolve context
+
+Company from `--company` or `bash core/scripts/hq-session.sh get company_slug`;
+project from the argument or `bash core/scripts/hq-session.sh get project`.
+If either is still unknown, ask — one structured question, not a guess. Verify
+`companies/<co>/projects/<project>/prd.json` exists; if not, stop and say so
+plainly (a delegation needs a PRD to describe what is being handed over).
+
+### 2. Resolve the recipient — confirm before anything else
+
+```bash
+bash core/scripts/hq-delegate-resolve.sh --company <co> --to "<recipient>"
+```
+
+- **Exit 0** — JSON `{kind, principal, displayName}`. Continue.
+- **Exit 3 (ambiguous)** — the output carries `matches[]`. Present the
+  candidates as a single structured picker (AskUserQuestion; decision-queue
+  pattern, one question). Never guess, never send blind. Re-run nothing —
+  use the chosen principal directly.
+- **Exit 4 (not found / no email)** — STOP. Relay the helper's message: no
+  teammate or fleet agent by that name in this company; the user can pass an
+  exact email, `prs_…`, or `agt_…` instead.
+
+Resolution is single-company and tenancy-safe; never look across companies.
+
+### 3. Dry run (when `--dry-run`)
+
+```bash
+bash core/scripts/hq-delegate-verify.sh --dry-run --company <co> --project <project> --to <principal> [--mode share]
+```
+
+Print the plan verbatim and stop. Nothing is pushed, granted, transferred, or
+sent, and nothing lands under `workspace/delegations/`.
+
+### 4. Freeze session state
+
+Before building the bundle, checkpoint the session so nothing in flight is
+lost to the handoff:
+
+```bash
+hq core checkpoint --summary "Delegating <project> to <displayName>" || true
+```
+
+If checkpointing is unavailable in this runtime, note it and continue — the
+delegation itself does not depend on it.
+
+### 5. Build the bundle
+
+```bash
+bash core/scripts/hq-delegate-bundle.sh build --company <co> --project <project> \
+  --to <principal> --to-kind <kind> --to-name "<displayName>" [--mode share]
+```
+
+Prints the `delegationId`; the manifest is
+`workspace/delegations/<delegationId>/manifest.json`. The builder fails closed
+if its own output matches a secret pattern — if it does, stop and report,
+never work around it.
+
+### 6. Collect the plan (no mutations yet)
+
+Run the three gated helpers WITHOUT `--yes`. Each prints its plan and exits 2;
+none of them touches anything:
+
+```bash
+bash core/scripts/hq-delegate-grant.sh --manifest <manifest>          # vault grants incl. write escalation
+bash core/scripts/hq-delegate-repo.sh --manifest <manifest>           # exit 2 only when a local-only branch needs pushing
+bash core/scripts/hq-delegate-secrets.sh --manifest <manifest>        # secret NAMES that would be granted (skip when --no-secrets)
+```
+
+### 7. The one confirmation
+
+Present exactly one structured confirmation (AskUserQuestion) before any
+mutation, in full prose — no shorthand here. It must name:
+
+- the recipient as resolved: display name + principal, and whether they are a
+  person or a fleet agent
+- the mode: full ownership transfer, or share (ownership stays)
+- every vault prefix with its permission — stating plainly that **write** lets
+  the recipient upload, overwrite, and delete under the project prefix, and
+  that access persists until manually revoked
+- every secret name that will be granted (read) — values never move, the
+  recipient consumes them via `hq run` / `hq secrets exec`
+- the repo and branch, including "the branch exists only locally and will be
+  pushed" when the repo helper said so
+- that a DM will be sent to the recipient when everything verifies
+
+Offer **Proceed** / **Proceed without secrets** / **Cancel**. On cancel:
+delete `workspace/delegations/<delegationId>/`, confirm nothing was granted,
+transferred, or sent, and stop. This single gate carries the write-grant and
+secret-handover confirmations — the helpers are then invoked with `--yes`.
+
+### 8. Execute, in order, stopping at the first failure
+
+```bash
+bash core/scripts/hq-delegate-grant.sh --manifest <manifest> --yes
+bash core/scripts/hq-delegate-repo.sh --manifest <manifest> --yes        # when the project has a repo
+bash core/scripts/hq-delegate-secrets.sh --manifest <manifest> --yes     # or --no-secrets
+bash core/scripts/hq-delegate-transfer.sh --manifest <manifest>          # skipped automatically in share mode
+bash core/scripts/hq-delegate-verify.sh --manifest <manifest>            # reachability probe — gates the send
+```
+
+If any step fails: report **which step** in plain language with the specific
+fix from its stderr, send nothing, and never claim partial success. The
+manifest keeps its last successful status, so re-running `/delegate` for the
+same project resumes instead of re-granting.
+
+### 9. Send
+
+Draft the DM headline, then run the channel-aware humanize pass on it per
+`core/knowledge/public/hq-core/humanize-before-send.md` (channel `dm`,
+intensity `light`) — plain and factual, no hype. Never rewrite the generated
+command lines, recipients, or flags. Then:
+
+```bash
+bash core/scripts/hq-delegate-send.sh --manifest <manifest> --send --headline "<humanized headline>"
+```
+
+One DM, prompt and brief attached from files. The helper refuses to send
+unless the probe passed.
+
+### 10. Report
+
+One plain sentence naming the recipient and what they now have — no step log,
+no jargon. Example:
+
+> Done — Alice owns the widget project now. Her DM has the brief and a prompt
+> that pulls everything she needs; nothing for her to ask for.
+
+## Rules
+
+1. **Never mint or embed a share-session URL.** Delegation uses direct ACL
+   grants only (policy `hq-delegate-never-inlines-secrets-or-share-urls`).
+   If a step suggests the browser share flow, that is the wrong path.
+2. **Never let a secret value into any artifact, DM, or output.** Names only;
+   the helpers fail closed on secret-shaped content — respect the failure,
+   never work around it.
+3. **Confirm before granting, once.** Exactly one structured confirmation
+   covers write grants, secret names, branch push, and the DM. Decline means
+   nothing mutates.
+4. **Never send blind.** The recipient must come from
+   `hq-delegate-resolve.sh` output or be an exact principal the user typed.
+   On ambiguity, use the picker; on not-found, stop.
+5. **A failed probe means no DM.** A delegation that cannot be picked up
+   fails in front of the delegator — that is the feature working, not a step
+   to skip.
+6. **Tenancy.** Everything is scoped to one company. Cross-company delegation
+   is out of scope and must be refused plainly.
+
+## See also
+
+- `/handoff` — session-state freeze without an ownership change
+- `/dm` — the delivery channel this skill sends through
+- `/hq-share` — one-off vault path shares (link or single grant)
+- `/new-agent` — provisioning a fleet agent (the verified-probe pattern this
+  skill's verification step follows)
+- `core/knowledge/public/hq-core/delegation-bundle-spec.md` — the manifest
+  contract every helper reads

--- a/.claude/skills/dm/SKILL.md
+++ b/.claude/skills/dm/SKILL.md
@@ -223,5 +223,6 @@ rules as send) — the read path only accepts email / personUid / agentUid.
 ## See also
 
 - `/hq-share` — share a vault path in your message
+- `/delegate` — a DM alone doesn't transfer work; use this to hand a whole project over (access, branch, secrets, ownership, and the pickup prompt in one flow)
 - `/signals` — see action items and commitments
 - `hq channels` — list named channels / group DM ids for `hq dm channel`

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -250,3 +250,4 @@ Fresh context = no accumulated noise, clean slate for complex tasks, follows Ral
 - `/resumework {thread_id}` — resume THIS thread exactly in a fresh session (takes the thread id this skill prints)
 - `/startwork` — the follow-up agent resumes the latest handoff, or picks a new company/project/repo
 - `/checkpoint` — a lighter mid-session save
+- `/delegate` — hand the project to ANOTHER person or fleet agent (ownership transfer + verified access + pickup DM), rather than to your own next session

--- a/.claude/skills/hq-share/SKILL.md
+++ b/.claude/skills/hq-share/SKILL.md
@@ -360,3 +360,4 @@ artifact — in those contexts use the redacted form
 
 - `/hq-files` — inspect or change the underlying ACLs
 - `/dm` — notify the recipient with the link
+- `/delegate` — handing over a whole project? Use this instead of composing shares by hand: it grants, verifies, transfers ownership, and sends the pickup DM in one confirmed flow (direct grants only — no share-session URLs)

--- a/.claude/skills/new-agent/SKILL.md
+++ b/.claude/skills/new-agent/SKILL.md
@@ -241,3 +241,4 @@ Done when: agent confirms probe checklist in {channel}.
 - `/designate-team` — make a company cloud-backed (prerequisite for layer 3)
 - `/accept` — how the agent's runtime claims a pending membership
 - `/hq-secrets`, `/hq-files` — the underlying grant primitives
+- `/delegate` — hand an existing project to a provisioned agent (or person): verified access, branch + secrets handover, ownership transfer, and a self-sufficient pickup DM

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -154,6 +154,39 @@ jobs:
       - name: /resumework requires explicit confirmation for locked threads
         run: bash core/scripts/tests/resume-thread-lock.test.sh
 
+  hq-delegate:
+    # /delegate — one-command project handoff. Every helper ships with an
+    # offline regression test (stubbed hq CLI / real git fixtures). The two
+    # hard rules (no secret values, no share-session URLs in any delegation
+    # artifact) are enforced by these tests, not reviewer vigilance. Policy:
+    # core/policies/hq-delegate-never-inlines-secrets-or-share-urls.md
+    name: hq-delegate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Bundle builder (schema, prefix conventions, fail-closed secret scan)
+        run: bash core/scripts/tests/hq-delegate-bundle.test.sh
+      - name: Recipient resolution (person/agent, tenancy-safe)
+        run: bash core/scripts/tests/hq-delegate-resolve.test.sh
+      - name: Vault grants (direct-only, verified read-back)
+        run: bash core/scripts/tests/hq-delegate-grant.test.sh
+      - name: Repo/branch handover (anchored push, dirty work surfaced)
+        run: bash core/scripts/tests/hq-delegate-repo.test.sh
+      - name: Secrets by name only (sentinel no-value-leak)
+        run: bash core/scripts/tests/hq-delegate-secrets.test.sh
+      - name: Ownership transfer (board/PRD/mesh/journal, idempotent)
+        run: bash core/scripts/tests/hq-delegate-transfer.test.sh
+      - name: Pickup prompt + single-DM delivery (verify-gated)
+        run: bash core/scripts/tests/hq-delegate-send.test.sh
+      - name: Reachability probe + inert dry run
+        run: bash core/scripts/tests/hq-delegate-verify.test.sh
+      - name: /delegate skill structural contract
+        run: bash core/scripts/tests/hq-delegate-skill.test.sh
+      - name: /delegate script references resolve
+        run: bash core/scripts/lint-skill-script-refs.sh delegate
+
   install-deps:
     # DEV-1727: HQ's install/setup surface must not install or dependency-check
     # a third-party CLI that HQ itself never calls. The /setup wizard used to

--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,5 +1,5 @@
 version: 1
-hqVersion: "15.0.84"
+hqVersion: "15.0.85"
 agentSessionContractVersion: 1
 # Provider adapter contract version (US-500). Must match
 # HQ_ADAPTER_CONTRACT_VERSION in core/scripts/lib/provider-adapter-version.sh.

--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,5 +1,5 @@
 version: 1
-hqVersion: "15.0.83"
+hqVersion: "15.0.84"
 agentSessionContractVersion: 1
 # Provider adapter contract version (US-500). Must match
 # HQ_ADAPTER_CONTRACT_VERSION in core/scripts/lib/provider-adapter-version.sh.

--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,5 +1,5 @@
 version: 1
-hqVersion: "15.0.88"
+hqVersion: "15.0.89"
 agentSessionContractVersion: 1
 # Provider adapter contract version (US-500). Must match
 # HQ_ADAPTER_CONTRACT_VERSION in core/scripts/lib/provider-adapter-version.sh.

--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,5 +1,5 @@
 version: 1
-hqVersion: "15.0.85"
+hqVersion: "15.0.86"
 agentSessionContractVersion: 1
 # Provider adapter contract version (US-500). Must match
 # HQ_ADAPTER_CONTRACT_VERSION in core/scripts/lib/provider-adapter-version.sh.

--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,5 +1,5 @@
 version: 1
-hqVersion: "15.0.86"
+hqVersion: "15.0.87"
 agentSessionContractVersion: 1
 # Provider adapter contract version (US-500). Must match
 # HQ_ADAPTER_CONTRACT_VERSION in core/scripts/lib/provider-adapter-version.sh.

--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,5 +1,5 @@
 version: 1
-hqVersion: "15.0.89"
+hqVersion: "15.0.90"
 agentSessionContractVersion: 1
 # Provider adapter contract version (US-500). Must match
 # HQ_ADAPTER_CONTRACT_VERSION in core/scripts/lib/provider-adapter-version.sh.

--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,5 +1,5 @@
 version: 1
-hqVersion: "15.0.90"
+hqVersion: "15.0.91"
 agentSessionContractVersion: 1
 # Provider adapter contract version (US-500). Must match
 # HQ_ADAPTER_CONTRACT_VERSION in core/scripts/lib/provider-adapter-version.sh.

--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,5 +1,5 @@
 version: 1
-hqVersion: "15.0.82"
+hqVersion: "15.0.83"
 agentSessionContractVersion: 1
 # Provider adapter contract version (US-500). Must match
 # HQ_ADAPTER_CONTRACT_VERSION in core/scripts/lib/provider-adapter-version.sh.

--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,5 +1,5 @@
 version: 1
-hqVersion: "15.0.81"
+hqVersion: "15.0.82"
 agentSessionContractVersion: 1
 # Provider adapter contract version (US-500). Must match
 # HQ_ADAPTER_CONTRACT_VERSION in core/scripts/lib/provider-adapter-version.sh.

--- a/core/core.yaml
+++ b/core/core.yaml
@@ -1,5 +1,5 @@
 version: 1
-hqVersion: "15.0.87"
+hqVersion: "15.0.88"
 agentSessionContractVersion: 1
 # Provider adapter contract version (US-500). Must match
 # HQ_ADAPTER_CONTRACT_VERSION in core/scripts/lib/provider-adapter-version.sh.

--- a/core/docs/hq/USER-GUIDE.md
+++ b/core/docs/hq/USER-GUIDE.md
@@ -22,6 +22,7 @@ If a skill is skipped as invalid YAML or a hook reports a launch failure, use th
 | `/startwork` | Pick company/project/repo, gather context |
 | `/checkpoint` | Save progress to `workspace/checkpoints/` |
 | `/handoff` | Prepare handoff for fresh session |
+| `/delegate <recipient> [project]` | Transfer a project to a teammate or fleet agent — verified vault access, branch push, secrets by name, board + work-mesh reassignment, and a DM whose prompt pulls every file on demand (no `/hq-sync` on their side). `--share` grants access without transferring ownership; `--dry-run` prints the plan and touches nothing |
 | `/recover-session` | Recover dead sessions that hit context limits |
 | `/learn` | Auto-capture learnings from task execution |
 

--- a/core/knowledge/public/hq-core/delegation-bundle-spec.md
+++ b/core/knowledge/public/hq-core/delegation-bundle-spec.md
@@ -1,0 +1,100 @@
+# Delegation bundle — manifest.json v1 schema
+
+A **delegation bundle** is the portable, self-describing artifact `/delegate`
+builds when a project is handed from one principal to another. It lives at
+`workspace/delegations/<delegationId>/` and contains:
+
+- `manifest.json` — the machine-readable contract described here
+- `BRIEF.md` — full-prose orientation for a reader who has never seen the
+  project
+- `PICKUP-PROMPT.md` — generated later (US-007) from the manifest; the
+  self-sufficient prompt delivered by DM
+
+The manifest is the **single source of truth** for the whole delegation: the
+grant step, the verification probe, and the pickup prompt are all generated
+from it. Nothing downstream may invent a path, prefix, or secret name that is
+not in the manifest, and nothing in the manifest may be silently skipped.
+
+Builder: `core/scripts/hq-delegate-bundle.sh build --company <slug>
+--project <name> --to <principal> [--to-kind person|agent] [--to-name <name>]
+[--mode transfer|share]`. Prints the `delegationId` on stdout.
+
+## Top-level fields
+
+| Field | Type | Meaning |
+|---|---|---|
+| `schemaVersion` | number | Always `1` for this spec. |
+| `delegationId` | string | `dlg-<UTCstamp>-<project>` — also the bundle directory name. |
+| `createdAt` | string | ISO-8601 UTC creation time. |
+| `mode` | `"transfer"` \| `"share"` | `transfer` reassigns ownership (board, PRD, work mesh); `share` grants access but leaves ownership with the delegator. |
+| `from` | object | `{email, personUid}` of the delegator — resolved from `hq whoami` when available, else `null`s (filled before send). |
+| `to` | object | `{kind, principal, displayName}` — `kind` is `person` or `agent`; `principal` is a **confirmed** email, `prs_…`, or `agt_…` (resolved by `hq-delegate-resolve.sh`, never a guessed name). |
+| `company` | string | Company slug. Delegation never crosses a company boundary. |
+| `project` | object | `{name, prdPath, boardId}` — `prdPath` is HQ-root-relative; `boardId` is the `companies/<co>/board.json` project id or `null`. |
+| `vaultPrefixes` | array | What gets granted — see below. |
+| `repo` | object \| `null` | Code handover state — see below. `null` when the project has no `metadata.repoPath`. |
+| `secrets` | array | Secret **names** (never values) the recipient is granted — filled by the US-005 step; `[]` until then, `{skipped: true}` recorded when `--no-secrets`. |
+| `knowledge` | array | HQ-root-relative knowledge paths referenced by the PRD (for the brief and pickup prompt). |
+| `policies` | array | HQ-root-relative policy paths referenced by the PRD. |
+| `checksums` | object | `{<HQ-root-relative path>: <sha256>}` for every file in the project dossier at freeze time (capped at 200 files). Lets the recipient verify integrity after pulling. |
+| `status` | string | Delegation state machine — see below. |
+
+## `vaultPrefixes[]` entries
+
+```json
+{ "prefix": "projects/hq-delegate-command/", "permission": "write", "reason": "project dossier" }
+```
+
+- `prefix` — **bucket-relative** (never prefixed with `companies/<slug>/`) and
+  **always trailing-slash folder form**, per the hq-files prefix conventions. A
+  bare prefix would degrade to a single literal key and grant nothing useful;
+  the builder hard-fails rather than emit one.
+- `permission` — `write` on the project dossier, `read` on referenced
+  knowledge/policy folders. Individual knowledge *files* are mapped to their
+  containing folder.
+- `reason` — human-readable justification, surfaced in the confirmation step.
+
+After the grant step verifies a prefix via ACL read-back, it may annotate the
+entry with `verifiedAt` and the confirmed permission.
+
+## `repo` block
+
+```json
+{ "path": "repos/public/hq-core", "remote": "git@github.com:org/repo.git",
+  "branch": "feature/x", "baseBranch": "main", "headSha": "abc123…",
+  "dirtyFiles": [], "accessVerified": false }
+```
+
+The builder records `path`, `branch`, and `baseBranch` from the PRD; the
+US-004 handover step fills `remote` and `headSha`, lists uncommitted work in
+`dirtyFiles[]` (called out in the brief as **not transferred**), and sets
+`accessVerified` after a read-only `gh` access check. Repo paths never appear
+in `vaultPrefixes[]` and repo content is never pushed to the vault.
+
+## `status` state machine
+
+```
+building → granted → verified → sent
+```
+
+- `building` — bundle written, nothing granted yet.
+- `granted` — vault ACL grants written and read back successfully (US-003).
+- `verified` — every prefix probed reachable via `hq files browse` (US-008).
+- `sent` — DM delivered; manifest records the DM `eventId`.
+
+A failed step leaves the last successful status, so a re-run resumes instead
+of repeating grants. `--dry-run` never creates a bundle at all.
+
+## Hard safety rules
+
+Two rules apply to every artifact in the bundle and everything generated from
+it (policy `hq-delegate-never-inlines-secrets-or-share-urls`):
+
+1. **No secret value, ever.** Secrets appear by *name* only and are consumed
+   through `hq run` / `hq secrets exec`. The builder scans its own manifest and
+   brief against the shared secret patterns
+   (`core/scripts/lib/secret-patterns.sh`, mirroring
+   `.claude/hooks/detect-secrets.sh`) and fails closed on any match.
+2. **No share-session URLs.** Delegation uses direct ACL grants only. A
+   share-session URL is a live capability token and must never be minted or
+   embedded by any delegation step.

--- a/core/knowledge/public/hq-core/quick-reference.md
+++ b/core/knowledge/public/hq-core/quick-reference.md
@@ -108,6 +108,7 @@ garden-scout, garden-auditor, garden-curator
 ## Commands (44)
 
 **Session:** `/startwork`, `/reanchor`, `/checkpoint`, `/handoff`, `/recover-session`, `/remember`, `/learn`
+**Handoff:** `/delegate <recipient> [project]` — transfer a project to a person or fleet agent: vault grants (verified), branch push, secrets by name, board + work-mesh reassignment, and a self-pulling pickup DM (no `/hq-sync` needed on their side). Skill: `.claude/skills/delegate/SKILL.md`; manifest spec: `core/knowledge/public/hq-core/delegation-bundle-spec.md`.
 **Workers:** `/run`, `/newworker`
 **Projects:** `/plan`, `/run-project`, `/execute-task`, `/understand-project`, `/idea`, `/goals`, `/dashboard`, `/tdd`, `/quality-gate`
 **Content:** `/contentidea`, `/suggestposts`, `/preview-post`, `/post`, `/post-results`, `/social-setup`

--- a/core/policies/hq-delegate-never-inlines-secrets-or-share-urls.md
+++ b/core/policies/hq-delegate-never-inlines-secrets-or-share-urls.md
@@ -1,0 +1,52 @@
+---
+id: hq-delegate-never-inlines-secrets-or-share-urls
+enforcement: hard
+public: true
+when: delegate || delegation || handoff || hq-delegate
+on: [UserPromptSubmit, AssistantIntent, PreToolUse]
+tags: [security, delegation, secrets, vault, capabilities, dm]
+created: 2026-08-07
+provenance: prd-decision
+---
+
+## Rule
+
+Two hard constraints bind every delegation artifact and every step of the
+`/delegate` flow — the manifest, `BRIEF.md`, `PICKUP-PROMPT.md`, the DM
+headline/prompt/details, journal stanzas, commit messages, and any output the
+skill or its helpers produce:
+
+1. **No secret value, ever.** Secrets travel by NAME only
+   (`manifest.secrets[]`, granted via `hq secrets share <name>`); the
+   recipient consumes them at runtime through `hq run` / `hq secrets exec`.
+   No delegation step may invoke a value-reading command (`hq secrets get
+   --reveal`, `hq secrets env`, printing injected env) or interpolate a value
+   into any artifact. The bundle builder and send helper scan their own
+   output against `core/scripts/lib/secret-patterns.sh` and MUST fail closed
+   (non-zero, nothing written or sent) on any match.
+
+2. **No share-session URL, ever.** Delegation grants access exclusively via
+   direct ACL grants (`hq files share <prefix> --with <principal>
+   --permission <level>`). A share-session URL is a live, single-use
+   capability token — any holder can redeem it to write ACLs in the issuer's
+   name — and minting or embedding one in a delegation artifact would persist
+   a capability into surfaces that outlive its safety (vault, DMs, journals).
+   The send helper scans for `share-session/` shapes and aborts on a match.
+
+A failure from either scan is the policy working. Never weaken the patterns,
+whitelist a match, or route around a failed scan to make a delegation go
+through.
+
+## Rationale
+
+A delegation bundle is designed to be copied: it is pushed to the vault,
+attached to a DM, pulled onto another machine, and quoted into a fresh agent
+session. Anything embedded in it escapes every boundary HQ maintains —
+tenancy, ACLs, TTLs. Secret values and capability URLs are exactly the two
+classes of content whose exposure cannot be undone by revoking access later:
+the value is known, the token may already be redeemed. Granting by name and
+by ACL keeps every access decision revocable and auditable after the
+handoff; inlining either one converts a revocable grant into a permanent
+leak. Enforcement lives in the helpers' fail-closed scans and their
+regression tests (`hq-delegate-bundle.test.sh`, `hq-delegate-send.test.sh`,
+`hq-delegate-secrets.test.sh` sentinel check), not in reviewer vigilance.

--- a/core/scripts/hq-delegate-bundle.sh
+++ b/core/scripts/hq-delegate-bundle.sh
@@ -6,7 +6,9 @@
 #   core/scripts/hq-delegate-bundle.sh build \
 #     --company <slug> --project <name> --to <principal> \
 #     [--to-kind person|agent] [--to-name <display name>] \
-#     [--mode transfer|share]
+#     [--mode transfer|share] [--dry-run]
+#
+# --dry-run prints the manifest JSON to stdout and writes nothing.
 #
 # Writes workspace/delegations/<delegationId>/{manifest.json,BRIEF.md} and
 # prints the delegationId on stdout. The manifest is the single source of
@@ -46,7 +48,7 @@ command -v jq >/dev/null 2>&1 || die "jq is required but not installed"
 [ "${1:-}" = "build" ] || { usage >&2; exit 1; }
 shift
 
-COMPANY="" PROJECT="" TO="" TO_KIND="person" TO_NAME="" MODE="transfer"
+COMPANY="" PROJECT="" TO="" TO_KIND="person" TO_NAME="" MODE="transfer" DRY_RUN=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --company) COMPANY="${2:-}"; shift 2 ;;
@@ -55,6 +57,7 @@ while [ $# -gt 0 ]; do
     --to-kind) TO_KIND="${2:-}"; shift 2 ;;
     --to-name) TO_NAME="${2:-}"; shift 2 ;;
     --mode)    MODE="${2:-}"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
     -h|--help) usage; exit 0 ;;
     *) die "unknown argument: $1" ;;
   esac
@@ -284,6 +287,16 @@ TRAPS="$(jq -r '[.metadata.securityNotes // empty, (.metadata.executionConventio
 
 if ! hq_scan_secrets "$STAGE/manifest.json" "$STAGE/BRIEF.md"; then
   die "generated bundle matched a secret-detection pattern — nothing written (see stderr above)"
+fi
+
+# --- dry run: print the manifest, write nothing ------------------------------
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  cat "$STAGE/manifest.json"
+  rm -rf "$STAGE"
+  trap - EXIT
+  echo "hq-delegate-bundle: dry run — nothing written" >&2
+  exit 0
 fi
 
 # --- move into place ---------------------------------------------------------

--- a/core/scripts/hq-delegate-bundle.sh
+++ b/core/scripts/hq-delegate-bundle.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# hq-core: public
+# hq-delegate-bundle.sh — freeze a project into a portable delegation bundle.
+#
+# Usage:
+#   core/scripts/hq-delegate-bundle.sh build \
+#     --company <slug> --project <name> --to <principal> \
+#     [--to-kind person|agent] [--to-name <display name>] \
+#     [--mode transfer|share]
+#
+# Writes workspace/delegations/<delegationId>/{manifest.json,BRIEF.md} and
+# prints the delegationId on stdout. The manifest is the single source of
+# truth for every downstream delegation step (grants, verification, pickup
+# prompt) — schema documented in
+# core/knowledge/public/hq-core/delegation-bundle-spec.md.
+#
+# Fails closed (non-zero, nothing written) when:
+#   - required arguments are missing
+#   - the project directory or its prd.json does not exist / parses invalid
+#   - the generated manifest or BRIEF matches a secret-detection pattern
+#
+# Env:
+#   HQ_ROOT — HQ root override (default: resolved from this script's location)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HQ_ROOT="${HQ_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+
+# shellcheck source=lib/secret-patterns.sh
+. "$SCRIPT_DIR/lib/secret-patterns.sh"
+
+usage() {
+  sed -n '3,13p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+die() {
+  echo "hq-delegate-bundle: $*" >&2
+  exit 1
+}
+
+command -v jq >/dev/null 2>&1 || die "jq is required but not installed"
+
+# --- argument parsing --------------------------------------------------------
+
+[ "${1:-}" = "build" ] || { usage >&2; exit 1; }
+shift
+
+COMPANY="" PROJECT="" TO="" TO_KIND="person" TO_NAME="" MODE="transfer"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --company) COMPANY="${2:-}"; shift 2 ;;
+    --project) PROJECT="${2:-}"; shift 2 ;;
+    --to)      TO="${2:-}"; shift 2 ;;
+    --to-kind) TO_KIND="${2:-}"; shift 2 ;;
+    --to-name) TO_NAME="${2:-}"; shift 2 ;;
+    --mode)    MODE="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$COMPANY" ] || die "--company is required"
+[ -n "$PROJECT" ] || die "--project is required"
+[ -n "$TO" ]      || die "--to is required"
+case "$MODE" in transfer|share) ;; *) die "--mode must be transfer or share" ;; esac
+case "$TO_KIND" in person|agent) ;; *) die "--to-kind must be person or agent" ;; esac
+
+PROJECT_DIR="$HQ_ROOT/companies/$COMPANY/projects/$PROJECT"
+PRD="$PROJECT_DIR/prd.json"
+[ -d "$PROJECT_DIR" ] || die "project directory not found: companies/$COMPANY/projects/$PROJECT"
+[ -f "$PRD" ] || die "project has no prd.json: companies/$COMPANY/projects/$PROJECT/prd.json"
+jq -e . "$PRD" >/dev/null 2>&1 || die "prd.json is not valid JSON: $PRD"
+
+# --- identity ----------------------------------------------------------------
+
+CREATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+DELEGATION_ID="dlg-$(date -u +%Y%m%d-%H%M%S)-$PROJECT"
+FROM_EMAIL="" FROM_UID=""
+if command -v hq >/dev/null 2>&1; then
+  WHOAMI_JSON="$(hq whoami --json 2>/dev/null || true)"
+  if [ -n "$WHOAMI_JSON" ] && printf '%s' "$WHOAMI_JSON" | jq -e . >/dev/null 2>&1; then
+    FROM_EMAIL="$(printf '%s' "$WHOAMI_JSON" | jq -r '.email // empty')"
+    FROM_UID="$(printf '%s' "$WHOAMI_JSON" | jq -r '.personUid // .uid // empty')"
+  fi
+fi
+
+# --- checksum helper (macOS + Linux) -----------------------------------------
+
+file_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+# --- derive vault prefixes, knowledge, policies ------------------------------
+#
+# Vault prefixes are BUCKET-RELATIVE (never prefixed with companies/<slug>/)
+# and always in trailing-slash folder form — see hq-files "Prefix Conventions".
+
+PROJECT_PREFIX="projects/$PROJECT/"
+
+# knowledge entries from prd metadata: split into vault-grantable (under this
+# company), policies (under this company's policies/), and repo-based docs
+# (recorded for the brief, never granted as vault prefixes).
+KNOWLEDGE_JSON="$(jq -c '[.metadata.knowledge // [] | .[]]' "$PRD")"
+
+VAULT_READ_PREFIXES="$(printf '%s' "$KNOWLEDGE_JSON" | jq -r --arg co "$COMPANY" '
+  [ .[]
+    | select(startswith("companies/" + $co + "/"))
+    | sub("^companies/" + $co + "/"; "")
+    # a file path -> its containing folder; a dir path -> itself with slash
+    | if endswith("/") then . else (split("/")[:-1] | join("/") + "/") end
+  ] | unique | .[]')"
+
+MANIFEST_KNOWLEDGE="$(printf '%s' "$KNOWLEDGE_JSON" | jq -c --arg co "$COMPANY" '
+  [ .[] | select((startswith("companies/" + $co + "/policies/")) | not) ] | unique')"
+MANIFEST_POLICIES="$(printf '%s' "$KNOWLEDGE_JSON" | jq -c --arg co "$COMPANY" '
+  [ .[] | select(startswith("companies/" + $co + "/policies/")) ] | unique')"
+
+# vaultPrefixes[]: write on the project dossier, read on referenced knowledge.
+VAULT_PREFIXES_JSON="$(
+  {
+    jq -cn --arg p "$PROJECT_PREFIX" \
+      '{prefix: $p, permission: "write", reason: "project dossier"}'
+    if [ -n "$VAULT_READ_PREFIXES" ]; then
+      printf '%s\n' "$VAULT_READ_PREFIXES" | while IFS= read -r pfx; do
+        [ -n "$pfx" ] || continue
+        jq -cn --arg p "$pfx" \
+          '{prefix: $p, permission: "read", reason: "referenced knowledge/policies"}'
+      done
+    fi
+  } | jq -cs 'unique_by(.prefix)'
+)"
+
+# Guard: every prefix must be folder form and company-relative.
+printf '%s' "$VAULT_PREFIXES_JSON" | jq -e '
+  all(.[]; (.prefix | endswith("/")) and (.prefix | startswith("companies/") | not))
+' >/dev/null || die "internal error: derived a non-folder or company-anchored prefix"
+
+# --- repo block (recorded here; verified/pushed by the US-004 step) ----------
+
+REPO_PATH="$(jq -r '.metadata.repoPath // empty' "$PRD")"
+if [ -n "$REPO_PATH" ]; then
+  REPO_JSON="$(jq -cn \
+    --arg path "$REPO_PATH" \
+    --arg branch "$(jq -r '.branchName // empty' "$PRD")" \
+    --arg base "$(jq -r '.metadata.baseBranch // "main"' "$PRD")" \
+    '{path: $path, remote: null, branch: (if $branch == "" then null else $branch end),
+      baseBranch: $base, headSha: null, dirtyFiles: [], accessVerified: false}')"
+else
+  REPO_JSON="null"
+fi
+
+# --- board id ----------------------------------------------------------------
+
+BOARD_ID="null"
+BOARD_FILE="$HQ_ROOT/companies/$COMPANY/board.json"
+if [ -f "$BOARD_FILE" ]; then
+  BOARD_ID="$(jq --arg prd "companies/$COMPANY/projects/$PROJECT/prd.json" \
+    '[.projects // [] | .[] | select(.prd_path == $prd) | .id] | first // null' \
+    "$BOARD_FILE" 2>/dev/null || echo null)"
+fi
+
+# --- checksums of the project dossier ----------------------------------------
+
+CHECKSUMS_JSON="$(
+  cd "$HQ_ROOT" || exit 1
+  find "companies/$COMPANY/projects/$PROJECT" -type f ! -name '.DS_Store' | sort | head -200 | \
+  while IFS= read -r f; do
+    jq -cn --arg p "$f" --arg h "$(file_sha256 "$f")" '{key: $p, value: $h}'
+  done | jq -s 'from_entries'
+)"
+
+# --- build in a temp dir, scan, then move into place -------------------------
+
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+
+jq -n \
+  --arg id "$DELEGATION_ID" \
+  --arg createdAt "$CREATED_AT" \
+  --arg mode "$MODE" \
+  --arg fromEmail "$FROM_EMAIL" \
+  --arg fromUid "$FROM_UID" \
+  --arg toKind "$TO_KIND" \
+  --arg toPrincipal "$TO" \
+  --arg toName "$TO_NAME" \
+  --arg company "$COMPANY" \
+  --arg project "$PROJECT" \
+  --arg prdPath "companies/$COMPANY/projects/$PROJECT/prd.json" \
+  --argjson boardId "$BOARD_ID" \
+  --argjson vaultPrefixes "$VAULT_PREFIXES_JSON" \
+  --argjson repo "$REPO_JSON" \
+  --argjson knowledge "$MANIFEST_KNOWLEDGE" \
+  --argjson policies "$MANIFEST_POLICIES" \
+  --argjson checksums "$CHECKSUMS_JSON" \
+  '{
+    schemaVersion: 1,
+    delegationId: $id,
+    createdAt: $createdAt,
+    mode: $mode,
+    from: {email: (if $fromEmail == "" then null else $fromEmail end),
+           personUid: (if $fromUid == "" then null else $fromUid end)},
+    to: {kind: $toKind, principal: $toPrincipal,
+         displayName: (if $toName == "" then null else $toName end)},
+    company: $company,
+    project: {name: $project, prdPath: $prdPath, boardId: $boardId},
+    vaultPrefixes: $vaultPrefixes,
+    repo: $repo,
+    secrets: [],
+    knowledge: $knowledge,
+    policies: $policies,
+    checksums: $checksums,
+    status: "building"
+  }' > "$STAGE/manifest.json"
+
+# --- BRIEF.md — full prose for a reader who has never seen the project -------
+
+DESCRIPTION="$(jq -r '.description // "No description recorded."' "$PRD")"
+GOAL="$(jq -r '.metadata.goal // empty' "$PRD")"
+TOTAL_STORIES="$(jq -r '[.userStories // [] | .[]] | length' "$PRD")"
+DONE_STORIES="$(jq -r '[.userStories // [] | .[] | select(.passes == true)] | length' "$PRD")"
+DONE_LIST="$(jq -r '[.userStories // [] | .[] | select(.passes == true)] | .[] | "- \(.id): \(.title)"' "$PRD")"
+NEXT_STEPS="$(jq -r '[.userStories // [] | .[] | select(.passes != true)]
+  | sort_by(.priority) | .[:3] | .[]
+  | "### \(.id): \(.title)\n\n\(.description)\n"' "$PRD")"
+OPEN_QUESTIONS="$(jq -r '[.metadata.openQuestions // [] | .[]] | .[] | "- \(.)"' "$PRD")"
+TRAPS="$(jq -r '[.metadata.securityNotes // empty, (.metadata.executionConventions // [] | .[])]
+  | .[] | "- \(.)"' "$PRD")"
+
+{
+  echo "# Delegation brief — $PROJECT"
+  echo
+  echo "You are receiving ownership of the **$PROJECT** project in the **$COMPANY** company. This brief is written assuming you have never seen the project before. Everything referenced here is covered by the access you have already been granted — nothing below requires asking the delegator for permissions."
+  echo
+  echo "## What this project is"
+  echo
+  echo "$DESCRIPTION"
+  if [ -n "$GOAL" ]; then
+    echo
+    echo "## The goal"
+    echo
+    echo "$GOAL"
+  fi
+  echo
+  echo "## Where things stand"
+  echo
+  echo "$DONE_STORIES of $TOTAL_STORIES stories are complete."
+  if [ -n "$DONE_LIST" ]; then
+    echo
+    echo "Already done:"
+    echo
+    echo "$DONE_LIST"
+  fi
+  echo
+  echo "## The next three steps"
+  echo
+  if [ -n "$NEXT_STEPS" ]; then
+    echo "$NEXT_STEPS"
+  else
+    echo "All stories are complete. Remaining work, if any, is described in the project's post-implementation notes."
+  fi
+  if [ -n "$OPEN_QUESTIONS" ]; then
+    echo "## Open questions"
+    echo
+    echo "$OPEN_QUESTIONS"
+    echo
+  fi
+  if [ -n "$TRAPS" ]; then
+    echo "## Known traps and conventions"
+    echo
+    echo "$TRAPS"
+    echo
+  fi
+  echo "## Where everything lives"
+  echo
+  echo "The full PRD (every story, acceptance criteria, and decision history) is at \`companies/$COMPANY/projects/$PROJECT/prd.json\`. The pickup prompt that accompanied this brief pulls every file you need on demand — you do not need to run a full sync."
+} > "$STAGE/BRIEF.md"
+
+# --- fail-closed secret scan -------------------------------------------------
+
+if ! hq_scan_secrets "$STAGE/manifest.json" "$STAGE/BRIEF.md"; then
+  die "generated bundle matched a secret-detection pattern — nothing written (see stderr above)"
+fi
+
+# --- move into place ---------------------------------------------------------
+
+DEST="$HQ_ROOT/workspace/delegations/$DELEGATION_ID"
+mkdir -p "$(dirname "$DEST")"
+mv "$STAGE" "$DEST"
+trap - EXIT
+
+echo "$DELEGATION_ID"
+echo "hq-delegate-bundle: wrote workspace/delegations/$DELEGATION_ID/{manifest.json,BRIEF.md}" >&2

--- a/core/scripts/hq-delegate-grant.sh
+++ b/core/scripts/hq-delegate-grant.sh
@@ -52,10 +52,23 @@ jq -e . "$MANIFEST" >/dev/null 2>&1 || die "manifest is not valid JSON: $MANIFES
 COMPANY="$(jq -r '.company // empty' "$MANIFEST")"
 PROJECT="$(jq -r '.project.name // empty' "$MANIFEST")"
 PRINCIPAL="$(jq -r '.to.principal // empty' "$MANIFEST")"
+DISPLAY="$(jq -r '.to.displayName // .to.principal // empty' "$MANIFEST")"
 STATUS="$(jq -r '.status // empty' "$MANIFEST")"
 [ -n "$COMPANY" ]   || die "manifest has no company"
 [ -n "$PROJECT" ]   || die "manifest has no project.name"
 [ -n "$PRINCIPAL" ] || die "manifest has no to.principal"
+
+# File-ACL principals must be an email, grp_<id>, or @all — an agentUid is
+# NOT accepted by `hq files share`. For agent recipients, grants flow through
+# a deterministic per-agent delegation group (the /new-agent pattern):
+# grp_dlg-<uid tail>, containing exactly that agent.
+GRANT_PRINCIPAL="$PRINCIPAL"
+case "$PRINCIPAL" in
+  agt_*)
+    TAIL="$(printf '%s' "$PRINCIPAL" | tail -c 9 | tr '[:upper:]' '[:lower:]')"
+    GRANT_PRINCIPAL="grp_dlg-$TAIL"
+    ;;
+esac
 
 case "$STATUS" in
   building|granted) ;;
@@ -79,6 +92,9 @@ fi
 # --- plan (always printed; the only output without --yes) --------------------
 
 echo "Delegation grant plan — company '$COMPANY', recipient '$PRINCIPAL':"
+if [ "$GRANT_PRINCIPAL" != "$PRINCIPAL" ]; then
+  echo "  0. Agent recipient: grants flow through group $GRANT_PRINCIPAL (created if absent, containing exactly $DISPLAY)"
+fi
 echo "  1. Push companies/$COMPANY/projects/$PROJECT/ to the vault (on-conflict keep)"
 jq -r '.vaultPrefixes[] | "  2. Grant \(.permission) on \(.prefix) — \(.reason // "")"' "$MANIFEST"
 WRITE_PREFIXES="$(jq -r '.vaultPrefixes[] | select(.permission == "write") | .prefix' "$MANIFEST")"
@@ -94,10 +110,36 @@ if [ "$YES" -ne 1 ]; then
   exit 2
 fi
 
-# --- 1. materialize the dossier in the vault ---------------------------------
+# --- 1. materialize the dossier AND referenced knowledge in the vault --------
+# (Live finding: granting read on a knowledge prefix is useless if the
+# specific referenced file was never pushed — the recipient's pull succeeds
+# on the prefix and silently misses the file. Push every referenced
+# company-local knowledge/policy path alongside the dossier.)
 
 hq sync push "companies/$COMPANY/projects/$PROJECT/" --company "$COMPANY" --on-conflict keep \
   || die "vault push failed for companies/$COMPANY/projects/$PROJECT/"
+
+jq -r --arg co "$COMPANY" \
+  '((.knowledge // []) + (.policies // []))[] | select(startswith("companies/" + $co + "/"))' \
+  "$MANIFEST" | while IFS= read -r kpath; do
+  if [ -e "$HQ_ROOT/$kpath" ]; then
+    hq sync push "$kpath" --company "$COMPANY" --on-conflict keep \
+      || die "vault push failed for referenced knowledge: $kpath"
+  else
+    echo "hq-delegate-grant: referenced path missing locally (cannot push): $kpath — the verify probe will fail if it is not already in the vault" >&2
+  fi
+done
+
+# --- 1b. agent recipients: ensure the delegation group exists + contains them
+
+if [ "$GRANT_PRINCIPAL" != "$PRINCIPAL" ]; then
+  # Both calls are idempotent-tolerated: an existing group / existing member
+  # is fine — the ACL read-back below is the arbiter of success.
+  hq groups create "$GRANT_PRINCIPAL" --name "Delegation: $DISPLAY" --company "$COMPANY" \
+    || echo "hq-delegate-grant: group create reported an error (may already exist) — continuing" >&2
+  hq groups add "$GRANT_PRINCIPAL" "$PRINCIPAL" --company "$COMPANY" \
+    || echo "hq-delegate-grant: group add reported an error (may already be a member) — continuing" >&2
+fi
 
 # --- 2+3. grant each prefix, then verify via ACL read-back -------------------
 
@@ -107,14 +149,14 @@ while [ "$i" -lt "$PREFIX_COUNT" ]; do
   PFX="$(jq -r ".vaultPrefixes[$i].prefix" "$MANIFEST")"
   PERM="$(jq -r ".vaultPrefixes[$i].permission" "$MANIFEST")"
 
-  if ! hq files share "$PFX" --with "$PRINCIPAL" --permission "$PERM" --company "$COMPANY"; then
+  if ! hq files share "$PFX" --with "$GRANT_PRINCIPAL" --permission "$PERM" --company "$COMPANY"; then
     # The share may fail because an identical grant already exists — the
     # read-back below is the arbiter either way.
     echo "hq-delegate-grant: share reported an error on $PFX — checking whether the grant already exists" >&2
   fi
 
   ACL_OUT="$(hq files acl "$PFX" --company "$COMPANY" 2>/dev/null || true)"
-  MATCH="$(printf '%s\n' "$ACL_OUT" | grep -F "$PRINCIPAL" | grep -c "$PERM" || true)"
+  MATCH="$(printf '%s\n' "$ACL_OUT" | grep -F "$GRANT_PRINCIPAL" | grep -c "$PERM" || true)"
   if [ "${MATCH:-0}" -eq 0 ]; then
     die "grant did not land: '$PRINCIPAL' with '$PERM' not visible in ACL for '$PFX' — manifest status left unchanged"
   fi
@@ -125,8 +167,9 @@ done
 # --- 4. advance manifest status ----------------------------------------------
 
 TMP_MANIFEST="$(mktemp)"
-jq --arg now "$NOW" '
+jq --arg now "$NOW" --arg gp "$GRANT_PRINCIPAL" '
   .status = "granted"
+  | .grantPrincipal = $gp
   | .vaultPrefixes = [.vaultPrefixes[] | . + {verifiedAt: $now}]
 ' "$MANIFEST" > "$TMP_MANIFEST" && mv "$TMP_MANIFEST" "$MANIFEST"
 

--- a/core/scripts/hq-delegate-grant.sh
+++ b/core/scripts/hq-delegate-grant.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# hq-core: public
+# hq-delegate-grant.sh — materialize a delegation's dossier in the vault and
+# write the ACL grants its manifest declares, verifying each one landed.
+#
+# Usage:
+#   core/scripts/hq-delegate-grant.sh --manifest <path> [--yes]
+#
+# Without --yes: prints the full grant plan (prefix, principal, permission —
+# the write grant is a privilege escalation and needs explicit confirmation)
+# and exits 2 without mutating anything. The caller (the /delegate skill)
+# confirms with the user, then re-invokes with --yes.
+#
+# With --yes:
+#   1. hq sync push the project directory so the vault prefix exists
+#   2. hq files share each manifest vaultPrefix to the recipient
+#   3. read each grant back with hq files acl and match grantee + permission
+#   4. advance manifest status building -> granted, stamping verifiedAt
+#
+# Direct ACL grants ONLY — this helper never mints a share-session URL
+# (policy hq-delegate-never-inlines-secrets-or-share-urls).
+#
+# Idempotent: a prefix whose grant already exists is reported, not an error.
+# A failed read-back exits non-zero and leaves manifest status unchanged.
+#
+# Env: HQ_ROOT — HQ root override (default: resolved from script location)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HQ_ROOT="${HQ_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+
+usage() { sed -n '3,25p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+die()   { echo "hq-delegate-grant: $*" >&2; exit 1; }
+
+command -v jq >/dev/null 2>&1 || die "jq is required but not installed"
+
+MANIFEST="" YES=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --manifest) MANIFEST="${2:-}"; shift 2 ;;
+    --yes)      YES=1; shift ;;
+    -h|--help)  usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$MANIFEST" ] || die "--manifest is required"
+[ -f "$MANIFEST" ] || die "manifest not found: $MANIFEST"
+jq -e . "$MANIFEST" >/dev/null 2>&1 || die "manifest is not valid JSON: $MANIFEST"
+
+COMPANY="$(jq -r '.company // empty' "$MANIFEST")"
+PROJECT="$(jq -r '.project.name // empty' "$MANIFEST")"
+PRINCIPAL="$(jq -r '.to.principal // empty' "$MANIFEST")"
+STATUS="$(jq -r '.status // empty' "$MANIFEST")"
+[ -n "$COMPANY" ]   || die "manifest has no company"
+[ -n "$PROJECT" ]   || die "manifest has no project.name"
+[ -n "$PRINCIPAL" ] || die "manifest has no to.principal"
+
+case "$STATUS" in
+  building|granted) ;;
+  *) die "manifest status is '$STATUS' — grants run from 'building' (or re-run from 'granted'), not from there" ;;
+esac
+
+PREFIX_COUNT="$(jq '.vaultPrefixes | length' "$MANIFEST")"
+[ "$PREFIX_COUNT" -gt 0 ] || die "manifest has no vaultPrefixes"
+
+# --- validate every prefix BEFORE touching anything --------------------------
+# Company-relative, trailing-slash folder form. A bare prefix would degrade to
+# a single literal key and grant nothing useful; company-anchored prefixes do
+# not exist in the bucket. Either is a hard error, never a silent grant.
+
+BAD="$(jq -r '.vaultPrefixes[] | .prefix
+  | select((endswith("/") | not) or startswith("companies/") or startswith("/"))' "$MANIFEST")"
+if [ -n "$BAD" ]; then
+  die "prefix violates the hq-files prefix conventions (must be company-relative folder form ending in '/'): $BAD"
+fi
+
+# --- plan (always printed; the only output without --yes) --------------------
+
+echo "Delegation grant plan — company '$COMPANY', recipient '$PRINCIPAL':"
+echo "  1. Push companies/$COMPANY/projects/$PROJECT/ to the vault (on-conflict keep)"
+jq -r '.vaultPrefixes[] | "  2. Grant \(.permission) on \(.prefix) — \(.reason // "")"' "$MANIFEST"
+WRITE_PREFIXES="$(jq -r '.vaultPrefixes[] | select(.permission == "write") | .prefix' "$MANIFEST")"
+if [ -n "$WRITE_PREFIXES" ]; then
+  echo
+  echo "NOTE: granting 'write' is a privilege escalation. The recipient will be able"
+  echo "to upload, overwrite, and delete under: $(printf '%s ' "$WRITE_PREFIXES")"
+fi
+
+if [ "$YES" -ne 1 ]; then
+  echo
+  echo "hq-delegate-grant: confirmation required — re-run with --yes after the user approves" >&2
+  exit 2
+fi
+
+# --- 1. materialize the dossier in the vault ---------------------------------
+
+hq sync push "companies/$COMPANY/projects/$PROJECT/" --company "$COMPANY" --on-conflict keep \
+  || die "vault push failed for companies/$COMPANY/projects/$PROJECT/"
+
+# --- 2+3. grant each prefix, then verify via ACL read-back -------------------
+
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+i=0
+while [ "$i" -lt "$PREFIX_COUNT" ]; do
+  PFX="$(jq -r ".vaultPrefixes[$i].prefix" "$MANIFEST")"
+  PERM="$(jq -r ".vaultPrefixes[$i].permission" "$MANIFEST")"
+
+  if ! hq files share "$PFX" --with "$PRINCIPAL" --permission "$PERM" --company "$COMPANY"; then
+    # The share may fail because an identical grant already exists — the
+    # read-back below is the arbiter either way.
+    echo "hq-delegate-grant: share reported an error on $PFX — checking whether the grant already exists" >&2
+  fi
+
+  ACL_OUT="$(hq files acl "$PFX" --company "$COMPANY" 2>/dev/null || true)"
+  MATCH="$(printf '%s\n' "$ACL_OUT" | grep -F "$PRINCIPAL" | grep -c "$PERM" || true)"
+  if [ "${MATCH:-0}" -eq 0 ]; then
+    die "grant did not land: '$PRINCIPAL' with '$PERM' not visible in ACL for '$PFX' — manifest status left unchanged"
+  fi
+  echo "hq-delegate-grant: verified $PERM on $PFX for $PRINCIPAL"
+  i=$((i + 1))
+done
+
+# --- 4. advance manifest status ----------------------------------------------
+
+TMP_MANIFEST="$(mktemp)"
+jq --arg now "$NOW" '
+  .status = "granted"
+  | .vaultPrefixes = [.vaultPrefixes[] | . + {verifiedAt: $now}]
+' "$MANIFEST" > "$TMP_MANIFEST" && mv "$TMP_MANIFEST" "$MANIFEST"
+
+echo "hq-delegate-grant: all $PREFIX_COUNT grants verified — manifest status advanced to 'granted'"

--- a/core/scripts/hq-delegate-repo.sh
+++ b/core/scripts/hq-delegate-repo.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# hq-core: public
+# hq-delegate-repo.sh — code/branch handover for a delegation: make sure the
+# project's branch exists on the remote, record uncommitted work as NOT
+# transferred, and verify the recipient's repository access read-only.
+#
+# Usage:
+#   core/scripts/hq-delegate-repo.sh --manifest <path> [--yes] [--github-user <login>]
+#
+# Behavior (driven by the manifest's repo{} block; no-op when repo is null):
+#   - records remote URL and the branch's headSha into the manifest
+#   - a branch that exists only locally requires confirmation: without --yes
+#     the helper prints the plan and exits 2; with --yes it pushes via an
+#     explicitly anchored `git -C <abs path> push -u origin <branch>`
+#   - dirty/untracked files are captured into repo.dirtyFiles[] and appended
+#     to BRIEF.md as work NOT transferred — never silently dropped
+#   - recipient access is checked read-only via gh when --github-user is
+#     given; otherwise (or on a gh failure) repo.accessVerified stays false
+#     and the brief says so plainly — the helper never claims unverified access
+#   - never touches vaultPrefixes[] and never pushes repo content to the vault
+#
+# Env: HQ_ROOT — HQ root override (default: resolved from script location)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HQ_ROOT="${HQ_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+
+usage() { sed -n '3,22p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+die()   { echo "hq-delegate-repo: $*" >&2; exit 1; }
+
+command -v jq >/dev/null 2>&1 || die "jq is required but not installed"
+
+MANIFEST="" YES=0 GH_USER=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --manifest)    MANIFEST="${2:-}"; shift 2 ;;
+    --yes)         YES=1; shift ;;
+    --github-user) GH_USER="${2:-}"; shift 2 ;;
+    -h|--help)     usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$MANIFEST" ] || die "--manifest is required"
+[ -f "$MANIFEST" ] || die "manifest not found: $MANIFEST"
+jq -e . "$MANIFEST" >/dev/null 2>&1 || die "manifest is not valid JSON: $MANIFEST"
+
+BUNDLE_DIR="$(cd "$(dirname "$MANIFEST")" && pwd)"
+BRIEF="$BUNDLE_DIR/BRIEF.md"
+
+# --- no-repo projects skip cleanly -------------------------------------------
+
+if jq -e '.repo == null' "$MANIFEST" >/dev/null; then
+  echo "hq-delegate-repo: project has no repoPath — nothing to hand over"
+  exit 0
+fi
+
+REPO_REL="$(jq -r '.repo.path // empty' "$MANIFEST")"
+BRANCH="$(jq -r '.repo.branch // empty' "$MANIFEST")"
+[ -n "$REPO_REL" ] || die "manifest repo block has no path"
+
+REPO_DIR="$HQ_ROOT/$REPO_REL"
+[ -d "$REPO_DIR/.git" ] || git -C "$REPO_DIR" rev-parse --git-dir >/dev/null 2>&1 \
+  || die "not a git repository: $REPO_DIR"
+
+REMOTE_URL="$(git -C "$REPO_DIR" remote get-url origin 2>/dev/null || true)"
+
+# --- dirty / untracked work is recorded, never dropped -----------------------
+
+DIRTY_JSON="$(git -C "$REPO_DIR" status --porcelain | sed 's/^...//' | jq -R . | jq -cs .)"
+
+# --- branch state -------------------------------------------------------------
+
+BRANCH_PUSHED=false HEAD_SHA=""
+if [ -n "$BRANCH" ]; then
+  LOCAL_SHA="$(git -C "$REPO_DIR" rev-parse --verify --quiet "refs/heads/$BRANCH" || true)"
+  REMOTE_SHA="$(git -C "$REPO_DIR" rev-parse --verify --quiet "refs/remotes/origin/$BRANCH" || true)"
+
+  if [ -n "$REMOTE_SHA" ]; then
+    BRANCH_PUSHED=true
+    HEAD_SHA="$REMOTE_SHA"
+  elif [ -n "$LOCAL_SHA" ]; then
+    echo "Branch handover plan — repo '$REPO_REL':"
+    echo "  branch '$BRANCH' exists only locally ($LOCAL_SHA)"
+    echo "  action: git -C $REPO_DIR push -u origin $BRANCH"
+    if [ "$YES" -ne 1 ]; then
+      echo
+      echo "hq-delegate-repo: confirmation required — re-run with --yes to push the branch" >&2
+      exit 2
+    fi
+    git -C "$REPO_DIR" push -u origin "$BRANCH" \
+      || die "failed to push branch '$BRANCH' to origin"
+    BRANCH_PUSHED=true
+    HEAD_SHA="$LOCAL_SHA"
+  else
+    echo "hq-delegate-repo: branch '$BRANCH' does not exist yet (declared in the PRD, not started) — recording as unpushed"
+  fi
+fi
+
+# --- read-only recipient access check ----------------------------------------
+
+ACCESS_VERIFIED=false ACCESS_NOTE=""
+if [ -n "$GH_USER" ] && [ -n "$REMOTE_URL" ] && command -v gh >/dev/null 2>&1; then
+  # owner/repo from ssh or https remote forms
+  OWNER_REPO="$(printf '%s' "$REMOTE_URL" | sed -E 's#^(git@[^:]+:|https?://[^/]+/)##; s#\.git$##')"
+  if gh api "repos/$OWNER_REPO/collaborators/$GH_USER" >/dev/null 2>&1; then
+    ACCESS_VERIFIED=true
+    ACCESS_NOTE="verified: $GH_USER is a collaborator on $OWNER_REPO"
+  else
+    ACCESS_NOTE="UNVERIFIED: could not confirm $GH_USER has access to $OWNER_REPO — the recipient may need to be invited before they can pull the branch"
+  fi
+else
+  ACCESS_NOTE="UNVERIFIED: recipient repository access was not checked (no GitHub login supplied) — confirm they can reach the repo before assuming so"
+fi
+
+# --- manifest update (repo block only — vaultPrefixes are never touched) -----
+
+TMP_MANIFEST="$(mktemp)"
+jq \
+  --arg remote "$REMOTE_URL" \
+  --arg headSha "$HEAD_SHA" \
+  --argjson dirty "$DIRTY_JSON" \
+  --argjson pushed "$BRANCH_PUSHED" \
+  --argjson access "$ACCESS_VERIFIED" \
+  --arg accessNote "$ACCESS_NOTE" \
+  '.repo.remote = (if $remote == "" then null else $remote end)
+   | .repo.headSha = (if $headSha == "" then null else $headSha end)
+   | .repo.dirtyFiles = $dirty
+   | .repo.branchPushed = $pushed
+   | .repo.accessVerified = $access
+   | .repo.accessNote = $accessNote' \
+  "$MANIFEST" > "$TMP_MANIFEST" && mv "$TMP_MANIFEST" "$MANIFEST"
+
+# --- brief: call out untransferred work and unverified access ----------------
+
+if [ -f "$BRIEF" ]; then
+  DIRTY_COUNT="$(printf '%s' "$DIRTY_JSON" | jq 'length')"
+  if [ "$DIRTY_COUNT" -gt 0 ] || [ "$ACCESS_VERIFIED" != "true" ]; then
+    {
+      echo
+      echo "## Code handover notes"
+      echo
+      if [ "$DIRTY_COUNT" -gt 0 ]; then
+        echo "The delegator's working tree had uncommitted changes that are **not transferred** with this delegation. If something seems missing, these files are why — ask the delegator to commit and push them:"
+        echo
+        printf '%s' "$DIRTY_JSON" | jq -r '.[] | "- `\(.)`"'
+        echo
+      fi
+      if [ "$ACCESS_VERIFIED" != "true" ]; then
+        echo "$ACCESS_NOTE"
+      fi
+    } >> "$BRIEF"
+  fi
+fi
+
+echo "hq-delegate-repo: recorded branch state (pushed=$BRANCH_PUSHED, dirty=$(printf '%s' "$DIRTY_JSON" | jq 'length') files, accessVerified=$ACCESS_VERIFIED)"

--- a/core/scripts/hq-delegate-resolve.sh
+++ b/core/scripts/hq-delegate-resolve.sh
@@ -98,8 +98,9 @@ case "$PEOPLE_STATUS" in
     exit 3
     ;;
   no_email)
-    echo "hq-delegate-resolve: '$TOKEN' was found in company '$COMPANY' but has no email on record — pass their exact email or personUid instead" >&2
-    exit 4
+    # A person entry without an email is often a fleet agent's roster row —
+    # fall through to the agent roster before treating this as terminal.
+    PERSON_NO_EMAIL=1
     ;;
   not_found|"")
     : # fall through to the fleet-agent roster
@@ -136,5 +137,9 @@ elif [ "$MATCH_COUNT" -gt 1 ]; then
   exit 3
 fi
 
-echo "hq-delegate-resolve: no teammate or fleet agent named '$TOKEN' found in company '$COMPANY' — pass the exact email, personUid (prs_…), or agentUid (agt_…) instead" >&2
+if [ "${PERSON_NO_EMAIL:-0}" -eq 1 ]; then
+  echo "hq-delegate-resolve: '$TOKEN' was found in company '$COMPANY' but has no email on record and matches no fleet agent — pass their exact email, personUid (prs_…), or agentUid (agt_…) instead" >&2
+else
+  echo "hq-delegate-resolve: no teammate or fleet agent named '$TOKEN' found in company '$COMPANY' — pass the exact email, personUid (prs_…), or agentUid (agt_…) instead" >&2
+fi
 exit 4

--- a/core/scripts/hq-delegate-resolve.sh
+++ b/core/scripts/hq-delegate-resolve.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# hq-core: public
+# hq-delegate-resolve.sh — resolve a delegation recipient to a confirmed
+# principal (person email / prs_ uid, or fleet-agent agt_ uid). Read-only.
+#
+# Usage:
+#   core/scripts/hq-delegate-resolve.sh --company <slug> --to <token>
+#
+# Output (stdout, JSON): {kind, principal, displayName, source}
+#   kind      — "person" | "agent"
+#   principal — confirmed email, prs_… or agt_… uid
+#   source    — "verbatim" | "people-resolve" | "agents-list"
+#
+# Exit codes:
+#   0 — resolved
+#   1 — usage error (missing/invalid arguments)
+#   3 — ambiguous: candidate list printed to stdout as JSON
+#       {status:"ambiguous", matches:[…]} — caller must present a picker
+#   4 — not found (or found with no email): plain message on stderr
+#
+# Tenancy: every lookup is scoped with an explicit --company. This helper
+# never enumerates or falls back across companies — single-company by
+# construction, matching the /dm skill's resolution contract.
+#
+# Fast path: a token containing "@" or starting with prs_ / agt_ passes
+# through verbatim with NO lookup, preserving existing invocations exactly.
+
+set -euo pipefail
+
+usage() {
+  sed -n '3,26p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+die_usage() {
+  echo "hq-delegate-resolve: $*" >&2
+  usage >&2
+  exit 1
+}
+
+command -v jq >/dev/null 2>&1 || { echo "hq-delegate-resolve: jq is required" >&2; exit 1; }
+
+COMPANY="" TOKEN=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --company) COMPANY="${2:-}"; shift 2 ;;
+    --to)      TOKEN="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) die_usage "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$COMPANY" ] || die_usage "--company is required (single-company lookups only; never a multi-company scan)"
+[ -n "$TOKEN" ]   || die_usage "--to is required"
+
+emit() { # kind principal displayName source
+  jq -cn --arg kind "$1" --arg principal "$2" --arg name "$3" --arg source "$4" \
+    '{kind: $kind, principal: $principal,
+      displayName: (if $name == "" then null else $name end), source: $source}'
+}
+
+# Strip CLI noise (version warnings, session-refresh notices) before the JSON
+# payload: keep everything from the first line that starts a JSON value.
+json_only() {
+  awk 'started {print; next} /^[[:space:]]*[{[]/ {started=1; print}'
+}
+
+# --- fast path: already a principal — pass through verbatim, no lookup -------
+
+case "$TOKEN" in
+  agt_*)
+    emit agent "$TOKEN" "" verbatim
+    exit 0
+    ;;
+  prs_*|*@*)
+    emit person "$TOKEN" "" verbatim
+    exit 0
+    ;;
+esac
+
+# --- name → people roster (single-company, read-only) ------------------------
+
+PEOPLE_RAW="$(hq people resolve "$TOKEN" --json --company "$COMPANY" 2>/dev/null | json_only || true)"
+PEOPLE_STATUS=""
+if [ -n "$PEOPLE_RAW" ] && printf '%s' "$PEOPLE_RAW" | jq -e . >/dev/null 2>&1; then
+  PEOPLE_STATUS="$(printf '%s' "$PEOPLE_RAW" | jq -r '.status // empty')"
+fi
+
+case "$PEOPLE_STATUS" in
+  found)
+    EMAIL="$(printf '%s' "$PEOPLE_RAW" | jq -r '.email // empty')"
+    NAME="$(printf '%s' "$PEOPLE_RAW" | jq -r '.name // .displayName // empty')"
+    [ -n "$EMAIL" ] || { echo "hq-delegate-resolve: resolver returned found but no email for '$TOKEN'" >&2; exit 4; }
+    emit person "$EMAIL" "$NAME" people-resolve
+    exit 0
+    ;;
+  ambiguous)
+    printf '%s' "$PEOPLE_RAW" | jq -c '{status: "ambiguous", matches: (.matches // [])}'
+    exit 3
+    ;;
+  no_email)
+    echo "hq-delegate-resolve: '$TOKEN' was found in company '$COMPANY' but has no email on record — pass their exact email or personUid instead" >&2
+    exit 4
+    ;;
+  not_found|"")
+    : # fall through to the fleet-agent roster
+    ;;
+  *)
+    echo "hq-delegate-resolve: unexpected resolver status '$PEOPLE_STATUS' for '$TOKEN'" >&2
+    exit 4
+    ;;
+esac
+
+# --- name → fleet-agent roster (same company, read-only) ---------------------
+
+AGENTS_RAW="$(hq agents list --company "$COMPANY" --json 2>/dev/null | json_only || true)"
+if [ -z "$AGENTS_RAW" ] || ! printf '%s' "$AGENTS_RAW" | jq -e . >/dev/null 2>&1; then
+  AGENTS_RAW="[]"
+fi
+
+MATCHES="$(printf '%s' "$AGENTS_RAW" | jq -c --arg t "$TOKEN" '
+  [ .[]
+    | select((.name // .displayName // "") | ascii_downcase == ($t | ascii_downcase))
+    | {agentUid: (.agentUid // .uid // empty), name: (.name // .displayName // "")}
+    | select(.agentUid != "")
+  ]')"
+MATCH_COUNT="$(printf '%s' "$MATCHES" | jq 'length')"
+
+if [ "$MATCH_COUNT" -eq 1 ]; then
+  emit agent \
+    "$(printf '%s' "$MATCHES" | jq -r '.[0].agentUid')" \
+    "$(printf '%s' "$MATCHES" | jq -r '.[0].name')" \
+    agents-list
+  exit 0
+elif [ "$MATCH_COUNT" -gt 1 ]; then
+  printf '%s' "$MATCHES" | jq -c '{status: "ambiguous", matches: .}'
+  exit 3
+fi
+
+echo "hq-delegate-resolve: no teammate or fleet agent named '$TOKEN' found in company '$COMPANY' — pass the exact email, personUid (prs_…), or agentUid (agt_…) instead" >&2
+exit 4

--- a/core/scripts/hq-delegate-secrets.sh
+++ b/core/scripts/hq-delegate-secrets.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# hq-core: public
+# hq-delegate-secrets.sh — grant a delegation recipient access to the secrets
+# a project needs, BY NAME ONLY. No command in this helper ever reads,
+# prints, logs, or interpolates a secret value.
+#
+# Usage:
+#   core/scripts/hq-delegate-secrets.sh --manifest <path> [--yes] [--no-secrets]
+#     [--env-schema <path>]
+#
+# Behavior:
+#   - derives required secret NAMES from the project's / repo's .env.schema
+#     (--env-schema overrides discovery); no schema -> records secrets: []
+#     and says so plainly rather than guessing at credentials
+#   - without --yes: prints a full-prose confirmation listing every name and
+#     the principal, then exits 2 granting nothing — this step is a privilege
+#     handover and gets its own confirmation, separate from the file grants
+#   - with --yes: hq secrets share <NAME> --with <principal> --permission read
+#     per name, then records the names (and only the names) in the manifest
+#   - --no-secrets: skips everything, records {secrets: [], secretsSkipped: true}
+#
+# Consumption on the recipient's side is via `hq run` / `hq secrets exec` —
+# documented in the brief; values never appear in any delegation artifact
+# (policy hq-delegate-never-inlines-secrets-or-share-urls).
+#
+# Env: HQ_ROOT — HQ root override (default: resolved from script location)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HQ_ROOT="${HQ_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+
+usage() { sed -n '3,24p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+die()   { echo "hq-delegate-secrets: $*" >&2; exit 1; }
+
+command -v jq >/dev/null 2>&1 || die "jq is required but not installed"
+
+MANIFEST="" YES=0 NO_SECRETS=0 ENV_SCHEMA=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --manifest)   MANIFEST="${2:-}"; shift 2 ;;
+    --yes)        YES=1; shift ;;
+    --no-secrets) NO_SECRETS=1; shift ;;
+    --env-schema) ENV_SCHEMA="${2:-}"; shift 2 ;;
+    -h|--help)    usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$MANIFEST" ] || die "--manifest is required"
+[ -f "$MANIFEST" ] || die "manifest not found: $MANIFEST"
+jq -e . "$MANIFEST" >/dev/null 2>&1 || die "manifest is not valid JSON: $MANIFEST"
+
+COMPANY="$(jq -r '.company // empty' "$MANIFEST")"
+PRINCIPAL="$(jq -r '.to.principal // empty' "$MANIFEST")"
+PROJECT="$(jq -r '.project.name // empty' "$MANIFEST")"
+[ -n "$COMPANY" ]   || die "manifest has no company"
+[ -n "$PRINCIPAL" ] || die "manifest has no to.principal"
+
+update_manifest() { # jq-filter
+  local tmp
+  tmp="$(mktemp)"
+  jq "$1" "$MANIFEST" > "$tmp" && mv "$tmp" "$MANIFEST"
+}
+
+# --- explicit skip ------------------------------------------------------------
+
+if [ "$NO_SECRETS" -eq 1 ]; then
+  update_manifest '.secrets = [] | .secretsSkipped = true'
+  echo "hq-delegate-secrets: skipped (--no-secrets) — no credential access granted"
+  exit 0
+fi
+
+# --- discover the env schema --------------------------------------------------
+
+if [ -z "$ENV_SCHEMA" ]; then
+  REPO_REL="$(jq -r '.repo.path // empty' "$MANIFEST")"
+  for candidate in \
+    "$HQ_ROOT/companies/$COMPANY/projects/$PROJECT/.env.schema" \
+    "${REPO_REL:+$HQ_ROOT/$REPO_REL/.env.schema}"; do
+    [ -n "$candidate" ] && [ -f "$candidate" ] && { ENV_SCHEMA="$candidate"; break; }
+  done
+fi
+
+if [ -z "$ENV_SCHEMA" ] || [ ! -f "$ENV_SCHEMA" ]; then
+  update_manifest '.secrets = [] | .secretsSkipped = false'
+  echo "hq-delegate-secrets: no .env.schema found for this project or its repo — no secret names to grant. If the project needs credentials, add an .env.schema and re-run, or grant them manually with 'hq secrets share'."
+  exit 0
+fi
+
+# --- parse names (KEY= lines; comments and blanks ignored) --------------------
+
+NAMES="$(grep -E '^[A-Za-z_][A-Za-z0-9_]*=' "$ENV_SCHEMA" | cut -d= -f1 | sort -u)"
+if [ -z "$NAMES" ]; then
+  update_manifest '.secrets = [] | .secretsSkipped = false'
+  echo "hq-delegate-secrets: $ENV_SCHEMA declares no secret names — nothing to grant"
+  exit 0
+fi
+NAME_COUNT="$(printf '%s\n' "$NAMES" | wc -l | tr -d ' ')"
+
+# --- confirmation gate (full prose; separate from the file-grant confirm) ----
+
+echo "Secret access handover — this grants the recipient the ability to use these credentials."
+echo
+echo "The following $NAME_COUNT secret name(s), declared by $(basename "$ENV_SCHEMA") for project '$PROJECT', will be shared with read permission to '$PRINCIPAL' in company '$COMPANY':"
+echo
+printf '%s\n' "$NAMES" | sed 's/^/  - /'
+echo
+echo "Only the names are granted and recorded; no secret value is read, printed, or transmitted by this step. The recipient consumes them through 'hq run' / 'hq secrets exec'."
+
+if [ "$YES" -ne 1 ]; then
+  echo
+  echo "hq-delegate-secrets: confirmation required — re-run with --yes after the user approves (or --no-secrets to skip)" >&2
+  exit 2
+fi
+
+# --- grant each name (names only — never a value read) ------------------------
+
+printf '%s\n' "$NAMES" | while IFS= read -r name; do
+  hq secrets share "$name" --with "$PRINCIPAL" --permission read --company "$COMPANY" \
+    || die "failed to grant '$name' to '$PRINCIPAL' — aborting; manifest not updated"
+  echo "hq-delegate-secrets: granted read on '$name' to '$PRINCIPAL'"
+done
+
+NAMES_JSON="$(printf '%s\n' "$NAMES" | jq -R . | jq -cs .)"
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+update_manifest ".secrets = $NAMES_JSON | .secretsSkipped = false | .secretsGrantedAt = \"$NOW\""
+
+echo "hq-delegate-secrets: $NAME_COUNT secret name(s) granted and recorded (names only)"

--- a/core/scripts/hq-delegate-send.sh
+++ b/core/scripts/hq-delegate-send.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# hq-core: public
+# hq-delegate-send.sh — generate the self-sufficient pickup prompt for a
+# delegation and deliver it by DM. The prompt IS the handoff: pasted into a
+# fresh agent session on a clean HQ install, it pulls every file on demand
+# (hq files get per prefix — no /hq-sync run) and reaches the first
+# next-step with no follow-up question to the delegator.
+#
+# Usage:
+#   core/scripts/hq-delegate-send.sh --manifest <path> [--send]
+#     [--headline <text>] [--note <text>]
+#
+# Without --send: (re)generates PICKUP-PROMPT.md next to the manifest and
+# prints its path — inspectable, idempotent, sends nothing.
+# With --send: requires manifest status "verified" (the US-008 probe must
+# have passed), then delivers ONE `hq dm` with --prompt-file/--details-file
+# and advances status to "sent", recording the DM eventId.
+#
+# The caller (the /delegate skill) humanizes --headline / --note per
+# core/knowledge/public/hq-core/humanize-before-send.md (channel dm, light)
+# BEFORE invoking; this helper never rewrites recipients, flags, or the
+# generated command lines.
+#
+# Fail-closed: the generated prompt is scanned for secret-shaped content and
+# share-session URLs; a match aborts before anything is written or sent
+# (policy hq-delegate-never-inlines-secrets-or-share-urls).
+#
+# Env: HQ_ROOT — HQ root override (default: resolved from script location)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HQ_ROOT="${HQ_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+
+# shellcheck source=lib/secret-patterns.sh
+. "$SCRIPT_DIR/lib/secret-patterns.sh"
+
+usage() { sed -n '3,27p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+die()   { echo "hq-delegate-send: $*" >&2; exit 1; }
+
+command -v jq >/dev/null 2>&1 || die "jq is required but not installed"
+
+MANIFEST="" SEND=0 HEADLINE="" NOTE=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --manifest) MANIFEST="${2:-}"; shift 2 ;;
+    --send)     SEND=1; shift ;;
+    --headline) HEADLINE="${2:-}"; shift 2 ;;
+    --note)     NOTE="${2:-}"; shift 2 ;;
+    -h|--help)  usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$MANIFEST" ] || die "--manifest is required"
+[ -f "$MANIFEST" ] || die "manifest not found: $MANIFEST"
+jq -e . "$MANIFEST" >/dev/null 2>&1 || die "manifest is not valid JSON: $MANIFEST"
+
+BUNDLE_DIR="$(cd "$(dirname "$MANIFEST")" && pwd)"
+BRIEF="$BUNDLE_DIR/BRIEF.md"
+PROMPT="$BUNDLE_DIR/PICKUP-PROMPT.md"
+
+COMPANY="$(jq -r '.company // empty' "$MANIFEST")"
+PROJECT="$(jq -r '.project.name // empty' "$MANIFEST")"
+PRINCIPAL="$(jq -r '.to.principal // empty' "$MANIFEST")"
+DISPLAY="$(jq -r '.to.displayName // .to.principal' "$MANIFEST")"
+FROM="$(jq -r '.from.email // .from.personUid // "your teammate"' "$MANIFEST")"
+DELEGATION_ID="$(jq -r '.delegationId // empty' "$MANIFEST")"
+STATUS="$(jq -r '.status // empty' "$MANIFEST")"
+MODE="$(jq -r '.mode // "transfer"' "$MANIFEST")"
+[ -n "$COMPANY" ]   || die "manifest has no company"
+[ -n "$PROJECT" ]   || die "manifest has no project.name"
+[ -n "$PRINCIPAL" ] || die "manifest has no to.principal"
+
+PRD_ABS="$HQ_ROOT/$(jq -r '.project.prdPath' "$MANIFEST")"
+
+# --- assemble prompt sections from the manifest (single source of truth) -----
+
+GOAL="" STATE_LINE="" NEXT_STEPS=""
+if [ -f "$PRD_ABS" ] && jq -e . "$PRD_ABS" >/dev/null 2>&1; then
+  GOAL="$(jq -r '.metadata.goal // .description // ""' "$PRD_ABS")"
+  TOTAL="$(jq -r '[.userStories // [] | .[]] | length' "$PRD_ABS")"
+  DONE="$(jq -r '[.userStories // [] | .[] | select(.passes == true)] | length' "$PRD_ABS")"
+  STATE_LINE="$DONE of $TOTAL stories are complete."
+  NEXT_STEPS="$(jq -r '[.userStories // [] | .[] | select(.passes != true)]
+    | sort_by(.priority) | .[:3] | to_entries | .[]
+    | "\(.key + 1). **\(.value.id): \(.value.title)** — \(.value.description)"' "$PRD_ABS")"
+fi
+
+GET_LINES="$(jq -r --arg co "$COMPANY" \
+  '.vaultPrefixes[] | "hq files get \(.prefix) --company \($co)"' "$MANIFEST")"
+
+REPO_IS_NULL="$(jq -r 'if .repo == null then "yes" else "no" end' "$MANIFEST")"
+REPO_SECTION=""
+if [ "$REPO_IS_NULL" = "no" ]; then
+  R_PATH="$(jq -r '.repo.path // empty' "$MANIFEST")"
+  R_REMOTE="$(jq -r '.repo.remote // empty' "$MANIFEST")"
+  R_BRANCH="$(jq -r '.repo.branch // empty' "$MANIFEST")"
+  R_BASE="$(jq -r '.repo.baseBranch // "main"' "$MANIFEST")"
+  R_SHA="$(jq -r '.repo.headSha // empty' "$MANIFEST")"
+  R_ACCESS="$(jq -r '.repo.accessNote // empty' "$MANIFEST")"
+  if [ -n "$R_BRANCH" ]; then
+    REPO_SECTION="## Get the code
+
+The work lives on branch \`$R_BRANCH\` (base: \`$R_BASE\`)${R_SHA:+ at \`$R_SHA\`}.
+
+\`\`\`bash
+# From your HQ root; clone first if the repo is not present${R_REMOTE:+ (remote: $R_REMOTE)}:
+git -C $R_PATH fetch origin
+git -C $R_PATH switch $R_BRANCH
+\`\`\`
+${R_ACCESS:+
+> $R_ACCESS
+}"
+  fi
+fi
+
+SECRET_NAMES="$(jq -r '[.secrets // [] | .[]] | join(",")' "$MANIFEST")"
+SECRETS_SECTION=""
+if [ -n "$SECRET_NAMES" ]; then
+  SECRETS_SECTION="## Credentials
+
+You have been granted read access to the secret names this project needs: \`$SECRET_NAMES\`. Values never travel in this handoff — consume them at runtime:
+
+\`\`\`bash
+# Inject from the project's .env.schema:
+hq run -- <your command>
+# Or explicitly by name:
+hq secrets exec --only $SECRET_NAMES --company $COMPANY -- <your command>
+\`\`\`
+"
+fi
+
+# --- write the prompt (staged, scanned, then placed) -------------------------
+
+STAGE="$(mktemp -d)"
+trap 'rm -rf "$STAGE"' EXIT
+
+{
+  echo "# Project handoff: $PROJECT — you own this now"
+  echo
+  if [ "$MODE" = "share" ]; then
+    echo "$FROM has shared the **$PROJECT** project ($COMPANY) with you${NOTE:+ — $NOTE}. You are working on it together; ownership stays with them."
+  else
+    echo "$FROM has delegated the **$PROJECT** project ($COMPANY) to you${NOTE:+ — $NOTE}. Ownership has been transferred: the board, PRD, and work mesh already point at you. Delegation id: \`$DELEGATION_ID\`."
+  fi
+  echo
+  echo "Everything below is already granted and verified reachable — no /hq-sync run, no access requests, no follow-up questions needed."
+  echo
+  if [ -n "$GOAL" ]; then
+    echo "## The goal"
+    echo
+    echo "$GOAL"
+    echo
+  fi
+  if [ -n "$STATE_LINE" ]; then
+    echo "## Where things stand"
+    echo
+    echo "$STATE_LINE"
+    echo
+  fi
+  echo "## Pull the files (on demand — no sync)"
+  echo
+  echo "Run these from your HQ root; each materializes exactly that path locally:"
+  echo
+  echo '```bash'
+  printf '%s\n' "$GET_LINES"
+  echo '```'
+  echo
+  echo "Start with the project dossier: \`companies/$COMPANY/projects/$PROJECT/\` now contains the PRD (\`prd.json\`), a full brief (\`README.md\` / the DM's details pane), and the delegation journal."
+  echo
+  if [ -n "$REPO_SECTION" ]; then
+    printf '%s\n' "$REPO_SECTION"
+    echo
+  fi
+  if [ -n "$SECRETS_SECTION" ]; then
+    printf '%s\n' "$SECRETS_SECTION"
+    echo
+  fi
+  if [ -n "$NEXT_STEPS" ]; then
+    echo "## Your next three steps"
+    echo
+    printf '%s\n' "$NEXT_STEPS"
+    echo
+  fi
+  echo "## If something is off"
+  echo
+  echo "The manifest of everything transferred (prefixes, branch, secret names, checksums) rides with the dossier at \`companies/$COMPANY/projects/$PROJECT/\` once pulled. If a pull fails or a path looks empty, that is a bug in the handoff — flag it to $FROM rather than working around it."
+} > "$STAGE/PICKUP-PROMPT.md"
+
+# fail-closed scans: secret shapes + share-session capability URLs
+if ! hq_scan_secrets "$STAGE/PICKUP-PROMPT.md"; then
+  die "generated pickup prompt matched a secret-detection pattern — aborting, nothing written or sent"
+fi
+if grep -Eq 'share-session/[A-Za-z0-9_-]+' "$STAGE/PICKUP-PROMPT.md" "$BRIEF" 2>/dev/null; then
+  die "a share-session URL appeared in a delegation artifact — forbidden (direct grants only), aborting"
+fi
+
+mv "$STAGE/PICKUP-PROMPT.md" "$PROMPT"
+rm -rf "$STAGE"
+trap - EXIT
+
+echo "hq-delegate-send: pickup prompt written: $PROMPT"
+
+[ "$SEND" -eq 1 ] || exit 0
+
+# --- deliver: ONE hq dm invocation, file flags only --------------------------
+
+[ "$STATUS" = "verified" ] \
+  || die "manifest status is '$STATUS' — the reachability probe (hq-delegate-verify.sh) must pass before sending"
+[ -f "$BRIEF" ] || die "BRIEF.md missing from the bundle — cannot send without the details pane"
+
+[ -n "$HEADLINE" ] || HEADLINE="Project handoff: $PROJECT is yours now — open details for the brief, paste the prompt into your agent to pick it up"
+
+DM_OUT="$(hq dm "$PRINCIPAL" "$HEADLINE" --prompt-file "$PROMPT" --details-file "$BRIEF")" \
+  || die "hq dm delivery failed — manifest status left at '$STATUS'"
+
+EVENT_ID="$(printf '%s' "$DM_OUT" | grep -oE 'eventId[: ]+[A-Za-z0-9_-]+' | head -1 | sed -E 's/eventId[: ]+//')"
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+TMP_MANIFEST="$(mktemp)"
+jq --arg now "$NOW" --arg ev "${EVENT_ID:-}" \
+  '.status = "sent" | .sentAt = $now
+   | .dmEventId = (if $ev == "" then null else $ev end)' \
+  "$MANIFEST" > "$TMP_MANIFEST" && mv "$TMP_MANIFEST" "$MANIFEST"
+
+echo "hq-delegate-send: DM delivered to $DISPLAY ($PRINCIPAL)${EVENT_ID:+ (eventId $EVENT_ID)} — status advanced to 'sent'"

--- a/core/scripts/hq-delegate-transfer.sh
+++ b/core/scripts/hq-delegate-transfer.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# hq-core: public
+# hq-delegate-transfer.sh — make a delegation real everywhere HQ tracks
+# ownership: board entry, PRD metadata, work mesh, and the project journal.
+#
+# Usage:
+#   core/scripts/hq-delegate-transfer.sh --manifest <path>
+#
+# Behavior (mode "transfer"; mode "share" skips every mutation):
+#   1. companies/<co>/board.json — the project's entry gets owner=<recipient>
+#      and a bumped updated_at; created (once) if absent
+#   2. prd.json metadata gains owner, delegatedFrom, delegatedAt
+#   3. work-mesh: `done` event closes the delegator's in-progress thread and
+#      broadcasts the reassignment; silently skipped when the helper is
+#      unavailable (local/offline installs) — the transfer still succeeds
+#   4. a dated "Delegated" stanza is appended to the project journal naming
+#      the recipient, delegation id, and transferred scope
+#
+# Idempotent: re-running updates owner/timestamps in place — never a
+# duplicate board entry, never a duplicated journal stanza.
+#
+# The delegator's own vault access is untouched (granting the recipient
+# write does not revoke anything).
+#
+# Env: HQ_ROOT — HQ root override (default: resolved from script location)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HQ_ROOT="${HQ_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+
+usage() { sed -n '3,25p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+die()   { echo "hq-delegate-transfer: $*" >&2; exit 1; }
+
+command -v jq >/dev/null 2>&1 || die "jq is required but not installed"
+
+MANIFEST=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --manifest) MANIFEST="${2:-}"; shift 2 ;;
+    -h|--help)  usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$MANIFEST" ] || die "--manifest is required"
+[ -f "$MANIFEST" ] || die "manifest not found: $MANIFEST"
+jq -e . "$MANIFEST" >/dev/null 2>&1 || die "manifest is not valid JSON: $MANIFEST"
+
+MODE="$(jq -r '.mode // "transfer"' "$MANIFEST")"
+COMPANY="$(jq -r '.company // empty' "$MANIFEST")"
+PROJECT="$(jq -r '.project.name // empty' "$MANIFEST")"
+PRINCIPAL="$(jq -r '.to.principal // empty' "$MANIFEST")"
+DISPLAY="$(jq -r '.to.displayName // .to.principal // empty' "$MANIFEST")"
+DELEGATION_ID="$(jq -r '.delegationId // empty' "$MANIFEST")"
+FROM="$(jq -r '.from.email // .from.personUid // "unknown"' "$MANIFEST")"
+[ -n "$COMPANY" ]   || die "manifest has no company"
+[ -n "$PROJECT" ]   || die "manifest has no project.name"
+[ -n "$PRINCIPAL" ] || die "manifest has no to.principal"
+
+if [ "$MODE" = "share" ]; then
+  echo "hq-delegate-transfer: mode is 'share' — ownership stays with the delegator, nothing mutated"
+  exit 0
+fi
+
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+TODAY="$(date -u +%Y-%m-%d)"
+PRD_PATH="companies/$COMPANY/projects/$PROJECT/prd.json"
+PRD_ABS="$HQ_ROOT/$PRD_PATH"
+PROJECT_DIR="$HQ_ROOT/companies/$COMPANY/projects/$PROJECT"
+BOARD="$HQ_ROOT/companies/$COMPANY/board.json"
+
+[ -f "$PRD_ABS" ] || die "prd not found: $PRD_PATH"
+
+# --- 1. board entry: update in place, create once if absent ------------------
+
+if [ -f "$BOARD" ]; then
+  jq -e . "$BOARD" >/dev/null 2>&1 || die "board.json is not valid JSON: $BOARD"
+else
+  echo '{"projects": []}' > "$BOARD"
+fi
+
+TITLE="$(jq -r '.name // empty' "$PRD_ABS")"
+DESC="$(jq -r '.description // ""' "$PRD_ABS" | head -c 300)"
+
+TMP_BOARD="$(mktemp)"
+jq \
+  --arg prd "$PRD_PATH" \
+  --arg owner "$PRINCIPAL" \
+  --arg now "$NOW" \
+  --arg title "$TITLE" \
+  --arg desc "$DESC" \
+  --arg project "$PROJECT" \
+  '
+  if ([.projects // [] | .[] | select(.prd_path == $prd)] | length) > 0 then
+    .projects = [.projects[] |
+      if .prd_path == $prd then .owner = $owner | .updated_at = $now else . end]
+  else
+    .projects = (.projects // []) + [{
+      id: ("proj-" + $project),
+      title: $title,
+      description: $desc,
+      status: "in_progress",
+      owner: $owner,
+      prd_path: $prd,
+      created_at: $now,
+      updated_at: $now
+    }]
+  end
+  | .updated_at = $now
+  ' "$BOARD" > "$TMP_BOARD" && mv "$TMP_BOARD" "$BOARD"
+
+# --- 2. prd metadata ----------------------------------------------------------
+
+TMP_PRD="$(mktemp)"
+jq \
+  --arg owner "$PRINCIPAL" \
+  --arg from "$FROM" \
+  --arg now "$NOW" \
+  '.metadata.owner = $owner
+   | .metadata.delegatedFrom = $from
+   | .metadata.delegatedAt = $now' \
+  "$PRD_ABS" > "$TMP_PRD" && mv "$TMP_PRD" "$PRD_ABS"
+
+# --- 3. work mesh: close the delegator's thread, broadcast reassignment ------
+# Silently tolerated when unavailable (local/offline installs no-op).
+
+WORK_MESH="$HQ_ROOT/core/scripts/work-mesh.sh"
+if [ -f "$WORK_MESH" ]; then
+  bash "$WORK_MESH" done --company "$COMPANY" --project "$PROJECT" \
+    --summary "Delegated to $DISPLAY ($PRINCIPAL) — delegation $DELEGATION_ID; ownership transferred" \
+    --silent >/dev/null 2>&1 || true
+fi
+
+# --- 4. journal: one dated stanza per delegation id --------------------------
+
+JOURNAL_DIR="$PROJECT_DIR/journal"
+JOURNAL_FILE="$JOURNAL_DIR/delegations.md"
+mkdir -p "$JOURNAL_DIR"
+if [ ! -f "$JOURNAL_FILE" ]; then
+  {
+    echo "# Delegation log — $PROJECT"
+    echo
+    echo "Ownership handoffs for this project, appended by /delegate."
+  } > "$JOURNAL_FILE"
+fi
+
+if ! grep -qF "$DELEGATION_ID" "$JOURNAL_FILE"; then
+  SCOPE="$(jq -r '[.vaultPrefixes // [] | .[] | .prefix] | join(", ")' "$MANIFEST")"
+  {
+    echo
+    echo "## $TODAY — Delegated to $DISPLAY"
+    echo
+    echo "- Delegation: \`$DELEGATION_ID\`"
+    echo "- From: $FROM"
+    echo "- To: $DISPLAY ($PRINCIPAL)"
+    echo "- Transferred scope: $SCOPE"
+    echo "- Board and work-mesh ownership reassigned; the delegator retains read access."
+  } >> "$JOURNAL_FILE"
+fi
+
+# --- record on the manifest ---------------------------------------------------
+
+TMP_MANIFEST="$(mktemp)"
+jq --arg now "$NOW" '.ownershipTransferredAt = $now' "$MANIFEST" > "$TMP_MANIFEST" \
+  && mv "$TMP_MANIFEST" "$MANIFEST"
+
+echo "hq-delegate-transfer: ownership of '$PROJECT' transferred to $DISPLAY ($PRINCIPAL) — board, PRD, work mesh, and journal updated"

--- a/core/scripts/hq-delegate-verify.sh
+++ b/core/scripts/hq-delegate-verify.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# hq-core: public
+# hq-delegate-verify.sh — prove a delegation can actually be picked up
+# before anyone is told it is theirs, or print the full plan without
+# touching anything.
+#
+# Usage (probe mode — after grants, before the DM):
+#   core/scripts/hq-delegate-verify.sh --manifest <path>
+#
+# Probes every manifest vaultPrefix with `hq files browse` and requires it
+# reachable AND non-empty. All pass -> manifest advances granted -> verified
+# (send is gated on this). Any failure -> non-zero, the failing prefix and
+# likely cause named, status left at its last successful value so a re-run
+# resumes without re-granting.
+#
+# Usage (dry-run mode — full plan, zero mutation):
+#   core/scripts/hq-delegate-verify.sh --dry-run \
+#     --company <slug> --project <name> --to <principal> [--mode transfer|share]
+#
+# Prints recipient, mode, every prefix with its permission, the secret
+# names an .env.schema would grant, repo + branch, and the DM headline that
+# would be sent. Exits 0. Creates nothing under workspace/delegations/ and
+# invokes no mutating command.
+#
+# Env: HQ_ROOT — HQ root override (default: resolved from script location)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HQ_ROOT="${HQ_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+
+usage() { sed -n '3,25p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+die()   { echo "hq-delegate-verify: $*" >&2; exit 1; }
+
+command -v jq >/dev/null 2>&1 || die "jq is required but not installed"
+
+MANIFEST="" DRY_RUN=0 COMPANY="" PROJECT="" TO="" MODE="transfer"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --manifest) MANIFEST="${2:-}"; shift 2 ;;
+    --dry-run)  DRY_RUN=1; shift ;;
+    --company)  COMPANY="${2:-}"; shift 2 ;;
+    --project)  PROJECT="${2:-}"; shift 2 ;;
+    --to)       TO="${2:-}"; shift 2 ;;
+    --mode)     MODE="${2:-}"; shift 2 ;;
+    -h|--help)  usage; exit 0 ;;
+    *) die "unknown argument: $1" ;;
+  esac
+done
+
+# =============================================================================
+# Dry-run mode: full plan from the builder's own derivation, zero mutation
+# =============================================================================
+
+if [ "$DRY_RUN" -eq 1 ]; then
+  [ -n "$COMPANY" ] || die "--dry-run requires --company"
+  [ -n "$PROJECT" ] || die "--dry-run requires --project"
+  [ -n "$TO" ]      || die "--dry-run requires --to"
+
+  # The builder's --dry-run prints the manifest it WOULD write — single
+  # derivation source, nothing lands on disk.
+  PLAN_JSON="$(HQ_ROOT="$HQ_ROOT" bash "$SCRIPT_DIR/hq-delegate-bundle.sh" build \
+    --company "$COMPANY" --project "$PROJECT" --to "$TO" --mode "$MODE" --dry-run)" \
+    || die "could not derive the delegation plan (see builder error above)"
+
+  # Secret names the US-005 step would grant (same .env.schema derivation).
+  REPO_REL="$(printf '%s' "$PLAN_JSON" | jq -r '.repo.path // empty')"
+  SCHEMA=""
+  for candidate in \
+    "$HQ_ROOT/companies/$COMPANY/projects/$PROJECT/.env.schema" \
+    "${REPO_REL:+$HQ_ROOT/$REPO_REL/.env.schema}"; do
+    [ -n "$candidate" ] && [ -f "$candidate" ] && { SCHEMA="$candidate"; break; }
+  done
+  SECRET_NAMES="(none — no .env.schema found)"
+  if [ -n "$SCHEMA" ]; then
+    SECRET_NAMES="$(grep -E '^[A-Za-z_][A-Za-z0-9_]*=' "$SCHEMA" | cut -d= -f1 | sort -u | tr '\n' ' ')"
+    [ -n "$SECRET_NAMES" ] || SECRET_NAMES="(none declared)"
+  fi
+
+  echo "Delegation dry run — nothing will be pushed, granted, transferred, or sent."
+  echo
+  echo "  Recipient:  $TO"
+  echo "  Mode:       $MODE"
+  echo "  Company:    $COMPANY"
+  echo "  Project:    $PROJECT"
+  echo
+  echo "  Vault grants that would be written:"
+  printf '%s' "$PLAN_JSON" | jq -r '.vaultPrefixes[] | "    \(.permission)\ton \(.prefix)\t(\(.reason // ""))"'
+  echo
+  echo "  Secret names that would be granted (read): $SECRET_NAMES"
+  echo
+  if printf '%s' "$PLAN_JSON" | jq -e '.repo != null' >/dev/null; then
+    printf '%s' "$PLAN_JSON" | jq -r '"  Repo handover: \(.repo.path) — branch \(.repo.branch // "(none)") (base \(.repo.baseBranch))"'
+  else
+    echo "  Repo handover: none (project has no repoPath)"
+  fi
+  echo
+  echo "  DM that would be sent to $TO:"
+  echo "    \"Project handoff: $PROJECT is yours now — open details for the brief, paste the prompt into your agent to pick it up\""
+  echo "    (prompt: generated pickup prompt; details: the delegation brief)"
+  exit 0
+fi
+
+# =============================================================================
+# Probe mode: reachability of every granted prefix
+# =============================================================================
+
+[ -n "$MANIFEST" ] || die "--manifest is required (or --dry-run with --company/--project/--to)"
+[ -f "$MANIFEST" ] || die "manifest not found: $MANIFEST"
+jq -e . "$MANIFEST" >/dev/null 2>&1 || die "manifest is not valid JSON: $MANIFEST"
+
+COMPANY="$(jq -r '.company // empty' "$MANIFEST")"
+STATUS="$(jq -r '.status // empty' "$MANIFEST")"
+[ -n "$COMPANY" ] || die "manifest has no company"
+
+case "$STATUS" in
+  granted|verified) ;;
+  building) die "manifest status is 'building' — run hq-delegate-grant.sh first (probe verifies grants, it cannot create them)" ;;
+  *) die "manifest status is '$STATUS' — probe runs from 'granted' (or re-runs from 'verified')" ;;
+esac
+
+PREFIX_COUNT="$(jq '.vaultPrefixes | length' "$MANIFEST")"
+[ "$PREFIX_COUNT" -gt 0 ] || die "manifest has no vaultPrefixes to probe"
+
+echo "hq-delegate-verify: probing $PREFIX_COUNT prefix(es) in company '$COMPANY'"
+FAILED=0
+i=0
+while [ "$i" -lt "$PREFIX_COUNT" ]; do
+  PFX="$(jq -r ".vaultPrefixes[$i].prefix" "$MANIFEST")"
+  BROWSE_OUT="$(hq files browse "$PFX" --company "$COMPANY" 2>&1)" && BROWSE_RC=0 || BROWSE_RC=$?
+  if [ "$BROWSE_RC" -ne 0 ]; then
+    echo "  FAIL  $PFX — browse errored (likely cause: the grant did not land, or the caller's session expired — re-run /hq-login and hq-delegate-grant.sh)"
+    FAILED=1
+  elif [ -z "$(printf '%s' "$BROWSE_OUT" | tr -d '[:space:]')" ]; then
+    echo "  FAIL  $PFX — reachable but EMPTY (likely cause: the dossier was never pushed to the vault — hq sync push companies/$COMPANY/... and re-run)"
+    FAILED=1
+  else
+    echo "  pass  $PFX"
+  fi
+  i=$((i + 1))
+done
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "hq-delegate-verify: probe FAILED — the DM must not be sent; fix the failing prefix(es) above and re-run (manifest status left at '$STATUS')" >&2
+  exit 1
+fi
+
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+TMP_MANIFEST="$(mktemp)"
+jq --arg now "$NOW" '.status = "verified" | .verifiedAt = $now' \
+  "$MANIFEST" > "$TMP_MANIFEST" && mv "$TMP_MANIFEST" "$MANIFEST"
+
+echo "hq-delegate-verify: all $PREFIX_COUNT prefix(es) reachable — manifest status advanced to 'verified'"

--- a/core/scripts/hq-delegate-verify.sh
+++ b/core/scripts/hq-delegate-verify.sh
@@ -140,6 +140,32 @@ while [ "$i" -lt "$PREFIX_COUNT" ]; do
   i=$((i + 1))
 done
 
+# --- referenced files: prefix reachability is not enough ---------------------
+# (Live finding: a knowledge prefix can be reachable and non-empty while the
+# SPECIFIC referenced file is absent — the recipient then pulls a folder that
+# silently misses the note the brief points at. Probe each referenced file.)
+
+REF_COUNT="$(jq -r --arg co "$COMPANY" \
+  '[((.knowledge // []) + (.policies // []))[] | select(startswith("companies/" + $co + "/"))] | length' "$MANIFEST")"
+if [ "$REF_COUNT" -gt 0 ]; then
+  echo "hq-delegate-verify: probing $REF_COUNT referenced knowledge/policy file(s)"
+  while IFS= read -r kpath; do
+    [ -n "$kpath" ] || continue
+    REL="${kpath#companies/$COMPANY/}"
+    PARENT="$(dirname "$REL")/"
+    BASE="$(basename "$REL")"
+    LISTING="$(hq files browse "$PARENT" --company "$COMPANY" 2>/dev/null || true)"
+    if printf '%s\n' "$LISTING" | grep -qF "$BASE"; then
+      echo "  pass  $REL"
+    else
+      echo "  FAIL  $REL — granted prefix is reachable but this referenced file is NOT in the vault (likely cause: it was never pushed — hq sync push $kpath --company $COMPANY and re-run)"
+      FAILED=1
+    fi
+  done <<EOF
+$(jq -r --arg co "$COMPANY" '((.knowledge // []) + (.policies // []))[] | select(startswith("companies/" + $co + "/"))' "$MANIFEST")
+EOF
+fi
+
 if [ "$FAILED" -ne 0 ]; then
   echo "hq-delegate-verify: probe FAILED — the DM must not be sent; fix the failing prefix(es) above and re-run (manifest status left at '$STATUS')" >&2
   exit 1

--- a/core/scripts/lib/secret-patterns.sh
+++ b/core/scripts/lib/secret-patterns.sh
@@ -1,0 +1,49 @@
+# shellcheck shell=bash
+# hq-core: public
+# secret-patterns.sh — shared secret-detection patterns for hq-core shell scripts.
+#
+# SOURCED, never executed:  . "$ROOT/core/scripts/lib/secret-patterns.sh"
+# bash 3.2 safe; no associative arrays.
+#
+# Single source of truth for the secret-shaped patterns that generated
+# artifacts (delegation manifests, briefs, pickup prompts, DM payloads) are
+# scanned against before they are written to disk or transmitted. Mirrors the
+# runtime PreToolUse hook at .claude/hooks/detect-secrets.sh — a regression
+# test (core/scripts/tests/hq-delegate-bundle.test.sh) asserts this list stays
+# a superset of the hook's, so the two cannot silently drift.
+#
+# Entries are "<extended-regex>:<human name>". The regex part may not contain
+# a colon; the name may.
+
+SECRET_PATTERNS=(
+  "sk-[a-zA-Z0-9._-]{20,}:OpenAI/Stripe key"
+  "ghp_[a-zA-Z0-9]{36,}:GitHub PAT"
+  "AKIA[0-9A-Z]{16}:AWS access key"
+  "xox[bpsa]-[a-zA-Z0-9-]+:Slack token"
+  "Bearer [a-zA-Z0-9._-]{20,}:Bearer token"
+  "-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----:Private key"
+  "glpat-[a-zA-Z0-9_-]{20,}:GitLab PAT"
+  "gho_[a-zA-Z0-9]{36,}:GitHub OAuth token"
+  "github_pat_[a-zA-Z0-9_]{22,}:Fine-grained GitHub PAT"
+  "eyJ[a-zA-Z0-9_-]{20,}\.[a-zA-Z0-9_-]{20,}\.[a-zA-Z0-9_-]{10,}:JWT"
+)
+
+# hq_scan_secrets <file>...
+#   Scan files for secret-shaped content. Prints "pattern: <name> in <file>"
+#   to stderr for every hit (never the matched value itself) and returns 1 if
+#   anything matched, 0 when all files are clean. Missing files are skipped.
+hq_scan_secrets() {
+  local hit=0 f entry pattern name
+  for f in "$@"; do
+    [ -f "$f" ] || continue
+    for entry in "${SECRET_PATTERNS[@]}"; do
+      pattern="${entry%%:*}"
+      name="${entry#*:}"
+      if grep -Eq "$pattern" "$f" 2>/dev/null; then
+        echo "secret-scan: pattern '$name' matched in $f" >&2
+        hit=1
+      fi
+    done
+  done
+  return "$hit"
+}

--- a/core/scripts/tests/hq-delegate-bundle.test.sh
+++ b/core/scripts/tests/hq-delegate-bundle.test.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Regression: hq-delegate-bundle.sh must freeze a project into a valid v1
+# delegation bundle, fail closed on missing inputs, and fail closed (writing
+# nothing) when its own output matches a secret-detection pattern.
+#
+# Guards:
+#   1. A fixture project with a prd.json builds a manifest that validates
+#      against the documented v1 schema, plus a non-empty prose BRIEF.md, and
+#      the delegationId is printed on stdout.
+#   2. Vault prefixes are bucket-relative folder form: every prefix ends in
+#      "/" and none starts with "companies/".
+#   3. Missing prd.json → non-zero exit, nothing written.
+#   4. Secret-shaped content in the prd → non-zero exit, no new directory
+#      under workspace/delegations/.
+#   5. The shared secret-pattern lib stays a superset of the runtime hook's
+#      patterns (.claude/hooks/detect-secrets.sh) so the two cannot drift.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+BUILDER="$ROOT/core/scripts/hq-delegate-bundle.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$BUILDER" ] || fail "missing builder: $BUILDER"
+
+# --- fixture HQ root ---------------------------------------------------------
+
+FIX="$TMP/hqroot"
+PROJ="$FIX/companies/acme/projects/widget"
+mkdir -p "$PROJ" "$FIX/workspace" "$FIX/companies/acme/knowledge/insights"
+echo "insight body" > "$FIX/companies/acme/knowledge/insights/widget-notes.md"
+
+cat > "$PROJ/prd.json" <<'JSON'
+{
+  "name": "widget",
+  "description": "Build the widget.",
+  "branchName": "feature/widget",
+  "metadata": {
+    "goal": "Widgets ship.",
+    "repoPath": "repos/public/widget-repo",
+    "baseBranch": "main",
+    "knowledge": [
+      "companies/acme/knowledge/insights/widget-notes.md",
+      "companies/acme/policies/widget-policy.md",
+      "repos/public/widget-repo/docs/widget.md"
+    ],
+    "openQuestions": ["Should widgets spin?"],
+    "executionConventions": ["Branch from origin/main"]
+  },
+  "userStories": [
+    {"id": "US-001", "title": "Frame", "description": "Build the frame.", "priority": 1, "passes": true},
+    {"id": "US-002", "title": "Spin", "description": "Make it spin.", "priority": 1, "passes": false},
+    {"id": "US-003", "title": "Paint", "description": "Paint it.", "priority": 2, "passes": false}
+  ]
+}
+JSON
+
+cat > "$FIX/companies/acme/board.json" <<'JSON'
+{"projects": [{"id": "ac-proj-7", "prd_path": "companies/acme/projects/widget/prd.json"}]}
+JSON
+
+# Stub hq CLI so `hq whoami --json` works offline.
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/hq" <<'STUB'
+#!/usr/bin/env bash
+if [ "$1" = "whoami" ]; then
+  echo '{"email": "owner@acme.test", "personUid": "prs_owner1"}'
+  exit 0
+fi
+exit 0
+STUB
+chmod +x "$TMP/bin/hq"
+export PATH="$TMP/bin:$PATH"
+
+# --- 1+2. happy path ---------------------------------------------------------
+
+OUT="$(HQ_ROOT="$FIX" bash "$BUILDER" build --company acme --project widget \
+  --to alice@acme.test --to-name "Alice" 2>"$TMP/stderr.log")" \
+  || fail "builder exited non-zero on valid fixture: $(cat "$TMP/stderr.log")"
+
+DID="$(printf '%s' "$OUT" | head -1)"
+case "$DID" in dlg-*-widget) ;; *) fail "stdout is not a delegationId: '$OUT'" ;; esac
+
+BUNDLE="$FIX/workspace/delegations/$DID"
+MANIFEST="$BUNDLE/manifest.json"
+BRIEF="$BUNDLE/BRIEF.md"
+[ -f "$MANIFEST" ] || fail "manifest not written: $MANIFEST"
+[ -f "$BRIEF" ] || fail "BRIEF not written: $BRIEF"
+
+# Schema validation — required fields, correct values.
+jq -e '
+  .schemaVersion == 1 and
+  .delegationId != null and
+  .createdAt != null and
+  .mode == "transfer" and
+  .from.email == "owner@acme.test" and
+  .to.kind == "person" and
+  .to.principal == "alice@acme.test" and
+  .to.displayName == "Alice" and
+  .company == "acme" and
+  .project.name == "widget" and
+  .project.prdPath == "companies/acme/projects/widget/prd.json" and
+  .project.boardId == "ac-proj-7" and
+  (.vaultPrefixes | type) == "array" and (.vaultPrefixes | length) >= 2 and
+  .repo.path == "repos/public/widget-repo" and
+  .repo.branch == "feature/widget" and
+  .repo.baseBranch == "main" and
+  .secrets == [] and
+  (.checksums | type) == "object" and (.checksums | length) >= 1 and
+  .status == "building"
+' "$MANIFEST" >/dev/null || fail "manifest does not validate against the v1 schema: $(cat "$MANIFEST")"
+
+# Write on the project dossier, read on referenced knowledge.
+jq -e '.vaultPrefixes[] | select(.prefix == "projects/widget/" and .permission == "write")' \
+  "$MANIFEST" >/dev/null || fail "missing write grant on projects/widget/"
+jq -e '.vaultPrefixes[] | select(.prefix == "knowledge/insights/" and .permission == "read")' \
+  "$MANIFEST" >/dev/null || fail "missing read grant on knowledge/insights/"
+jq -e '.vaultPrefixes[] | select(.prefix == "policies/" and .permission == "read")' \
+  "$MANIFEST" >/dev/null || fail "missing read grant on policies/"
+
+# Prefix conventions: folder form, bucket-relative, no repo paths.
+jq -e 'all(.vaultPrefixes[]; (.prefix | endswith("/")) and (.prefix | startswith("companies/") | not) and (.prefix | startswith("repos/") | not))' \
+  "$MANIFEST" >/dev/null || fail "a vault prefix violates conventions (folder form, bucket-relative, no repos/)"
+
+# Repo docs recorded as knowledge but never granted.
+jq -e '.knowledge | index("repos/public/widget-repo/docs/widget.md")' "$MANIFEST" >/dev/null \
+  || fail "repo-based doc missing from knowledge[]"
+jq -e '.policies == ["companies/acme/policies/widget-policy.md"]' "$MANIFEST" >/dev/null \
+  || fail "policy path not routed into policies[]"
+
+# BRIEF is non-empty prose covering the required sections.
+[ -s "$BRIEF" ] || fail "BRIEF.md is empty"
+for section in "What this project is" "Where things stand" "The next three steps" "Open questions" "Known traps"; do
+  grep -q "$section" "$BRIEF" || fail "BRIEF missing section: $section"
+done
+grep -q "US-002" "$BRIEF" || fail "BRIEF next steps must name the top incomplete story"
+grep -q "1 of 3 stories" "$BRIEF" || fail "BRIEF must state where things stand (1 of 3)"
+
+# --- 3. missing prd.json → non-zero, nothing written -------------------------
+
+mkdir -p "$FIX/companies/acme/projects/empty"
+if HQ_ROOT="$FIX" bash "$BUILDER" build --company acme --project empty \
+  --to alice@acme.test >/dev/null 2>&1; then
+  fail "builder must exit non-zero when the project has no prd.json"
+fi
+[ -z "$(find "$FIX/workspace/delegations" -maxdepth 1 -name '*empty*' 2>/dev/null)" ] \
+  || fail "builder wrote a bundle for a project with no prd.json"
+
+# Missing --company is a usage error.
+if HQ_ROOT="$FIX" bash "$BUILDER" build --project widget --to a@b.c >/dev/null 2>&1; then
+  fail "builder must exit non-zero when --company is missing"
+fi
+
+# --- 4. secret-shaped prd → fail closed, no bundle ---------------------------
+
+SECRET_PROJ="$FIX/companies/acme/projects/leaky"
+mkdir -p "$SECRET_PROJ"
+jq '.name = "leaky" | .description = "key is AKIA" + "ABCDEFGHIJKLMNOP"' \
+  "$PROJ/prd.json" > "$SECRET_PROJ/prd.json"
+
+BEFORE_COUNT="$(find "$FIX/workspace/delegations" -maxdepth 1 -mindepth 1 -type d | wc -l | tr -d ' ')"
+if HQ_ROOT="$FIX" bash "$BUILDER" build --company acme --project leaky \
+  --to alice@acme.test >/dev/null 2>&1; then
+  fail "builder must fail closed when output matches a secret pattern"
+fi
+AFTER_COUNT="$(find "$FIX/workspace/delegations" -maxdepth 1 -mindepth 1 -type d | wc -l | tr -d ' ')"
+[ "$BEFORE_COUNT" = "$AFTER_COUNT" ] \
+  || fail "builder wrote a bundle despite a secret-pattern match"
+
+# --- 5. shared pattern lib is a superset of the runtime hook -----------------
+
+HOOK="$ROOT/.claude/hooks/detect-secrets.sh"
+LIB="$ROOT/core/scripts/lib/secret-patterns.sh"
+[ -f "$LIB" ] || fail "missing shared secret-pattern lib: $LIB"
+if [ -f "$HOOK" ]; then
+  # Extract each pattern literal from the hook's PATTERNS array and require it
+  # verbatim in the lib.
+  grep -oE '^  "[^"]+"' "$HOOK" | sed 's/^  //' | while IFS= read -r entry; do
+    grep -qF "$entry" "$LIB" \
+      || fail "secret-patterns.sh drifted: hook pattern $entry missing from lib"
+  done
+fi
+
+echo "hq-delegate-bundle: ok (schema valid; prefixes folder-form + bucket-relative; fail-closed on missing prd and secret match; pattern lib superset of hook)"

--- a/core/scripts/tests/hq-delegate-grant.test.sh
+++ b/core/scripts/tests/hq-delegate-grant.test.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Regression: hq-delegate-grant.sh must materialize the dossier, write the
+# manifest's grants via DIRECT ACL grants, verify each via read-back, and
+# fail closed on convention violations or unverified grants.
+#
+# Guards:
+#   1. Happy path: one sync push + one share per prefix, expected permission
+#      per prefix, every shared prefix ends in "/", manifest advances to
+#      'granted' with verifiedAt stamps.
+#   2. ACL read-back missing the grantee -> non-zero, status stays 'building'.
+#   3. A companies/<slug>/-anchored prefix -> non-zero naming the convention,
+#      nothing invoked.
+#   4. Without --yes -> exit 2, plan printed, zero mutating invocations.
+#   5. No share-session URL path: every share call carries --with (direct
+#      grant), never the bare browser-flow form.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+GRANT="$ROOT/core/scripts/hq-delegate-grant.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$GRANT" ] || fail "missing grant helper: $GRANT"
+
+# --- stub hq CLI -------------------------------------------------------------
+INVOKE_LOG="$TMP/invocations.log"
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/hq" <<'STUB'
+#!/usr/bin/env bash
+echo "$*" >> "$HQ_STUB_LOG"
+case "$1 $2" in
+  "sync push") exit 0 ;;
+  "files share") exit 0 ;;
+  "files acl")
+    resp="${HQ_STUB_ACL_RESPONSE:-}"
+    [ -n "$resp" ] || resp="grantee: alice@acme.test  permission: MATCHPERM"
+    # The stub echoes a per-permission line so grantee+permission matching is real.
+    printf '%s\n' "$resp"
+    exit 0
+    ;;
+esac
+exit 0
+STUB
+chmod +x "$TMP/bin/hq"
+export PATH="$TMP/bin:$PATH"
+export HQ_STUB_LOG="$INVOKE_LOG"
+
+write_manifest() { # path status
+  cat > "$1" <<JSON
+{
+  "schemaVersion": 1,
+  "delegationId": "dlg-test-widget",
+  "company": "acme",
+  "mode": "transfer",
+  "to": {"kind": "person", "principal": "alice@acme.test", "displayName": "Alice"},
+  "project": {"name": "widget", "prdPath": "companies/acme/projects/widget/prd.json", "boardId": null},
+  "vaultPrefixes": [
+    {"prefix": "projects/widget/", "permission": "write", "reason": "project dossier"},
+    {"prefix": "knowledge/insights/", "permission": "read", "reason": "referenced knowledge"},
+    {"prefix": "policies/", "permission": "read", "reason": "referenced policies"}
+  ],
+  "secrets": [],
+  "status": "$2"
+}
+JSON
+}
+
+# --- 4. without --yes: plan only, exit 2, zero mutations ---------------------
+
+M="$TMP/manifest.json"
+write_manifest "$M" building
+: > "$INVOKE_LOG"
+set +e
+PLAN="$(bash "$GRANT" --manifest "$M" 2>/dev/null)"
+RC=$?
+set -e
+[ "$RC" -eq 2 ] || fail "without --yes must exit 2, got $RC"
+[ ! -s "$INVOKE_LOG" ] || fail "without --yes nothing may be invoked, got: $(cat "$INVOKE_LOG")"
+printf '%s' "$PLAN" | grep -q "projects/widget/" || fail "plan must name the project prefix"
+printf '%s' "$PLAN" | grep -q "alice@acme.test" || fail "plan must name the principal"
+printf '%s' "$PLAN" | grep -qi "privilege escalation" || fail "plan must flag the write grant as a privilege escalation"
+jq -e '.status == "building"' "$M" >/dev/null || fail "plan-only run must not advance status"
+
+# --- 1. happy path -----------------------------------------------------------
+
+: > "$INVOKE_LOG"
+export HQ_STUB_ACL_RESPONSE="grantee: alice@acme.test permission: write
+grantee: alice@acme.test permission: read"
+bash "$GRANT" --manifest "$M" --yes >/dev/null 2>&1 || fail "happy path exited non-zero"
+
+grep -q "^sync push companies/acme/projects/widget/ --company acme --on-conflict keep" "$INVOKE_LOG" \
+  || fail "must push the project dir to the vault first: $(cat "$INVOKE_LOG")"
+
+SHARE_COUNT="$(grep -c '^files share' "$INVOKE_LOG")"
+[ "$SHARE_COUNT" -eq 3 ] || fail "expected exactly 3 share calls, got $SHARE_COUNT"
+grep -q '^files share projects/widget/ --with alice@acme.test --permission write --company acme$' "$INVOKE_LOG" \
+  || fail "missing write share on projects/widget/"
+grep -q '^files share knowledge/insights/ --with alice@acme.test --permission read --company acme$' "$INVOKE_LOG" \
+  || fail "missing read share on knowledge/insights/"
+grep -q '^files share policies/ --with alice@acme.test --permission read --company acme$' "$INVOKE_LOG" \
+  || fail "missing read share on policies/"
+
+# 5. direct grants only — every share carries --with (no browser/share-session flow)
+if grep '^files share' "$INVOKE_LOG" | grep -vq -- '--with'; then
+  fail "a share call omitted --with (browser/share-session flow is forbidden here)"
+fi
+
+# every shared prefix is folder form
+grep '^files share' "$INVOKE_LOG" | awk '{print $3}' | while IFS= read -r p; do
+  case "$p" in
+    */) ;;
+    *) fail "shared prefix not folder form: $p" ;;
+  esac
+done
+
+jq -e '.status == "granted"' "$M" >/dev/null || fail "manifest must advance to granted"
+jq -e 'all(.vaultPrefixes[]; .verifiedAt != null)' "$M" >/dev/null \
+  || fail "every vaultPrefix must be stamped verifiedAt"
+
+# --- 2. read-back missing grantee -> fail, status unchanged ------------------
+
+write_manifest "$M" building
+: > "$INVOKE_LOG"
+export HQ_STUB_ACL_RESPONSE="grantee: someone-else@acme.test permission: write"
+set +e
+bash "$GRANT" --manifest "$M" --yes >/dev/null 2>&1
+RC=$?
+set -e
+[ "$RC" -ne 0 ] || fail "unverified grant must exit non-zero"
+jq -e '.status == "building"' "$M" >/dev/null \
+  || fail "failed read-back must leave manifest status unchanged"
+unset HQ_STUB_ACL_RESPONSE
+
+# --- 3. company-anchored prefix -> hard error, nothing invoked ---------------
+
+write_manifest "$M" building
+TMP_M="$(mktemp)"
+jq '.vaultPrefixes[0].prefix = "companies/acme/projects/widget/"' "$M" > "$TMP_M" && mv "$TMP_M" "$M"
+: > "$INVOKE_LOG"
+set +e
+ERR="$(bash "$GRANT" --manifest "$M" --yes 2>&1 >/dev/null)"
+RC=$?
+set -e
+[ "$RC" -ne 0 ] || fail "company-anchored prefix must be a hard error"
+printf '%s' "$ERR" | grep -qi "convention" || fail "error must name the prefix-convention rule: $ERR"
+[ ! -s "$INVOKE_LOG" ] || fail "convention violation must invoke nothing: $(cat "$INVOKE_LOG")"
+
+# bare (non-folder) prefix is equally hard an error
+write_manifest "$M" building
+TMP_M="$(mktemp)"
+jq '.vaultPrefixes[1].prefix = "knowledge/insights"' "$M" > "$TMP_M" && mv "$TMP_M" "$M"
+: > "$INVOKE_LOG"
+set +e
+bash "$GRANT" --manifest "$M" --yes >/dev/null 2>&1
+RC=$?
+set -e
+[ "$RC" -ne 0 ] || fail "bare non-folder prefix must be a hard error"
+[ ! -s "$INVOKE_LOG" ] || fail "bare-prefix violation must invoke nothing"
+
+echo "hq-delegate-grant: ok (plan/confirm gate, push+share+readback, folder-form enforced, fail-closed on unverified grant, direct grants only)"

--- a/core/scripts/tests/hq-delegate-grant.test.sh
+++ b/core/scripts/tests/hq-delegate-grant.test.sh
@@ -32,6 +32,8 @@ cat > "$TMP/bin/hq" <<'STUB'
 echo "$*" >> "$HQ_STUB_LOG"
 case "$1 $2" in
   "sync push") exit 0 ;;
+  "groups create") exit 0 ;;
+  "groups add") exit 0 ;;
   "files share") exit 0 ;;
   "files acl")
     resp="${HQ_STUB_ACL_RESPONSE:-}"
@@ -61,11 +63,20 @@ write_manifest() { # path status
     {"prefix": "knowledge/insights/", "permission": "read", "reason": "referenced knowledge"},
     {"prefix": "policies/", "permission": "read", "reason": "referenced policies"}
   ],
+  "knowledge": ["companies/acme/knowledge/insights/widget-notes.md", "repos/public/widget-repo/docs/widget.md"],
+  "policies": ["companies/acme/policies/widget-policy.md"],
   "secrets": [],
   "status": "$2"
 }
 JSON
 }
+
+# Fixture HQ root so referenced knowledge exists locally for pushing
+FIXROOT="$TMP/hqroot"
+mkdir -p "$FIXROOT/companies/acme/knowledge/insights" "$FIXROOT/companies/acme/policies"
+echo note > "$FIXROOT/companies/acme/knowledge/insights/widget-notes.md"
+echo policy > "$FIXROOT/companies/acme/policies/widget-policy.md"
+export HQ_ROOT="$FIXROOT"
 
 # --- 4. without --yes: plan only, exit 2, zero mutations ---------------------
 
@@ -92,6 +103,17 @@ bash "$GRANT" --manifest "$M" --yes >/dev/null 2>&1 || fail "happy path exited n
 
 grep -q "^sync push companies/acme/projects/widget/ --company acme --on-conflict keep" "$INVOKE_LOG" \
   || fail "must push the project dir to the vault first: $(cat "$INVOKE_LOG")"
+
+# Referenced company-local knowledge/policies are pushed too (live finding:
+# a read grant on a prefix is useless if the referenced file was never
+# pushed); repo-based docs are NOT pushed.
+grep -q "^sync push companies/acme/knowledge/insights/widget-notes.md --company acme --on-conflict keep" "$INVOKE_LOG" \
+  || fail "must push referenced knowledge files: $(cat "$INVOKE_LOG")"
+grep -q "^sync push companies/acme/policies/widget-policy.md --company acme --on-conflict keep" "$INVOKE_LOG" \
+  || fail "must push referenced policy files"
+if grep '^sync push' "$INVOKE_LOG" | grep -q 'repos/'; then
+  fail "repo-based docs must never be pushed to the vault"
+fi
 
 SHARE_COUNT="$(grep -c '^files share' "$INVOKE_LOG")"
 [ "$SHARE_COUNT" -eq 3 ] || fail "expected exactly 3 share calls, got $SHARE_COUNT"
@@ -159,4 +181,29 @@ set -e
 [ "$RC" -ne 0 ] || fail "bare non-folder prefix must be a hard error"
 [ ! -s "$INVOKE_LOG" ] || fail "bare-prefix violation must invoke nothing"
 
-echo "hq-delegate-grant: ok (plan/confirm gate, push+share+readback, folder-form enforced, fail-closed on unverified grant, direct grants only)"
+# --- agent recipient: grants flow through a per-agent delegation group -------
+# (Live finding: `hq files share --with` rejects agt_ principals — only
+# email/grp_/@all are valid file-ACL grantees. Agent grants use grp_dlg-<tail>.)
+
+write_manifest "$M" building
+TMP_M="$(mktemp)"
+jq '.to = {"kind": "agent", "principal": "agt_01KTXDEACON", "displayName": "Deacon"}' "$M" > "$TMP_M" && mv "$TMP_M" "$M"
+: > "$INVOKE_LOG"
+export HQ_STUB_ACL_RESPONSE="grantee: group:grp_dlg-ktxdeacon permission: write
+grantee: group:grp_dlg-ktxdeacon permission: read"
+bash "$GRANT" --manifest "$M" --yes >/dev/null 2>&1 || fail "agent-recipient grant run exited non-zero"
+
+grep -q '^groups create grp_dlg-ktxdeacon --name Delegation: Deacon --company acme$' "$INVOKE_LOG" \
+  || fail "agent recipient must ensure the delegation group exists: $(cat "$INVOKE_LOG")"
+grep -q '^groups add grp_dlg-ktxdeacon agt_01KTXDEACON --company acme$' "$INVOKE_LOG" \
+  || fail "agent recipient must be added to the delegation group"
+if grep '^files share' "$INVOKE_LOG" | grep -q 'agt_'; then
+  fail "files share must never receive a raw agt_ principal"
+fi
+grep -q '^files share projects/widget/ --with grp_dlg-ktxdeacon --permission write --company acme$' "$INVOKE_LOG" \
+  || fail "agent write grant must target the delegation group"
+jq -e '.status == "granted" and .grantPrincipal == "grp_dlg-ktxdeacon"' "$M" >/dev/null \
+  || fail "manifest must record the group grant principal"
+unset HQ_STUB_ACL_RESPONSE
+
+echo "hq-delegate-grant: ok (plan/confirm gate, push+share+readback, folder-form enforced, fail-closed on unverified grant, direct grants only, agent-via-group)"

--- a/core/scripts/tests/hq-delegate-repo.test.sh
+++ b/core/scripts/tests/hq-delegate-repo.test.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Regression: hq-delegate-repo.sh must hand over the code branch with an
+# explicit repo anchor, record dirty work as NOT transferred, verify access
+# read-only, and never leak repo paths into vault prefixes.
+#
+# Guards (uses a REAL git fixture — local clone + bare origin):
+#   1. Local-only branch + --yes -> pushed with `git -C ... push -u origin`,
+#      visible in the bare origin, headSha recorded, branchPushed=true.
+#   2. Local-only branch without --yes -> exit 2, branch NOT pushed.
+#   3. Dirty/untracked files -> recorded in repo.dirtyFiles[] AND called out
+#      in BRIEF.md as not transferred.
+#   4. gh access check failure -> accessVerified=false, note says UNVERIFIED;
+#      no step claims access exists.
+#   5. vaultPrefixes[] untouched and free of repos/ paths.
+#   6. repo: null -> clean exit 0, nothing changed.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+HELPER="$ROOT/core/scripts/hq-delegate-repo.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$HELPER" ] || fail "missing helper: $HELPER"
+
+# --- real git fixture: bare origin + working clone under a fake HQ root ------
+
+FIX="$TMP/hqroot"
+mkdir -p "$FIX/repos/public" "$TMP/origin"
+git init --bare --quiet --initial-branch=main "$TMP/origin/widget-repo.git"
+git -C "$FIX/repos/public" clone --quiet "$TMP/origin/widget-repo.git" widget-repo 2>/dev/null
+REPO="$FIX/repos/public/widget-repo"
+git -C "$REPO" config user.email test@test.local
+git -C "$REPO" config user.name Test
+echo "hello" > "$REPO/README.md"
+git -C "$REPO" add README.md
+git -C "$REPO" commit --quiet -m "init"
+git -C "$REPO" push --quiet -u origin main 2>/dev/null
+git -C "$REPO" switch --quiet -c feature/widget
+echo "wip" > "$REPO/feature.txt"
+git -C "$REPO" add feature.txt
+git -C "$REPO" commit --quiet -m "feature work"
+# leave dirty + untracked work behind
+echo "uncommitted" >> "$REPO/README.md"
+echo "scratch" > "$REPO/notes.tmp"
+
+# stub gh: always 404s the collaborator check
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+echo "$*" >> "$GH_STUB_LOG"
+exit 1
+STUB
+chmod +x "$TMP/bin/gh"
+export PATH="$TMP/bin:$PATH"
+export GH_STUB_LOG="$TMP/gh.log"
+
+# --- bundle fixture ----------------------------------------------------------
+
+BUNDLE="$TMP/bundle"
+mkdir -p "$BUNDLE"
+MANIFEST="$BUNDLE/manifest.json"
+cat > "$MANIFEST" <<'JSON'
+{
+  "schemaVersion": 1,
+  "delegationId": "dlg-test-widget",
+  "company": "acme",
+  "to": {"kind": "person", "principal": "alice@acme.test"},
+  "project": {"name": "widget"},
+  "vaultPrefixes": [
+    {"prefix": "projects/widget/", "permission": "write", "reason": "project dossier"}
+  ],
+  "repo": {"path": "repos/public/widget-repo", "remote": null, "branch": "feature/widget",
+           "baseBranch": "main", "headSha": null, "dirtyFiles": [], "accessVerified": false},
+  "status": "building"
+}
+JSON
+echo "# Delegation brief — widget" > "$BUNDLE/BRIEF.md"
+PREFIXES_BEFORE="$(jq -c '.vaultPrefixes' "$MANIFEST")"
+
+# --- 2. without --yes: exit 2, branch not pushed -----------------------------
+
+set +e
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$MANIFEST" >/dev/null 2>&1
+RC=$?
+set -e
+[ "$RC" -eq 2 ] || fail "local-only branch without --yes must exit 2, got $RC"
+git -C "$TMP/origin/widget-repo.git" rev-parse --verify --quiet refs/heads/feature/widget >/dev/null \
+  && fail "branch must NOT be pushed without --yes"
+
+# --- 1+3+4. with --yes: push, record dirty, unverified access ----------------
+
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$MANIFEST" --yes --github-user alicehub >/dev/null 2>&1 \
+  || fail "handover with --yes exited non-zero"
+
+# 1. branch landed in the bare origin; manifest records it
+git -C "$TMP/origin/widget-repo.git" rev-parse --verify --quiet refs/heads/feature/widget >/dev/null \
+  || fail "branch was not pushed to origin"
+LOCAL_SHA="$(git -C "$REPO" rev-parse refs/heads/feature/widget)"
+jq -e --arg sha "$LOCAL_SHA" '.repo.headSha == $sha and .repo.branchPushed == true' "$MANIFEST" >/dev/null \
+  || fail "manifest must record the pushed headSha: $(jq -c '.repo' "$MANIFEST")"
+
+# 3. dirty + untracked recorded and surfaced in the brief
+jq -e '.repo.dirtyFiles | index("README.md") and index("notes.tmp")' "$MANIFEST" >/dev/null \
+  || fail "dirty and untracked files must land in repo.dirtyFiles: $(jq -c '.repo.dirtyFiles' "$MANIFEST")"
+grep -q "not transferred" "$BUNDLE/BRIEF.md" || fail "BRIEF must call out untransferred work"
+grep -q "README.md" "$BUNDLE/BRIEF.md" || fail "BRIEF must name the dirty files"
+
+# 4. gh 404 -> unverified, stated plainly, never claimed
+grep -q "collaborators/alicehub" "$GH_STUB_LOG" || fail "gh collaborator check was not invoked"
+jq -e '.repo.accessVerified == false' "$MANIFEST" >/dev/null \
+  || fail "failed gh check must leave accessVerified=false"
+jq -e '.repo.accessNote | test("UNVERIFIED")' "$MANIFEST" >/dev/null \
+  || fail "manifest accessNote must say UNVERIFIED"
+grep -q "UNVERIFIED" "$BUNDLE/BRIEF.md" || fail "BRIEF must state access is unverified"
+
+# --- 5. vaultPrefixes untouched, no repos/ paths -----------------------------
+
+[ "$(jq -c '.vaultPrefixes' "$MANIFEST")" = "$PREFIXES_BEFORE" ] \
+  || fail "handover must not touch vaultPrefixes"
+jq -e 'all(.vaultPrefixes[]; .prefix | startswith("repos/") | not)' "$MANIFEST" >/dev/null \
+  || fail "vaultPrefixes must contain no repos/ path"
+
+# --- 6. repo: null skips cleanly ---------------------------------------------
+
+NULL_MANIFEST="$TMP/null-manifest.json"
+jq '.repo = null' "$MANIFEST" > "$NULL_MANIFEST"
+BEFORE="$(cat "$NULL_MANIFEST")"
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$NULL_MANIFEST" >/dev/null 2>&1 \
+  || fail "repo:null project must skip cleanly with exit 0"
+[ "$(cat "$NULL_MANIFEST")" = "$BEFORE" ] || fail "repo:null run must change nothing"
+
+echo "hq-delegate-repo: ok (anchored push behind --yes, dirty work surfaced, access unverified stated plainly, vaultPrefixes untouched, null skip)"

--- a/core/scripts/tests/hq-delegate-resolve.test.sh
+++ b/core/scripts/tests/hq-delegate-resolve.test.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Regression: hq-delegate-resolve.sh must resolve delegation recipients
+# safely — verbatim fast path, confirmed people lookups, fleet-agent
+# fallback — while staying read-only and strictly single-company.
+#
+# Guards:
+#   1. Fast path: email / prs_ / agt_ tokens pass through verbatim with NO
+#      lookup invoked.
+#   2. A bare name resolving to exactly one person exits 0 with that email.
+#   3. An ambiguous name exits 3 and prints the candidate list.
+#   4. A name matching only a fleet agent exits 0 with kind=agent.
+#   5. Every stubbed hq invocation carries --company <slug>; none names
+#      another company; nothing is invoked without it (tenancy).
+#   6. Missing --company is a usage error before any lookup.
+#   7. not-found in both rosters exits 4 with a plain message.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+RESOLVE="$ROOT/core/scripts/hq-delegate-resolve.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$RESOLVE" ] || fail "missing resolver: $RESOLVE"
+
+# --- stub hq CLI -------------------------------------------------------------
+# Records every invocation; behavior driven by env:
+#   HQ_STUB_PEOPLE_JSON — response for `hq people resolve`
+#   HQ_STUB_AGENTS_JSON — response for `hq agents list`
+INVOKE_LOG="$TMP/invocations.log"
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/hq" <<'STUB'
+#!/usr/bin/env bash
+echo "$*" >> "$HQ_STUB_LOG"
+people_resp="${HQ_STUB_PEOPLE_JSON:-}"
+[ -n "$people_resp" ] || people_resp='{"status":"not_found"}'
+agents_resp="${HQ_STUB_AGENTS_JSON:-}"
+[ -n "$agents_resp" ] || agents_resp='[]'
+case "$1 $2" in
+  "people resolve")
+    echo "warning: noise line the parser must skip"
+    printf '%s\n' "$people_resp"
+    ;;
+  "agents list")
+    printf '%s\n' "$agents_resp"
+    ;;
+esac
+exit 0
+STUB
+chmod +x "$TMP/bin/hq"
+export PATH="$TMP/bin:$PATH"
+export HQ_STUB_LOG="$INVOKE_LOG"
+
+run() { # token [env overrides via pre-set vars]
+  : > "$INVOKE_LOG"
+  bash "$RESOLVE" --company acme --to "$1"
+}
+
+# --- 1. fast path: verbatim, zero lookups ------------------------------------
+
+OUT="$(run "alice@acme.test")" || fail "email fast path exited non-zero"
+printf '%s' "$OUT" | jq -e '.kind == "person" and .principal == "alice@acme.test" and .source == "verbatim"' >/dev/null \
+  || fail "email fast path wrong output: $OUT"
+[ ! -s "$INVOKE_LOG" ] || fail "email fast path must invoke NO lookup, got: $(cat "$INVOKE_LOG")"
+
+OUT="$(run "prs_abc123")" || fail "prs_ fast path exited non-zero"
+printf '%s' "$OUT" | jq -e '.kind == "person" and .principal == "prs_abc123"' >/dev/null \
+  || fail "prs_ fast path wrong output: $OUT"
+[ ! -s "$INVOKE_LOG" ] || fail "prs_ fast path must invoke no lookup"
+
+OUT="$(run "agt_xyz789")" || fail "agt_ fast path exited non-zero"
+printf '%s' "$OUT" | jq -e '.kind == "agent" and .principal == "agt_xyz789"' >/dev/null \
+  || fail "agt_ fast path wrong output: $OUT"
+[ ! -s "$INVOKE_LOG" ] || fail "agt_ fast path must invoke no lookup"
+
+# --- 2. unique person match --------------------------------------------------
+
+export HQ_STUB_PEOPLE_JSON='{"status":"found","email":"stefan@acme.test","name":"Stefan Walsh"}'
+OUT="$(run "stefan")" || fail "unique person match exited non-zero"
+printf '%s' "$OUT" | jq -e '.kind == "person" and .principal == "stefan@acme.test" and .displayName == "Stefan Walsh" and .source == "people-resolve"' >/dev/null \
+  || fail "unique person match wrong output: $OUT"
+
+# --- 3. ambiguous person -> exit 3 + candidates ------------------------------
+
+export HQ_STUB_PEOPLE_JSON='{"status":"ambiguous","matches":[{"name":"Sam A","email":"sama@acme.test"},{"name":"Sam B","email":"samb@acme.test"}]}'
+set +e
+OUT="$(run "sam")"
+RC=$?
+set -e
+[ "$RC" -eq 3 ] || fail "ambiguous person must exit 3, got $RC"
+printf '%s' "$OUT" | jq -e '.status == "ambiguous" and (.matches | length) == 2' >/dev/null \
+  || fail "ambiguous person must print both candidates: $OUT"
+
+# --- 4. agent fallback -------------------------------------------------------
+
+export HQ_STUB_PEOPLE_JSON='{"status":"not_found"}'
+export HQ_STUB_AGENTS_JSON='[{"agentUid":"agt_01DEACON","name":"Deacon"},{"agentUid":"agt_01OTHER","name":"Scout"}]'
+OUT="$(run "deacon")" || fail "agent fallback exited non-zero"
+printf '%s' "$OUT" | jq -e '.kind == "agent" and .principal == "agt_01DEACON" and .displayName == "Deacon" and .source == "agents-list"' >/dev/null \
+  || fail "agent fallback wrong output: $OUT"
+
+# --- 5. tenancy: every lookup carries --company acme, no other company -------
+
+grep -q 'people resolve' "$INVOKE_LOG" || fail "expected a people lookup in the agent-fallback run"
+while IFS= read -r line; do
+  case "$line" in
+    *"--company acme"*) ;;
+    *) fail "lookup invoked without --company acme: '$line'" ;;
+  esac
+done < "$INVOKE_LOG"
+! grep -vq 'acme' "$INVOKE_LOG" >/dev/null 2>&1 || true # every line already checked above
+
+# --- 6. missing --company = usage error, zero lookups ------------------------
+
+: > "$INVOKE_LOG"
+set +e
+bash "$RESOLVE" --to "somebody" >/dev/null 2>&1
+RC=$?
+set -e
+[ "$RC" -eq 1 ] || fail "missing --company must exit 1 (usage), got $RC"
+[ ! -s "$INVOKE_LOG" ] || fail "missing --company must invoke no lookup"
+
+# --- 7. not found anywhere -> exit 4, plain message --------------------------
+
+export HQ_STUB_PEOPLE_JSON='{"status":"not_found"}'
+export HQ_STUB_AGENTS_JSON='[]'
+set +e
+ERR="$(run "nobody" 2>&1 >/dev/null)"
+RC=$?
+set -e
+[ "$RC" -eq 4 ] || fail "not-found must exit 4, got $RC"
+case "$ERR" in
+  *nobody*acme*) ;;
+  *) fail "not-found message must name the token and company: '$ERR'" ;;
+esac
+
+# no_email also stops with exit 4
+export HQ_STUB_PEOPLE_JSON='{"status":"no_email"}'
+set +e
+run "ghost" >/dev/null 2>&1
+RC=$?
+set -e
+[ "$RC" -eq 4 ] || fail "no_email must exit 4, got $RC"
+
+echo "hq-delegate-resolve: ok (verbatim fast path, person/agent resolution, ambiguous=3, not-found=4, single-company enforced)"

--- a/core/scripts/tests/hq-delegate-resolve.test.sh
+++ b/core/scripts/tests/hq-delegate-resolve.test.sh
@@ -135,12 +135,22 @@ case "$ERR" in
   *) fail "not-found message must name the token and company: '$ERR'" ;;
 esac
 
-# no_email also stops with exit 4
+# no_email with no agent match stops with exit 4
 export HQ_STUB_PEOPLE_JSON='{"status":"no_email"}'
+export HQ_STUB_AGENTS_JSON='[]'
 set +e
 run "ghost" >/dev/null 2>&1
 RC=$?
 set -e
 [ "$RC" -eq 4 ] || fail "no_email must exit 4, got $RC"
+
+# no_email BUT the name matches a fleet agent -> resolves as that agent.
+# (Live finding: fleet agents appear in the people roster without an email;
+# stopping at no_email would make agents unreachable by name.)
+export HQ_STUB_PEOPLE_JSON='{"status":"no_email"}'
+export HQ_STUB_AGENTS_JSON='[{"agentUid":"agt_01DEACON","name":"Deacon"}]'
+OUT="$(run "deacon")" || fail "no_email + agent match must resolve, not stop"
+printf '%s' "$OUT" | jq -e '.kind == "agent" and .principal == "agt_01DEACON" and .source == "agents-list"' >/dev/null \
+  || fail "no_email + agent match must resolve to the agent: $OUT"
 
 echo "hq-delegate-resolve: ok (verbatim fast path, person/agent resolution, ambiguous=3, not-found=4, single-company enforced)"

--- a/core/scripts/tests/hq-delegate-secrets.test.sh
+++ b/core/scripts/tests/hq-delegate-secrets.test.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Regression: hq-delegate-secrets.sh must grant secret access BY NAME ONLY —
+# no command may ever read, print, or transmit a secret value — behind its
+# own explicit confirmation, with --no-secrets and no-schema paths that
+# grant nothing.
+#
+# Guards:
+#   1. Schema with 3 names + --yes -> exactly those 3 names shared with
+#      --permission read; the stub's value-read commands (get/env/exec/
+#      --reveal) are NEVER invoked; manifest records names only.
+#   2. --no-secrets -> zero invocations, {secrets: [], secretsSkipped: true}.
+#   3. Without --yes -> exit 2, zero invocations, prose lists names +
+#      principal.
+#   4. No .env.schema -> secrets: [], plain report, exit 0, zero grants.
+#   5. A sentinel secret VALUE planted in the stub store never appears in
+#      the manifest or anywhere in the bundle.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+HELPER="$ROOT/core/scripts/hq-delegate-secrets.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$HELPER" ] || fail "missing helper: $HELPER"
+
+# --- stub hq CLI with a sentinel value that must never surface ---------------
+SENTINEL="sentinel-value-Zx9Qw7-never-leaks"
+INVOKE_LOG="$TMP/invocations.log"
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/hq" <<STUB
+#!/usr/bin/env bash
+echo "\$*" >> "\$HQ_STUB_LOG"
+case "\$1 \$2" in
+  "secrets share") exit 0 ;;
+  "secrets get"|"secrets env"|"secrets exec")
+    echo "$SENTINEL"
+    exit 0
+    ;;
+esac
+exit 0
+STUB
+chmod +x "$TMP/bin/hq"
+export PATH="$TMP/bin:$PATH"
+export HQ_STUB_LOG="$INVOKE_LOG"
+
+# --- fixture: HQ root, project with .env.schema, bundle ----------------------
+
+FIX="$TMP/hqroot"
+PROJ="$FIX/companies/acme/projects/widget"
+mkdir -p "$PROJ"
+cat > "$PROJ/.env.schema" <<'SCHEMA'
+# Widget runtime credentials
+DATABASE_URL=
+WIDGET_API_KEY=
+STRIPE_WEBHOOK_SECRET=
+SCHEMA
+
+BUNDLE="$FIX/workspace/delegations/dlg-test-widget"
+mkdir -p "$BUNDLE"
+MANIFEST="$BUNDLE/manifest.json"
+write_manifest() {
+  cat > "$MANIFEST" <<'JSON'
+{
+  "schemaVersion": 1,
+  "delegationId": "dlg-test-widget",
+  "company": "acme",
+  "to": {"kind": "person", "principal": "alice@acme.test"},
+  "project": {"name": "widget"},
+  "repo": null,
+  "secrets": [],
+  "status": "building"
+}
+JSON
+}
+write_manifest
+echo "# Delegation brief — widget" > "$BUNDLE/BRIEF.md"
+
+# --- 3. without --yes: exit 2, prose plan, zero invocations ------------------
+
+: > "$INVOKE_LOG"
+set +e
+PLAN="$(HQ_ROOT="$FIX" bash "$HELPER" --manifest "$MANIFEST" 2>/dev/null)"
+RC=$?
+set -e
+[ "$RC" -eq 2 ] || fail "without --yes must exit 2, got $RC"
+[ ! -s "$INVOKE_LOG" ] || fail "without --yes nothing may be invoked: $(cat "$INVOKE_LOG")"
+printf '%s' "$PLAN" | grep -q "WIDGET_API_KEY" || fail "confirmation prose must list the names"
+printf '%s' "$PLAN" | grep -q "alice@acme.test" || fail "confirmation prose must name the principal"
+jq -e '.secrets == []' "$MANIFEST" >/dev/null || fail "declined run must not record names"
+
+# --- 1. with --yes: names granted, values never read -------------------------
+
+: > "$INVOKE_LOG"
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$MANIFEST" --yes >/dev/null 2>&1 \
+  || fail "grant run exited non-zero"
+
+SHARE_COUNT="$(grep -c '^secrets share' "$INVOKE_LOG")"
+[ "$SHARE_COUNT" -eq 3 ] || fail "expected exactly 3 share calls, got $SHARE_COUNT: $(cat "$INVOKE_LOG")"
+for name in DATABASE_URL WIDGET_API_KEY STRIPE_WEBHOOK_SECRET; do
+  grep -q "^secrets share $name --with alice@acme.test --permission read --company acme$" "$INVOKE_LOG" \
+    || fail "missing read share for $name"
+done
+
+# value-read commands must never run
+if grep -Eq '^secrets (get|env|exec)|--reveal' "$INVOKE_LOG"; then
+  fail "a value-reading command was invoked: $(cat "$INVOKE_LOG")"
+fi
+
+jq -e '.secrets == ["DATABASE_URL","STRIPE_WEBHOOK_SECRET","WIDGET_API_KEY"] and .secretsSkipped == false and .secretsGrantedAt != null' \
+  "$MANIFEST" >/dev/null || fail "manifest must record exactly the granted names: $(jq -c '.secrets' "$MANIFEST")"
+
+# --- 5. the sentinel value appears nowhere in the bundle ---------------------
+
+if grep -r "$SENTINEL" "$BUNDLE" >/dev/null 2>&1; then
+  fail "a secret VALUE leaked into the bundle"
+fi
+
+# --- 2. --no-secrets: zero invocations, skipped recorded ---------------------
+
+write_manifest
+: > "$INVOKE_LOG"
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$MANIFEST" --no-secrets >/dev/null 2>&1 \
+  || fail "--no-secrets run exited non-zero"
+[ ! -s "$INVOKE_LOG" ] || fail "--no-secrets must invoke nothing"
+jq -e '.secrets == [] and .secretsSkipped == true' "$MANIFEST" >/dev/null \
+  || fail "--no-secrets must record secrets: [] with skipped: true"
+
+# --- 4. no .env.schema: plain report, zero grants, exit 0 --------------------
+
+write_manifest
+rm "$PROJ/.env.schema"
+: > "$INVOKE_LOG"
+OUT="$(HQ_ROOT="$FIX" bash "$HELPER" --manifest "$MANIFEST" --yes 2>&1)" \
+  || fail "no-schema run must exit 0"
+[ ! -s "$INVOKE_LOG" ] || fail "no-schema run must grant nothing"
+printf '%s' "$OUT" | grep -qi "no .env.schema" || fail "no-schema run must say so plainly: $OUT"
+jq -e '.secrets == [] and .secretsSkipped == false' "$MANIFEST" >/dev/null \
+  || fail "no-schema run must record empty secrets without the skipped flag"
+
+echo "hq-delegate-secrets: ok (names only, own confirm gate, --no-secrets and no-schema paths, sentinel value never surfaced)"

--- a/core/scripts/tests/hq-delegate-send.test.sh
+++ b/core/scripts/tests/hq-delegate-send.test.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Regression: hq-delegate-send.sh must generate a pickup prompt covered
+# one-to-one against the manifest, deliver exactly one hq dm with file
+# flags, refuse to send before verification, and fail closed on secret or
+# share-session content.
+#
+# Guards:
+#   1. Manifest with 4 vault prefixes -> prompt contains exactly those 4
+#      `hq files get` lines (each exactly once) and no others.
+#   2. --send on a verified manifest -> exactly ONE hq dm invocation using
+#      --prompt-file and --details-file; status -> sent; eventId recorded.
+#   3. Prompt and brief scanned: no secret-pattern match, no share-session
+#      URL shape.
+#   4. repo: null -> no git/checkout section, no branch reference.
+#   5. --send with status != verified -> refused, no dm invocation.
+#   6. A share-session URL smuggled into the brief -> send aborts.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+HELPER="$ROOT/core/scripts/hq-delegate-send.sh"
+LIB="$ROOT/core/scripts/lib/secret-patterns.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$HELPER" ] || fail "missing helper: $HELPER"
+[ -f "$LIB" ] || fail "missing secret-pattern lib: $LIB"
+
+# --- stub hq CLI -------------------------------------------------------------
+INVOKE_LOG="$TMP/invocations.log"
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/hq" <<'STUB'
+#!/usr/bin/env bash
+echo "$*" >> "$HQ_STUB_LOG"
+if [ "$1" = "dm" ]; then
+  echo "DM sent to $2 (eventId evt_stub123)"
+fi
+exit 0
+STUB
+chmod +x "$TMP/bin/hq"
+export PATH="$TMP/bin:$PATH"
+export HQ_STUB_LOG="$INVOKE_LOG"
+
+# --- fixture -----------------------------------------------------------------
+
+FIX="$TMP/hqroot"
+PROJ="$FIX/companies/acme/projects/widget"
+mkdir -p "$PROJ"
+cat > "$PROJ/prd.json" <<'JSON'
+{
+  "name": "widget",
+  "description": "Build the widget.",
+  "metadata": {"goal": "Widgets ship."},
+  "userStories": [
+    {"id": "US-001", "title": "Frame", "description": "Build the frame.", "priority": 1, "passes": true},
+    {"id": "US-002", "title": "Spin", "description": "Make it spin.", "priority": 1, "passes": false}
+  ]
+}
+JSON
+
+BUNDLE="$FIX/workspace/delegations/dlg-test-widget"
+mkdir -p "$BUNDLE"
+MANIFEST="$BUNDLE/manifest.json"
+write_manifest() { # status repo_json
+  cat > "$MANIFEST" <<JSON
+{
+  "schemaVersion": 1,
+  "delegationId": "dlg-test-widget",
+  "mode": "transfer",
+  "company": "acme",
+  "from": {"email": "owner@acme.test", "personUid": null},
+  "to": {"kind": "person", "principal": "alice@acme.test", "displayName": "Alice"},
+  "project": {"name": "widget", "prdPath": "companies/acme/projects/widget/prd.json", "boardId": null},
+  "vaultPrefixes": [
+    {"prefix": "projects/widget/", "permission": "write", "reason": "project dossier"},
+    {"prefix": "knowledge/insights/", "permission": "read", "reason": "knowledge"},
+    {"prefix": "knowledge/eng/", "permission": "read", "reason": "knowledge"},
+    {"prefix": "policies/", "permission": "read", "reason": "policies"}
+  ],
+  "repo": $2,
+  "secrets": ["DATABASE_URL", "WIDGET_API_KEY"],
+  "status": "$1"
+}
+JSON
+}
+REPO_JSON='{"path": "repos/public/widget-repo", "remote": "git@github.test:acme/widget-repo.git", "branch": "feature/widget", "baseBranch": "main", "headSha": "abc1234", "dirtyFiles": [], "accessVerified": true, "accessNote": ""}'
+echo "# Delegation brief — widget" > "$BUNDLE/BRIEF.md"
+
+# --- 1. prompt covers the manifest one-to-one --------------------------------
+
+write_manifest verified "$REPO_JSON"
+: > "$INVOKE_LOG"
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$MANIFEST" >/dev/null 2>&1 \
+  || fail "prompt generation exited non-zero"
+PROMPT="$BUNDLE/PICKUP-PROMPT.md"
+[ -f "$PROMPT" ] || fail "PICKUP-PROMPT.md not written"
+
+GET_COUNT="$(grep -c '^hq files get ' "$PROMPT")"
+[ "$GET_COUNT" -eq 4 ] || fail "expected exactly 4 hq files get lines, got $GET_COUNT"
+for p in "projects/widget/" "knowledge/insights/" "knowledge/eng/" "policies/"; do
+  C="$(grep -c "^hq files get $p --company acme$" "$PROMPT")"
+  [ "$C" -eq 1 ] || fail "prefix $p must appear exactly once, got $C"
+done
+
+# ordered essentials: goal, state, next steps, repo, secrets consumption
+for needle in "Widgets ship." "1 of 2 stories" "US-002" \
+  "git -C repos/public/widget-repo fetch origin" \
+  "git -C repos/public/widget-repo switch feature/widget" \
+  "hq secrets exec --only DATABASE_URL,WIDGET_API_KEY" \
+  "hq run --"; do
+  grep -qF "$needle" "$PROMPT" || fail "prompt missing: $needle"
+done
+grep -q "no /hq-sync run" "$PROMPT" || fail "prompt must state no sync is needed"
+
+# generation alone must not send
+[ ! -s "$INVOKE_LOG" ] || fail "generation without --send must invoke nothing: $(cat "$INVOKE_LOG")"
+
+# --- 3. no secrets, no share-session shapes ----------------------------------
+
+(
+  # shellcheck source=/dev/null
+  . "$LIB"
+  hq_scan_secrets "$PROMPT" "$BUNDLE/BRIEF.md"
+) || fail "prompt or brief matched a secret pattern"
+if grep -Eq 'share-session/' "$PROMPT" "$BUNDLE/BRIEF.md"; then
+  fail "a share-session URL shape appeared in a delegation artifact"
+fi
+
+# --- 2. --send on verified: one dm, file flags, status sent ------------------
+
+: > "$INVOKE_LOG"
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$MANIFEST" --send >/dev/null 2>&1 \
+  || fail "send exited non-zero"
+DM_COUNT="$(grep -c '^dm ' "$INVOKE_LOG")"
+[ "$DM_COUNT" -eq 1 ] || fail "expected exactly one hq dm invocation, got $DM_COUNT"
+grep '^dm alice@acme.test ' "$INVOKE_LOG" | grep -q -- '--prompt-file' \
+  || fail "dm must use --prompt-file"
+grep '^dm alice@acme.test ' "$INVOKE_LOG" | grep -q -- '--details-file' \
+  || fail "dm must use --details-file"
+jq -e '.status == "sent" and .dmEventId == "evt_stub123" and .sentAt != null' "$MANIFEST" >/dev/null \
+  || fail "manifest must record sent status + eventId: $(jq -c '{status, dmEventId}' "$MANIFEST")"
+
+# --- 5. --send before verification is refused --------------------------------
+
+write_manifest granted "$REPO_JSON"
+: > "$INVOKE_LOG"
+set +e
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$MANIFEST" --send >/dev/null 2>&1
+RC=$?
+set -e
+[ "$RC" -ne 0 ] || fail "--send must refuse when status is not 'verified'"
+if grep -q '^dm ' "$INVOKE_LOG"; then fail "no dm may be sent before verification"; fi
+jq -e '.status == "granted"' "$MANIFEST" >/dev/null || fail "refused send must not advance status"
+
+# --- 4. repo: null -> no git section -----------------------------------------
+
+write_manifest verified null
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$MANIFEST" >/dev/null 2>&1 \
+  || fail "repo:null generation exited non-zero"
+if grep -Eq 'git (fetch|switch|checkout)|git -C' "$PROMPT"; then
+  fail "repo:null prompt must contain no git section"
+fi
+grep -q "feature/widget" "$PROMPT" && fail "repo:null prompt must not reference a branch" || true
+
+# --- 6. share-session URL smuggled into the brief -> abort -------------------
+
+write_manifest verified "$REPO_JSON"
+echo "see https://hq.example.com/share-session/tok123abc" >> "$BUNDLE/BRIEF.md"
+: > "$INVOKE_LOG"
+set +e
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$MANIFEST" --send >/dev/null 2>&1
+RC=$?
+set -e
+[ "$RC" -ne 0 ] || fail "a share-session URL in the brief must abort the send"
+if grep -q '^dm ' "$INVOKE_LOG"; then fail "no dm may be sent when a share-session URL is present"; fi
+
+echo "hq-delegate-send: ok (one-to-one prefix coverage, single file-flag dm, verify-before-send, repo-null clean, secret/share-session fail-closed)"

--- a/core/scripts/tests/hq-delegate-skill.test.sh
+++ b/core/scripts/tests/hq-delegate-skill.test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Regression: the /delegate skill must wire the eight tested helpers into a
+# single confirmed flow — structural contract on SKILL.md, plus the shipped
+# helper scripts it references must exist and be runnable.
+#
+# Guards:
+#   1. Skill exists with scoped frontmatter (name, description,
+#      allowed-tools including AskUserQuestion for the confirm/picker).
+#   2. Every hq-delegate-*.sh helper is referenced AND exists on disk.
+#   3. Ambiguous resolution (exit 3) is handled with a structured picker;
+#      not-found stops; never sends blind.
+#   4. Exactly-one-confirmation contract: the gated helpers are first run
+#      WITHOUT --yes (plan mode), and the confirmation section precedes
+#      execution with --yes.
+#   5. Decline path: cancel deletes the bundle and mutates nothing.
+#   6. Failure path: report the failing step, never claim partial success;
+#      probe failure means no DM.
+#   7. Dry-run documented as fully inert.
+#   8. Humanize pass wired for the DM headline; success report is one plain
+#      sentence.
+#   9. Both hard policies are stated: no share-session URLs, no secret
+#      values.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SKILL="$ROOT/.claude/skills/delegate/SKILL.md"
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$SKILL" ] || fail "missing delegate skill: $SKILL"
+
+# 1. frontmatter
+grep -q '^name: delegate$' "$SKILL" || fail "frontmatter must declare name: delegate"
+grep -q '^description: ' "$SKILL" || fail "frontmatter must carry a description"
+grep -q '^allowed-tools: .*AskUserQuestion' "$SKILL" \
+  || fail "allowed-tools must include AskUserQuestion (picker + confirmation)"
+
+# 2. every helper referenced and shipped
+for helper in hq-delegate-resolve hq-delegate-bundle hq-delegate-grant \
+  hq-delegate-repo hq-delegate-secrets hq-delegate-transfer \
+  hq-delegate-verify hq-delegate-send; do
+  grep -q "core/scripts/$helper.sh" "$SKILL" \
+    || fail "skill must reference core/scripts/$helper.sh"
+  [ -f "$ROOT/core/scripts/$helper.sh" ] \
+    || fail "referenced helper missing from tree: core/scripts/$helper.sh"
+  bash -n "$ROOT/core/scripts/$helper.sh" \
+    || fail "helper does not parse: core/scripts/$helper.sh"
+done
+
+# 3. resolution outcomes
+grep -q 'Exit 3' "$SKILL" || fail "skill must handle the ambiguous (exit 3) outcome"
+grep -q 'Exit 4' "$SKILL" || fail "skill must handle the not-found (exit 4) outcome"
+grep -qi 'never send blind' "$SKILL" || fail "skill must state it never sends blind"
+grep -qi 'single-company' "$SKILL" || fail "skill must state resolution is single-company"
+
+# 4. one-confirmation contract: plan (no --yes) before the gate, --yes after
+grep -q 'WITHOUT `--yes`' "$SKILL" || fail "plan collection must run helpers without --yes"
+grep -qi 'exactly one structured confirmation\|one structured confirmation (AskUserQuestion) before any mutation' "$SKILL" \
+  || fail "skill must promise exactly one confirmation before mutation"
+# ordering: the "collect the plan" section must appear before "--yes" execution
+PLAN_LINE="$(grep -n 'Collect the plan' "$SKILL" | head -1 | cut -d: -f1)"
+EXEC_LINE="$(grep -n -- '--manifest <manifest> --yes' "$SKILL" | head -1 | cut -d: -f1)"
+[ -n "$PLAN_LINE" ] && [ -n "$EXEC_LINE" ] && [ "$PLAN_LINE" -lt "$EXEC_LINE" ] \
+  || fail "plan collection must precede --yes execution"
+
+# 5. decline path
+grep -qi 'On cancel' "$SKILL" || fail "skill must document the cancel path"
+grep -q 'delete `workspace/delegations/' "$SKILL" \
+  || fail "cancel must delete the bundle"
+grep -qi 'confirm nothing was granted' "$SKILL" \
+  || fail "cancel must confirm nothing mutated"
+
+# 6. failure semantics
+grep -qi 'never claim partial success' "$SKILL" || fail "skill must never claim partial success"
+grep -qi 'failed probe means no DM' "$SKILL" || fail "probe failure must block the DM"
+grep -qi 'resumes instead of re-granting' "$SKILL" || fail "re-run must resume, not re-grant"
+
+# 7. dry run inert
+grep -q -- '--dry-run' "$SKILL" || fail "skill must document --dry-run"
+grep -qi 'Nothing is pushed, granted' "$SKILL" \
+  || fail "dry run must be documented as fully inert"
+
+# 8. humanize + plain report
+grep -q 'humanize-before-send.md' "$SKILL" || fail "DM headline must go through the humanize pass"
+grep -qi 'One plain sentence' "$SKILL" || fail "success report must be one plain sentence"
+
+# 9. hard policies
+grep -q 'share-session' "$SKILL" || fail "skill must forbid share-session URLs"
+grep -q 'hq-delegate-never-inlines-secrets-or-share-urls' "$SKILL" \
+  || fail "skill must cite the delegation policy"
+grep -qi 'Names only' "$SKILL" || fail "skill must state secret values never move"
+
+echo "hq-delegate-skill: ok (frontmatter scoped, all 8 helpers shipped+referenced, picker/stop resolution, single confirm gate, inert dry-run, fail-closed semantics)"

--- a/core/scripts/tests/hq-delegate-transfer.test.sh
+++ b/core/scripts/tests/hq-delegate-transfer.test.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# Regression: hq-delegate-transfer.sh must reassign ownership everywhere HQ
+# tracks it — board, PRD metadata, work mesh, journal — idempotently, with
+# --share mode mutating nothing and offline installs still succeeding.
+#
+# Guards:
+#   1. Project already on the board -> owner set, updated_at bumped, array
+#      length unchanged (update in place, no duplicate).
+#   2. Project absent from the board -> exactly one entry created with the
+#      correct prd_path.
+#   3. Run twice -> still one board entry, exactly one journal stanza for
+#      the delegation id.
+#   4. work-mesh.sh present -> invoked with done + company + project + a
+#      summary naming the recipient; absent -> transfer still exits 0 and
+#      the board/PRD mutations land.
+#   5. mode "share" -> board.json and prd.json byte-identical afterward.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+HELPER="$ROOT/core/scripts/hq-delegate-transfer.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$HELPER" ] || fail "missing helper: $HELPER"
+
+# --- fixture -----------------------------------------------------------------
+
+make_fixture() { # root  (fresh HQ root with project + board + fake work-mesh)
+  local fix="$1"
+  rm -rf "$fix"
+  mkdir -p "$fix/companies/acme/projects/widget" "$fix/core/scripts"
+  cat > "$fix/companies/acme/projects/widget/prd.json" <<'JSON'
+{"name": "widget", "description": "Build the widget.", "metadata": {"goal": "ship"}}
+JSON
+  cat > "$fix/companies/acme/board.json" <<'JSON'
+{"projects": [
+  {"id": "ac-proj-1", "title": "other", "prd_path": "companies/acme/projects/other/prd.json", "updated_at": "2026-01-01T00:00:00Z"},
+  {"id": "ac-proj-7", "title": "widget", "prd_path": "companies/acme/projects/widget/prd.json", "updated_at": "2026-01-01T00:00:00Z"}
+]}
+JSON
+  cat > "$fix/core/scripts/work-mesh.sh" <<'MESH'
+#!/usr/bin/env bash
+echo "$*" >> "$MESH_STUB_LOG"
+exit 0
+MESH
+  chmod +x "$fix/core/scripts/work-mesh.sh"
+}
+
+write_manifest() { # path mode
+  cat > "$1" <<JSON
+{
+  "schemaVersion": 1,
+  "delegationId": "dlg-20260807-widget",
+  "mode": "$2",
+  "company": "acme",
+  "from": {"email": "owner@acme.test", "personUid": "prs_owner1"},
+  "to": {"kind": "person", "principal": "alice@acme.test", "displayName": "Alice"},
+  "project": {"name": "widget", "prdPath": "companies/acme/projects/widget/prd.json", "boardId": "ac-proj-7"},
+  "vaultPrefixes": [{"prefix": "projects/widget/", "permission": "write", "reason": "project dossier"}],
+  "status": "granted"
+}
+JSON
+}
+
+FIX="$TMP/hqroot"
+M="$TMP/manifest.json"
+export MESH_STUB_LOG="$TMP/mesh.log"
+
+# --- 1+4. existing board entry: in-place update; work-mesh invoked -----------
+
+make_fixture "$FIX"
+write_manifest "$M" transfer
+: > "$MESH_STUB_LOG"
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$M" >/dev/null 2>&1 \
+  || fail "transfer exited non-zero"
+
+BOARD="$FIX/companies/acme/board.json"
+jq -e '(.projects | length) == 2' "$BOARD" >/dev/null \
+  || fail "board array length must be unchanged: $(jq '.projects | length' "$BOARD")"
+jq -e '.projects[] | select(.prd_path == "companies/acme/projects/widget/prd.json") | .owner == "alice@acme.test" and .updated_at != "2026-01-01T00:00:00Z"' \
+  "$BOARD" >/dev/null || fail "board entry must gain owner + bumped updated_at"
+
+PRD="$FIX/companies/acme/projects/widget/prd.json"
+jq -e '.metadata.owner == "alice@acme.test" and .metadata.delegatedFrom == "owner@acme.test" and .metadata.delegatedAt != null' \
+  "$PRD" >/dev/null || fail "prd metadata must record owner/delegatedFrom/delegatedAt"
+
+grep -q '^done --company acme --project widget' "$MESH_STUB_LOG" \
+  || fail "work-mesh must be invoked with done for the company/project: $(cat "$MESH_STUB_LOG")"
+grep -q 'alice@acme.test' "$MESH_STUB_LOG" \
+  || fail "work-mesh summary must name the recipient"
+
+JOURNAL="$FIX/companies/acme/projects/widget/journal/delegations.md"
+[ -f "$JOURNAL" ] || fail "journal delegation log must be created"
+grep -q 'dlg-20260807-widget' "$JOURNAL" || fail "journal must name the delegation id"
+grep -q 'Alice' "$JOURNAL" || fail "journal must name the recipient"
+grep -q 'projects/widget/' "$JOURNAL" || fail "journal must record the transferred scope"
+
+jq -e '.ownershipTransferredAt != null' "$M" >/dev/null \
+  || fail "manifest must record ownershipTransferredAt"
+
+# --- 3. idempotent second run ------------------------------------------------
+
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$M" >/dev/null 2>&1 \
+  || fail "second transfer run exited non-zero"
+jq -e '(.projects | length) == 2' "$BOARD" >/dev/null \
+  || fail "second run must not add a board entry"
+STANZAS="$(grep -c '^## ' "$JOURNAL")"
+[ "$STANZAS" -eq 1 ] || fail "second run must not duplicate the journal stanza (got $STANZAS)"
+
+# --- 2. project absent from board -> exactly one entry created ---------------
+
+make_fixture "$FIX"
+jq 'del(.projects[1])' "$FIX/companies/acme/board.json" > "$TMP/b" && mv "$TMP/b" "$FIX/companies/acme/board.json"
+write_manifest "$M" transfer
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$M" >/dev/null 2>&1 \
+  || fail "transfer (absent from board) exited non-zero"
+COUNT="$(jq '[.projects[] | select(.prd_path == "companies/acme/projects/widget/prd.json")] | length' "$FIX/companies/acme/board.json")"
+[ "$COUNT" -eq 1 ] || fail "exactly one board entry must be created, got $COUNT"
+jq -e '.projects[] | select(.prd_path == "companies/acme/projects/widget/prd.json") | .owner == "alice@acme.test"' \
+  "$FIX/companies/acme/board.json" >/dev/null || fail "created entry must carry the owner"
+
+# --- 4b. work-mesh unavailable -> still succeeds -----------------------------
+
+make_fixture "$FIX"
+rm "$FIX/core/scripts/work-mesh.sh"
+write_manifest "$M" transfer
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$M" >/dev/null 2>&1 \
+  || fail "transfer must exit 0 when work-mesh.sh is unavailable"
+jq -e '.projects[] | select(.prd_path == "companies/acme/projects/widget/prd.json") | .owner == "alice@acme.test"' \
+  "$FIX/companies/acme/board.json" >/dev/null \
+  || fail "board mutation must land even without work-mesh"
+
+# --- 5. share mode mutates nothing -------------------------------------------
+
+make_fixture "$FIX"
+write_manifest "$M" share
+BOARD_BEFORE="$(cat "$FIX/companies/acme/board.json")"
+PRD_BEFORE="$(cat "$FIX/companies/acme/projects/widget/prd.json")"
+: > "$MESH_STUB_LOG"
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$M" >/dev/null 2>&1 \
+  || fail "share mode must exit 0"
+[ "$(cat "$FIX/companies/acme/board.json")" = "$BOARD_BEFORE" ] \
+  || fail "share mode must leave board.json byte-identical"
+[ "$(cat "$FIX/companies/acme/projects/widget/prd.json")" = "$PRD_BEFORE" ] \
+  || fail "share mode must leave prd.json byte-identical"
+[ ! -s "$MESH_STUB_LOG" ] || fail "share mode must not touch the work mesh"
+[ ! -d "$FIX/companies/acme/projects/widget/journal" ] \
+  || fail "share mode must not write a journal stanza"
+
+echo "hq-delegate-transfer: ok (in-place board update, single created entry, idempotent journal, offline work-mesh tolerated, share mode inert)"

--- a/core/scripts/tests/hq-delegate-verify.test.sh
+++ b/core/scripts/tests/hq-delegate-verify.test.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# Regression: hq-delegate-verify.sh must prove every granted prefix is
+# reachable before any DM, resume without re-granting, and offer a
+# zero-mutation dry run of the whole delegation plan.
+#
+# Guards:
+#   1. One prefix's browse fails -> exit non-zero, that prefix named with a
+#      likely cause, status stays 'granted', and no dm was ever invoked.
+#   2. All prefixes reachable -> status becomes 'verified' (send gates on
+#      this) with verifiedAt stamped.
+#   3. Re-run after a failed probe issues no `files share` (no re-grant).
+#   4. Empty-but-reachable prefix is a failure (dossier never pushed).
+#   5. --dry-run: prints recipient, mode, prefixes+permissions, secret
+#      names, repo+branch, and the DM headline; invokes no mutating
+#      command; leaves workspace/delegations/ untouched; exits 0.
+#   6. Probe from status 'building' refuses (grants must exist first).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+HELPER="$ROOT/core/scripts/hq-delegate-verify.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+[ -f "$HELPER" ] || fail "missing helper: $HELPER"
+
+# --- stub hq CLI -------------------------------------------------------------
+# HQ_STUB_BROWSE_FAIL: prefix whose browse errors
+# HQ_STUB_BROWSE_EMPTY: prefix whose browse succeeds with empty output
+INVOKE_LOG="$TMP/invocations.log"
+mkdir -p "$TMP/bin"
+cat > "$TMP/bin/hq" <<'STUB'
+#!/usr/bin/env bash
+echo "$*" >> "$HQ_STUB_LOG"
+case "$1 $2" in
+  "files browse")
+    if [ "$3" = "${HQ_STUB_BROWSE_FAIL:-}" ]; then
+      echo "403 Forbidden" >&2
+      exit 1
+    fi
+    if [ "$3" = "${HQ_STUB_BROWSE_EMPTY:-}" ]; then
+      exit 0
+    fi
+    echo "prd.json  1.2KB  shared-with-you"
+    exit 0
+    ;;
+  "whoami "*|"whoami ")
+    echo '{"email":"owner@acme.test"}'
+    exit 0
+    ;;
+esac
+exit 0
+STUB
+chmod +x "$TMP/bin/hq"
+export PATH="$TMP/bin:$PATH"
+export HQ_STUB_LOG="$INVOKE_LOG"
+
+# --- fixture -----------------------------------------------------------------
+
+FIX="$TMP/hqroot"
+PROJ="$FIX/companies/acme/projects/widget"
+mkdir -p "$PROJ" "$FIX/workspace/delegations"
+cat > "$PROJ/prd.json" <<'JSON'
+{
+  "name": "widget", "description": "Build the widget.", "branchName": "feature/widget",
+  "metadata": {"goal": "ship", "repoPath": "repos/public/widget-repo", "baseBranch": "main",
+    "knowledge": ["companies/acme/knowledge/insights/notes.md"]},
+  "userStories": [{"id": "US-001", "title": "Frame", "description": "d", "priority": 1, "passes": false}]
+}
+JSON
+cat > "$PROJ/.env.schema" <<'SCHEMA'
+WIDGET_API_KEY=
+SCHEMA
+
+M="$TMP/manifest.json"
+write_manifest() { # status
+  cat > "$M" <<JSON
+{
+  "schemaVersion": 1, "delegationId": "dlg-test-widget", "mode": "transfer",
+  "company": "acme",
+  "to": {"kind": "person", "principal": "alice@acme.test"},
+  "project": {"name": "widget", "prdPath": "companies/acme/projects/widget/prd.json"},
+  "vaultPrefixes": [
+    {"prefix": "projects/widget/", "permission": "write"},
+    {"prefix": "knowledge/insights/", "permission": "read"}
+  ],
+  "status": "$1"
+}
+JSON
+}
+
+# --- 1+3. failing browse: named prefix, no dm, no re-grant, status kept ------
+
+write_manifest granted
+: > "$INVOKE_LOG"
+export HQ_STUB_BROWSE_FAIL="knowledge/insights/"
+set +e
+OUT="$(HQ_ROOT="$FIX" bash "$HELPER" --manifest "$M" 2>&1)"
+RC=$?
+set -e
+[ "$RC" -ne 0 ] || fail "failed probe must exit non-zero"
+printf '%s' "$OUT" | grep -q "FAIL  knowledge/insights/" || fail "output must name the failing prefix: $OUT"
+printf '%s' "$OUT" | grep -qi "likely cause" || fail "output must state a likely cause"
+jq -e '.status == "granted"' "$M" >/dev/null || fail "failed probe must leave status at granted"
+if grep -Eq '^(dm|files share|sync push)' "$INVOKE_LOG"; then
+  fail "probe must never send a dm, share, or push: $(cat "$INVOKE_LOG")"
+fi
+
+# re-run (still failing): still no share/dm — resume never re-grants
+set +e
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$M" >/dev/null 2>&1
+set -e
+if grep -Eq '^(dm|files share)' "$INVOKE_LOG"; then
+  fail "re-run must not issue shares or dms"
+fi
+unset HQ_STUB_BROWSE_FAIL
+
+# --- 4. reachable-but-empty prefix fails -------------------------------------
+
+write_manifest granted
+export HQ_STUB_BROWSE_EMPTY="projects/widget/"
+set +e
+OUT="$(HQ_ROOT="$FIX" bash "$HELPER" --manifest "$M" 2>&1)"
+RC=$?
+set -e
+[ "$RC" -ne 0 ] || fail "empty prefix must fail the probe"
+printf '%s' "$OUT" | grep -q "EMPTY" || fail "empty prefix failure must say so: $OUT"
+unset HQ_STUB_BROWSE_EMPTY
+
+# --- 2. all reachable -> verified --------------------------------------------
+
+write_manifest granted
+: > "$INVOKE_LOG"
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$M" >/dev/null 2>&1 \
+  || fail "healthy probe exited non-zero"
+jq -e '.status == "verified" and .verifiedAt != null' "$M" >/dev/null \
+  || fail "healthy probe must advance status to verified"
+BROWSE_COUNT="$(grep -c '^files browse' "$INVOKE_LOG")"
+[ "$BROWSE_COUNT" -eq 2 ] || fail "expected one browse per prefix (2), got $BROWSE_COUNT"
+
+# --- 6. probe from 'building' refuses ----------------------------------------
+
+write_manifest building
+set +e
+HQ_ROOT="$FIX" bash "$HELPER" --manifest "$M" >/dev/null 2>&1
+RC=$?
+set -e
+[ "$RC" -ne 0 ] || fail "probe from 'building' must refuse (grants first)"
+
+# --- 5. dry run: full plan, zero mutation ------------------------------------
+
+: > "$INVOKE_LOG"
+BEFORE="$(find "$FIX/workspace/delegations" -mindepth 1 | sort)"
+OUT="$(HQ_ROOT="$FIX" bash "$HELPER" --dry-run --company acme --project widget --to alice@acme.test 2>/dev/null)" \
+  || fail "dry run must exit 0"
+AFTER="$(find "$FIX/workspace/delegations" -mindepth 1 | sort)"
+[ "$BEFORE" = "$AFTER" ] || fail "dry run must leave workspace/delegations/ untouched"
+if grep -Eq '^(dm|files share|sync push|secrets share)' "$INVOKE_LOG"; then
+  fail "dry run invoked a mutating command: $(cat "$INVOKE_LOG")"
+fi
+for needle in "alice@acme.test" "transfer" "projects/widget/" "knowledge/insights/" \
+  "WIDGET_API_KEY" "feature/widget" "DM that would be sent"; do
+  printf '%s' "$OUT" | grep -qF "$needle" || fail "dry-run plan missing: $needle"
+done
+printf '%s' "$OUT" | grep -q "write" || fail "dry-run plan must show permissions"
+
+echo "hq-delegate-verify: ok (probe gates the DM, named failures with causes, resume without re-grant, empty=fail, dry run fully inert)"

--- a/core/scripts/tests/hq-delegate-verify.test.sh
+++ b/core/scripts/tests/hq-delegate-verify.test.sh
@@ -43,6 +43,10 @@ case "$1 $2" in
       exit 0
     fi
     echo "prd.json  1.2KB  shared-with-you"
+    # the referenced knowledge file is present unless the scenario hides it
+    if [ "${HQ_STUB_BROWSE_NO_FILE:-0}" != "1" ]; then
+      echo "notes.md  0.4KB  shared-with-you"
+    fi
     exit 0
     ;;
   "whoami "*|"whoami ")
@@ -85,6 +89,8 @@ write_manifest() { # status
     {"prefix": "projects/widget/", "permission": "write"},
     {"prefix": "knowledge/insights/", "permission": "read"}
   ],
+  "knowledge": ["companies/acme/knowledge/insights/notes.md"],
+  "policies": [],
   "status": "$1"
 }
 JSON
@@ -137,7 +143,23 @@ HQ_ROOT="$FIX" bash "$HELPER" --manifest "$M" >/dev/null 2>&1 \
 jq -e '.status == "verified" and .verifiedAt != null' "$M" >/dev/null \
   || fail "healthy probe must advance status to verified"
 BROWSE_COUNT="$(grep -c '^files browse' "$INVOKE_LOG")"
-[ "$BROWSE_COUNT" -eq 2 ] || fail "expected one browse per prefix (2), got $BROWSE_COUNT"
+[ "$BROWSE_COUNT" -eq 3 ] || fail "expected one browse per prefix (2) + one per referenced file (1), got $BROWSE_COUNT"
+
+# --- referenced file absent from a reachable prefix -> FAIL naming the file --
+# (Live finding: Deacon's pickup pulled a reachable knowledge prefix that
+# silently lacked the specific referenced note.)
+
+write_manifest granted
+export HQ_STUB_BROWSE_NO_FILE=1
+set +e
+OUT="$(HQ_ROOT="$FIX" bash "$HELPER" --manifest "$M" 2>&1)"
+RC=$?
+set -e
+[ "$RC" -ne 0 ] || fail "missing referenced file must fail the probe"
+printf '%s' "$OUT" | grep -q "FAIL  knowledge/insights/notes.md" \
+  || fail "failure must name the missing referenced file: $OUT"
+jq -e '.status == "granted"' "$M" >/dev/null || fail "missing-file probe must not advance status"
+unset HQ_STUB_BROWSE_NO_FILE
 
 # --- 6. probe from 'building' refuses ----------------------------------------
 


### PR DESCRIPTION
Consolidated landing of the full `/delegate` feature (project: `hq-delegate-command`, indigo) — supersedes the stacked PRs #160/#161/#163/#164/#165/#167/#169/#170/#172/#174, whose branches collapsed into this one (linear chain; every commit present here).

## What ships

`/delegate <recipient> [project] [--share] [--no-secrets] [--dry-run]` — transfer a project to a person or fleet agent in one confirmed flow:

- **8 shell helpers** (`core/scripts/hq-delegate-*.sh`), each with an offline regression test: bundle builder + manifest spec, recipient resolution, vault grants (direct-only, ACL read-back verified), branch handover, secrets by name, ownership transfer, reachability probe + inert dry-run, pickup prompt + single-DM delivery
- **The skill** (`.claude/skills/delegate/SKILL.md`) with narrow per-command permissions, one structured confirmation before any mutation, resume-on-failure semantics
- **Policy** `hq-delegate-never-inlines-secrets-or-share-urls` (both hard rules enforced by fail-closed scans + tests)
- **CI**: `hq-delegate` job in pr-checks running all nine test suites
- **Docs**: quick-reference, USER-GUIDE, charter path, cross-links from /handoff, /dm, /hq-share, /new-agent
- `hqVersion` 15.0.81 → **15.0.91**

## Proven live

Real delegation `dlg-20260807-184759-delegate-e2e-canary` to fleet agent Deacon: grants verified, ownership transferred, DM delivered (eventId `f4d3700d…`), cold pickup completed from the agent's own box with zero follow-up questions, write-back confirmed in the vault. Three live findings fixed + regression-tested along the way (agent name resolution, agent grants via delegation group, referenced-file push+probe). Full evidence: https://github.com/indigoai-us/hq-core/pull/174#issuecomment-5221255642

https://claude.ai/code/session_015YaqhyfE5w7L1NHnMiSnTp